### PR TITLE
Add deferred get_weather, set_location, search_books tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ go build -o her && ./her run
 You (Telegram) → her binary → Qwen3 (agent, orchestrates the turn)
                                  ├── think (reason about what to do)
                                  ├── recall_memories (semantic fact search)
-                                 ├── use_tools → web_search / web_read / view_image
+                                 ├── use_tools → search  (web_search, web_read, search_books)
+                                 │             / vision  (view_image)
+                                 │             / context (get_weather, set_location)
                                  ├── reply (calls Deepseek, sends response)
                                  └── done (signals turn complete)
                                ↓ (after reply sent)
@@ -62,6 +64,8 @@ For a deep dive into all model calls, data flow, and the dual compaction system,
 - **Persona evolution** — Mira reflects on conversations and rewrites her own personality description over time, with trait tracking and damped updates
 - **Thinking traces** — Optional `/traces` command shows the agent's tool calls and the memory agent's fact extraction in a single Telegram message above the reply
 - **Web search** — Tavily integration for real-time information, loaded on demand via `use_tools`
+- **Book search** — Open Library lookup for titles, authors, topics, or ISBNs. No API key, loaded on demand alongside web search
+- **Weather + location** — On-demand current conditions via Open-Meteo. `set_location` geocodes a city, address, landmark, or raw coords (via Nominatim) and persists to both `config.yaml` and the `location_history` table so Mira remembers where "home" is across restarts
 - **Vision** — Image understanding via Gemini Flash, loaded on demand via `use_tools`
 - **Voice** — Local speech-to-text (Parakeet) and text-to-speech (Piper)
 - **PII scrubbing** — Tiered: hard identifiers redacted, contact info tokenized + deanonymized, names pass through
@@ -105,6 +109,7 @@ Copy `config.yaml.example` to `config.yaml` and fill in:
 - `embed.base_url` — local embedding server (LM Studio, Ollama)
 - `embed.model` — embedding model name
 - `voice` — paths to local Parakeet STT and Piper TTS binaries
+- `location` — home coordinates + unit prefs (`fahrenheit`/`celsius`, `mph`/`kmh`). Populated automatically by the `set_location` tool — you rarely need to edit this by hand.
 
 ## Editable Prompts (no recompilation needed)
 
@@ -128,16 +133,18 @@ her-go/
 ├── compact/          # Dual compaction (chat conversations + agent action history)
 ├── config/           # YAML config loading + env var substitution
 ├── embed/            # Local embedding client for semantic similarity
+├── integrate/        # External integrations (Nominatim geocoding)
 ├── llm/              # OpenAI-compatible LLM client (fallback, cost tracking)
 ├── logger/           # Structured logging (charmbracelet/log)
-├── memory/           # SQLite store: messages, facts, summaries, metrics, vault
+├── memory/           # SQLite store: messages, facts, summaries, metrics, vault, location_history
 ├── persona/          # Reflection, persona evolution, trait tracking, dreaming
 ├── scrub/            # Tiered PII detection + deanonymization
-├── search/           # Tavily web search
+├── search/           # Tavily web search + Open Library book search
 ├── tools/            # Tool YAML manifests + handlers (init-registered)
 ├── tui/              # Terminal UI events and rendering
 ├── vision/           # Image understanding via Gemini Flash
 ├── voice/            # Parakeet STT + Piper TTS
+├── weather/          # Current conditions via Open-Meteo (no API key)
 ├── sims/             # Simulation suites + results
 ├── docs/             # Architecture docs (model calls, data flow, compaction)
 ├── prompt.md         # Mira's personality
@@ -153,4 +160,4 @@ her-go/
 - Contact info (phone, email) is tokenized and deanonymized in responses
 - Names and context pass through for conversational coherence
 - Voice processing runs entirely locally via Parakeet and Piper
-- Search queries go to Tavily; everything else stays on your machine
+- External services used only when the matching tool is invoked: Tavily (web search), Open Library (book search), Open-Meteo (weather), Nominatim (geocoding). All four are free; only Tavily needs a key. Everything else stays on your machine.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,8 +24,11 @@ import (
 	// Each import causes the package's init() to run, which calls
 	// tools.Register("name", Handle) to add the handler to the registry.
 	_ "her/tools/done"
+	_ "her/tools/get_weather"
 	_ "her/tools/recall_memories"
 	_ "her/tools/reply"
+	_ "her/tools/search_books"
+	_ "her/tools/set_location"
 	_ "her/tools/think"
 	_ "her/tools/update_persona"
 	_ "her/tools/use_tools"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -100,6 +100,13 @@ persona:
   min_rewrite_days: 7                # minimum days between persona rewrites
   min_reflections: 3                 # minimum unconsumed reflections required before a rewrite is allowed
 
+location:
+  latitude: 0                   # written by set_location — leave 0/0 until set
+  longitude: 0
+  name: ""                      # display name from the last geocoding (e.g., "Portland, Oregon")
+  temp_unit: "fahrenheit"       # "fahrenheit" or "celsius"
+  wind_unit: "mph"              # "mph" or "kmh"
+
 voice:
   enabled: false                                                  # set true to accept voice memos
   stt:

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,22 @@ type Config struct {
 	Scrub      ScrubConfig      `yaml:"scrub"`
 	Persona    PersonaConfig    `yaml:"persona"`
 	Voice      VoiceConfig      `yaml:"voice"`
+	Location   LocationConfig   `yaml:"location,omitempty"`
+}
+
+// LocationConfig holds the user's saved home coordinates and unit
+// preferences, used by the get_weather tool. Lat/lon are written by
+// the set_location tool whenever the user updates their home location
+// (via SetLocation — a surgical YAML edit that preserves formatting).
+//
+// Zero values are the "no location set" state; the get_weather tool
+// prompts the user to run set_location when it sees 0/0.
+type LocationConfig struct {
+	Latitude  float64 `yaml:"latitude"`
+	Longitude float64 `yaml:"longitude"`
+	Name      string  `yaml:"name,omitempty"`       // display name from the last geocoding ("Portland, Oregon")
+	TempUnit  string  `yaml:"temp_unit,omitempty"`  // "fahrenheit" (default) or "celsius"
+	WindUnit  string  `yaml:"wind_unit,omitempty"`  // "mph" (default) or "kmh"
 }
 
 // IdentityConfig holds the bot and owner names. These get injected into
@@ -362,6 +378,166 @@ func (c *Config) SetTrace(configPath string, enabled bool) error {
 	}
 
 	return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0644)
+}
+
+// SetLocation writes the user's home coordinates (and optional display
+// name) into both the in-memory config and config.yaml on disk. Like
+// SetTrace, this is a surgical line-level edit — finds the latitude/
+// longitude/name lines under the "location:" section and replaces
+// their values, preserving comments and formatting.
+//
+// If the "location:" section doesn't exist yet, it's appended to the
+// end of the file. We intentionally don't use a full YAML round-trip
+// (yaml.Marshal → yaml.Unmarshal) because it would strip comments
+// from the whole file.
+func (c *Config) SetLocation(configPath string, lat, lon float64, name string) error {
+	c.Location.Latitude = lat
+	c.Location.Longitude = lon
+	if name != "" {
+		c.Location.Name = name
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	const indent = "  " // same two-space indent as other top-level sections
+
+	// Scan once to find the section and each field's line index (if present).
+	inLocation := false
+	locationHeader := -1
+	latIdx, lonIdx, nameIdx := -1, -1, -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Detect top-level YAML sections (no leading whitespace, not a comment).
+		isTopLevel := len(trimmed) > 0 &&
+			!strings.HasPrefix(line, " ") &&
+			!strings.HasPrefix(line, "\t") &&
+			!strings.HasPrefix(trimmed, "#")
+
+		if isTopLevel {
+			if strings.HasPrefix(trimmed, "location:") {
+				inLocation = true
+				locationHeader = i
+				continue
+			}
+			if inLocation {
+				// Left the location: section — stop scanning.
+				inLocation = false
+			}
+		}
+
+		if inLocation {
+			switch {
+			case strings.HasPrefix(trimmed, "latitude:"):
+				latIdx = i
+			case strings.HasPrefix(trimmed, "longitude:"):
+				lonIdx = i
+			case strings.HasPrefix(trimmed, "name:"):
+				nameIdx = i
+			}
+		}
+	}
+
+	// Helper: replace the "key: value" part of a line in place, preserving
+	// leading indent and any trailing " # comment".
+	replaceValue := func(line, key, value string) string {
+		// Everything up to (and including) "key:".
+		keyMarker := key + ":"
+		keyPos := strings.Index(line, keyMarker)
+		if keyPos < 0 {
+			return line // shouldn't happen — we already matched the prefix
+		}
+		prefix := line[:keyPos]
+		// Preserve an inline comment if there is one.
+		rest := line[keyPos+len(keyMarker):]
+		comment := ""
+		if hashPos := strings.Index(rest, "#"); hashPos >= 0 {
+			comment = " " + strings.TrimLeft(rest[hashPos:], " ")
+		}
+		return fmt.Sprintf("%s%s %s%s", prefix, keyMarker, value, comment)
+	}
+
+	// If the location section doesn't exist yet, append a fresh block.
+	if locationHeader < 0 {
+		block := []string{
+			"",
+			"location:",
+			fmt.Sprintf("%slatitude: %s", indent, formatFloat(lat)),
+			fmt.Sprintf("%slongitude: %s", indent, formatFloat(lon)),
+		}
+		if name != "" {
+			block = append(block, fmt.Sprintf("%sname: %q", indent, name))
+		}
+		// Trim a trailing empty line so we don't end up with a double blank.
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		lines = append(lines, block...)
+		return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0644)
+	}
+
+	// Section exists — update in place, or insert any missing keys right
+	// after the "location:" header. We insert in reverse order so the
+	// index math stays correct after each splice.
+	if nameIdx >= 0 && name != "" {
+		lines[nameIdx] = replaceValue(lines[nameIdx], "name", fmt.Sprintf("%q", name))
+	} else if name != "" {
+		newLine := fmt.Sprintf("%sname: %q", indent, name)
+		lines = insertAfter(lines, locationHeader, newLine)
+		// Shift latIdx/lonIdx if they come after the header.
+		if latIdx > locationHeader {
+			latIdx++
+		}
+		if lonIdx > locationHeader {
+			lonIdx++
+		}
+	}
+
+	if lonIdx >= 0 {
+		lines[lonIdx] = replaceValue(lines[lonIdx], "longitude", formatFloat(lon))
+	} else {
+		newLine := fmt.Sprintf("%slongitude: %s", indent, formatFloat(lon))
+		lines = insertAfter(lines, locationHeader, newLine)
+		if latIdx > locationHeader {
+			latIdx++
+		}
+	}
+
+	if latIdx >= 0 {
+		lines[latIdx] = replaceValue(lines[latIdx], "latitude", formatFloat(lat))
+	} else {
+		newLine := fmt.Sprintf("%slatitude: %s", indent, formatFloat(lat))
+		lines = insertAfter(lines, locationHeader, newLine)
+	}
+
+	return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0644)
+}
+
+// formatFloat renders a float with up to 6 decimal places and no trailing
+// zeros — matches the precision Open-Meteo and Nominatim return. Using
+// %g would drop trailing zeros but can slip into scientific notation for
+// very small or very large values, which would be confusing in config.
+func formatFloat(f float64) string {
+	s := fmt.Sprintf("%.6f", f)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	if s == "" || s == "-" {
+		return "0"
+	}
+	return s
+}
+
+// insertAfter splices a new line into a slice immediately after the given
+// index. This is the standard Go idiom for inserting into a slice — no
+// built-in "insert" function (unlike Python's list.insert()), so we build
+// it from append() and a slice expression.
+func insertAfter(lines []string, idx int, newLine string) []string {
+	return append(lines[:idx+1], append([]string{newLine}, lines[idx+1:]...)...)
 }
 
 // ExportEnv sets process-level environment variables from config values

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,292 @@
+package config
+
+// Tests for SetLocation — the surgical YAML edit that persists the user's
+// home coordinates to config.yaml without trashing comments or formatting.
+//
+// We test the file-level behavior (byte-for-byte output checks), not just
+// the in-memory struct, because the whole point of SetLocation is to
+// preserve what's around it. A yaml.Marshal round-trip would pass any
+// field check but strip every comment in the file.
+//
+// Table-driven tests are idiomatic Go for this shape of problem: a list
+// of {input, expected-output} cases run through the same assertion code.
+// Similar to pytest.mark.parametrize in Python, but built into testing.T.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempConfig writes content to a fresh file inside t.TempDir() and
+// returns its path. t.TempDir() gives us an isolated directory that gets
+// auto-cleaned when the test ends — no leftover /tmp junk. Same idea as
+// Python's tmp_path pytest fixture.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper() // marks this as a test helper so failures report the caller's line, not ours
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+// readFile is a tiny convenience — SetLocation is fully about the file
+// contents so every test reads the result and greps it.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+	return string(data)
+}
+
+// TestSetLocation exercises the main shapes: update, append, partial
+// section, preserved comments. Each subtest is named so a failure in
+// `go test -v` shows exactly which case broke.
+func TestSetLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		lat      float64
+		lon      float64
+		locName  string
+		// wantContains: substrings that MUST appear in the output.
+		// Plain substring checks are easier to read than regex and
+		// good enough for this surgical-edit test.
+		wantContains []string
+		// wantAbsent: substrings that must NOT appear (e.g., the old
+		// placeholder value after an update).
+		wantAbsent []string
+	}{
+		{
+			name: "updates existing section in place",
+			input: `identity:
+  her: "Mira"
+
+location:
+  latitude: 0
+  longitude: 0
+  name: ""
+  temp_unit: "fahrenheit"
+  wind_unit: "mph"
+
+voice:
+  enabled: false
+`,
+			lat: 45.5152, lon: -122.6784, locName: "Portland, Oregon",
+			wantContains: []string{
+				"latitude: 45.5152",
+				"longitude: -122.6784",
+				`name: "Portland, Oregon"`,
+				// Unit lines should survive untouched.
+				`temp_unit: "fahrenheit"`,
+				`wind_unit: "mph"`,
+				// Surrounding sections should survive.
+				`her: "Mira"`,
+				"voice:",
+				"enabled: false",
+			},
+			wantAbsent: []string{
+				"latitude: 0\n",
+				"longitude: 0\n",
+				`name: ""`,
+			},
+		},
+		{
+			name: "preserves inline comments on existing lines",
+			input: `location:
+  latitude: 0                   # written by set_location
+  longitude: 0
+  name: ""
+`,
+			lat: 40.7128, lon: -74.006, locName: "New York, NY",
+			wantContains: []string{
+				"latitude: 40.7128",
+				// The comment must survive the value swap.
+				"# written by set_location",
+				"longitude: -74.006",
+				`name: "New York, NY"`,
+			},
+		},
+		{
+			name: "appends a new section when none exists",
+			input: `identity:
+  her: "Mira"
+
+voice:
+  enabled: false
+`,
+			lat: 35.6762, lon: 139.6503, locName: "Tokyo, Japan",
+			wantContains: []string{
+				// Existing content kept as-is.
+				`her: "Mira"`,
+				"voice:",
+				// New block appended at the end.
+				"location:",
+				"latitude: 35.6762",
+				"longitude: 139.6503",
+				`name: "Tokyo, Japan"`,
+			},
+		},
+		{
+			name: "fills in missing fields when the section is partial",
+			input: `location:
+  latitude: 0
+`,
+			lat: 51.5074, lon: -0.1278, locName: "London, UK",
+			wantContains: []string{
+				"latitude: 51.5074",
+				"longitude: -0.1278",
+				`name: "London, UK"`,
+			},
+		},
+		{
+			name: "empty name preserves whatever was on disk",
+			input: `location:
+  latitude: 0
+  longitude: 0
+  name: "Keep Me"
+`,
+			lat: 1.23, lon: 4.56, locName: "",
+			wantContains: []string{
+				"latitude: 1.23",
+				"longitude: 4.56",
+				// With empty locName we don't touch the name line at all.
+				`name: "Keep Me"`,
+			},
+		},
+		{
+			name: "formats negative and fractional coords without scientific notation",
+			input: `location:
+  latitude: 0
+  longitude: 0
+`,
+			lat: -0.0001, lon: 179.987654321, locName: "Edge",
+			wantContains: []string{
+				// -0.0001 must round-trip cleanly (no scientific).
+				"latitude: -0.0001",
+				// 179.987654321 truncates to 6 decimals.
+				"longitude: 179.987654",
+			},
+			wantAbsent: []string{"e-", "E-"}, // no scientific notation
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture for the subtest closure — classic Go gotcha
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTempConfig(t, tc.input)
+
+			cfg := &Config{}
+			if err := cfg.SetLocation(path, tc.lat, tc.lon, tc.locName); err != nil {
+				t.Fatalf("SetLocation failed: %v", err)
+			}
+
+			got := readFile(t, path)
+
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\n--- full output ---\n%s", want, got)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("output should not contain %q\n--- full output ---\n%s", absent, got)
+				}
+			}
+
+			// Also verify the in-memory struct was mutated. This is the
+			// "subsequent tool calls in the same turn see new coords"
+			// contract that set_location relies on.
+			if cfg.Location.Latitude != tc.lat {
+				t.Errorf("in-memory latitude = %v, want %v", cfg.Location.Latitude, tc.lat)
+			}
+			if cfg.Location.Longitude != tc.lon {
+				t.Errorf("in-memory longitude = %v, want %v", cfg.Location.Longitude, tc.lon)
+			}
+			if tc.locName != "" && cfg.Location.Name != tc.locName {
+				t.Errorf("in-memory name = %q, want %q", cfg.Location.Name, tc.locName)
+			}
+		})
+	}
+}
+
+// TestSetLocation_IdempotentUpdate verifies that calling SetLocation
+// twice with the same values doesn't corrupt the file — we shouldn't
+// accumulate duplicate lines or drift formatting on re-writes. This is
+// the scenario where the agent sets the same location repeatedly (e.g.,
+// user confirms their city, and the model helpfully re-calls the tool).
+func TestSetLocation_IdempotentUpdate(t *testing.T) {
+	input := `location:
+  latitude: 0
+  longitude: 0
+  name: ""
+`
+	path := writeTempConfig(t, input)
+	cfg := &Config{}
+
+	if err := cfg.SetLocation(path, 45.5, -122.6, "Portland"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	after1 := readFile(t, path)
+
+	if err := cfg.SetLocation(path, 45.5, -122.6, "Portland"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	after2 := readFile(t, path)
+
+	if after1 != after2 {
+		t.Errorf("output changed between identical calls\n--- after1 ---\n%s\n--- after2 ---\n%s", after1, after2)
+	}
+
+	// Count latitude/longitude/name lines — we should have exactly one each,
+	// not duplicates accumulating on each call.
+	for _, key := range []string{"latitude:", "longitude:", "name:"} {
+		count := strings.Count(after2, key)
+		if count != 1 {
+			t.Errorf("expected exactly 1 %q line, got %d\n%s", key, count, after2)
+		}
+	}
+}
+
+// TestSetLocation_MissingFile verifies that a broken path surfaces an
+// error rather than silently creating a new file or panicking. The tool
+// handler logs this and returns a user-facing warning, so the error
+// return matters.
+func TestSetLocation_MissingFile(t *testing.T) {
+	cfg := &Config{}
+	err := cfg.SetLocation("/nonexistent/path/config.yaml", 1.0, 2.0, "X")
+	if err == nil {
+		t.Fatal("expected error for missing config path, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading config") {
+		t.Errorf("error should mention reading config, got: %v", err)
+	}
+}
+
+// TestFormatFloat covers the precision/notation corner cases formatFloat
+// is specifically designed to avoid: trailing zeros (ugly in YAML) and
+// scientific notation (would confuse humans reading config.yaml).
+func TestFormatFloat(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want string
+	}{
+		{0, "0"},                      // zero: no trailing ".000000"
+		{45.5, "45.5"},                // trailing zeros trimmed
+		{45.500000, "45.5"},           // same even with explicit zeros
+		{-122.6784, "-122.6784"},      // negative preserved
+		{0.000001, "0.000001"},        // 6-decimal precision floor
+		{179.987654321, "179.987654"}, // truncated, not rounded to scientific
+		{-0.0001, "-0.0001"},          // tiny negative stays decimal
+	}
+	for _, tc := range tests {
+		got := formatFloat(tc.in)
+		if got != tc.want {
+			t.Errorf("formatFloat(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/search/books.go
+++ b/search/books.go
@@ -1,0 +1,133 @@
+package search
+
+// books.go — Open Library book search.
+//
+// Open Library is a free API backed by the Internet Archive. No API key,
+// no rate limits for reasonable use. We hit the /search.json endpoint
+// and return a handful of fields useful for grounding book conversations:
+// title, authors, first-published year, subjects, page count, cover URL.
+//
+// This lives in the search package alongside Tavily because it's the
+// same shape of problem — structured lookup against an external API —
+// even though books use their own client (no shared auth with Tavily).
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// BookResult holds the fields we show from a single Open Library hit.
+type BookResult struct {
+	Title          string
+	Authors        []string
+	FirstPublished int
+	Subjects       []string
+	PageCount      int
+	CoverURL       string
+}
+
+// openLibraryResponse mirrors the JSON shape returned by Open Library's
+// /search.json endpoint. We only unmarshal the fields we use — the raw
+// response has ~60 more we don't care about.
+type openLibraryResponse struct {
+	Docs []struct {
+		Title            string   `json:"title"`
+		AuthorName       []string `json:"author_name"`
+		FirstPublishYear int      `json:"first_publish_year"`
+		Subject          []string `json:"subject"`
+		CoverI           int      `json:"cover_i"`
+		NumberOfPages    int      `json:"number_of_pages_median"`
+	} `json:"docs"`
+}
+
+// SearchBooks queries Open Library and returns up to maxResults hits.
+// maxResults <= 0 defaults to 3; we also cap at 10 to keep tool output
+// readable. If nothing matches, returns an empty slice (not an error).
+func SearchBooks(query string, maxResults int) ([]BookResult, error) {
+	if maxResults <= 0 {
+		maxResults = 3
+	}
+	if maxResults > 10 {
+		maxResults = 10
+	}
+
+	// The "fields" parameter asks Open Library to only return the
+	// columns we use, shrinking the response from ~100KB to ~5KB.
+	searchURL := fmt.Sprintf(
+		"https://openlibrary.org/search.json?q=%s&limit=%d"+
+			"&fields=title,author_name,first_publish_year,subject,cover_i,number_of_pages_median",
+		url.QueryEscape(query), maxResults,
+	)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(searchURL)
+	if err != nil {
+		return nil, fmt.Errorf("open library request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("open library returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var olResp openLibraryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&olResp); err != nil {
+		return nil, fmt.Errorf("parsing open library response: %w", err)
+	}
+
+	results := make([]BookResult, 0, len(olResp.Docs))
+	for _, doc := range olResp.Docs {
+		book := BookResult{
+			Title:          doc.Title,
+			Authors:        doc.AuthorName,
+			FirstPublished: doc.FirstPublishYear,
+			PageCount:      doc.NumberOfPages,
+		}
+		// Cap subject tags — Open Library can return hundreds for popular books.
+		if len(doc.Subject) > 5 {
+			book.Subjects = doc.Subject[:5]
+		} else {
+			book.Subjects = doc.Subject
+		}
+		if doc.CoverI > 0 {
+			book.CoverURL = fmt.Sprintf("https://covers.openlibrary.org/b/id/%d-M.jpg", doc.CoverI)
+		}
+		results = append(results, book)
+	}
+
+	return results, nil
+}
+
+// FormatBookResults renders a slice of BookResult into a readable string
+// for the tool to return to the agent. Same shape as FormatSearchResults
+// (Tavily) — numbered list, one entry per book.
+func FormatBookResults(books []BookResult) string {
+	if len(books) == 0 {
+		return "No books found."
+	}
+
+	var b strings.Builder
+	for i, book := range books {
+		fmt.Fprintf(&b, "%d. **%s**", i+1, book.Title)
+		if len(book.Authors) > 0 {
+			fmt.Fprintf(&b, " by %s", strings.Join(book.Authors, ", "))
+		}
+		if book.FirstPublished > 0 {
+			fmt.Fprintf(&b, " (%d)", book.FirstPublished)
+		}
+		b.WriteString("\n")
+		if book.PageCount > 0 {
+			fmt.Fprintf(&b, "   Pages: %d\n", book.PageCount)
+		}
+		if len(book.Subjects) > 0 {
+			fmt.Fprintf(&b, "   Subjects: %s\n", strings.Join(book.Subjects, ", "))
+		}
+	}
+	return b.String()
+}

--- a/search/books_test.go
+++ b/search/books_test.go
@@ -1,0 +1,99 @@
+package search
+
+// Tests for FormatBookResults — the pure formatting function in books.go.
+// SearchBooks itself makes HTTP calls to Open Library, so we test that
+// separately if/when we add httptest.Server coverage. For now, the
+// formatting logic has enough branching to be worth covering.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatBookResults exercises the formatter with various result shapes:
+// empty, single, multiple, missing fields. Table-driven, same pattern as
+// the config tests.
+func TestFormatBookResults(t *testing.T) {
+	tests := []struct {
+		name         string
+		books        []BookResult
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "empty results",
+			books:        nil,
+			wantContains: []string{"No books found."},
+		},
+		{
+			name: "single book with all fields",
+			books: []BookResult{
+				{
+					Title:          "The Overstory",
+					Authors:        []string{"Richard Powers"},
+					FirstPublished: 2018,
+					Subjects:       []string{"Fiction", "Trees", "Environment"},
+					PageCount:      502,
+					CoverURL:       "https://covers.openlibrary.org/b/id/12345-M.jpg",
+				},
+			},
+			wantContains: []string{
+				"1. **The Overstory**",
+				"by Richard Powers",
+				"(2018)",
+				"Pages: 502",
+				"Subjects: Fiction, Trees, Environment",
+			},
+		},
+		{
+			name: "book with no authors or year",
+			books: []BookResult{
+				{
+					Title: "Anonymous Pamphlet",
+				},
+			},
+			wantContains: []string{"1. **Anonymous Pamphlet**"},
+			wantAbsent:   []string{"by ", "(0)", "Pages:", "Subjects:"},
+		},
+		{
+			name: "multiple authors",
+			books: []BookResult{
+				{
+					Title:   "Good Omens",
+					Authors: []string{"Terry Pratchett", "Neil Gaiman"},
+				},
+			},
+			wantContains: []string{"by Terry Pratchett, Neil Gaiman"},
+		},
+		{
+			name: "multiple books are numbered",
+			books: []BookResult{
+				{Title: "First"},
+				{Title: "Second"},
+				{Title: "Third"},
+			},
+			wantContains: []string{
+				"1. **First**",
+				"2. **Second**",
+				"3. **Third**",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatBookResults(tc.books)
+
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\n--- got ---\n%s", want, got)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("output should not contain %q\n--- got ---\n%s", absent, got)
+				}
+			}
+		})
+	}
+}

--- a/tools/categories.yaml
+++ b/tools/categories.yaml
@@ -7,4 +7,7 @@ vision:
   hint: "User sent a photo"
 
 search:
-  hint: "User asks about current events, facts you don't know, or shares a link to read"
+  hint: "User asks about current events, facts you don't know, a specific book/author, or shares a link to read"
+
+context:
+  hint: "User asks about weather, mentions the outdoors/commute, or wants to set their home location"

--- a/tools/get_weather/handler.go
+++ b/tools/get_weather/handler.go
@@ -1,0 +1,88 @@
+// Package get_weather implements the get_weather tool — fetches current
+// conditions from Open-Meteo for either the user's saved home location
+// or a one-off place passed in as an argument.
+//
+// This is a deferred tool: the agent loads it via use_tools(["context"])
+// when weather becomes relevant. It's NOT a passive context layer —
+// weather is only fetched when the agent explicitly asks for it, which
+// keeps the chat prompt clean and avoids spurious API calls.
+package get_weather
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"her/integrate"
+	"her/logger"
+	"her/tools"
+	"her/weather"
+)
+
+var log = logger.WithPrefix("tools/get_weather")
+
+func init() {
+	tools.Register("get_weather", Handle)
+}
+
+// Handle fetches the current weather. The location argument is optional:
+// when empty, we use the saved home coords from config; otherwise we
+// geocode the string via integrate.Geocode and fetch for those coords
+// (without persisting anything — that's set_location's job).
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var args struct {
+		Location string `json:"location"`
+	}
+	// Empty JSON "{}" is valid — no location arg just means "use home".
+	if argsJSON != "" {
+		if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+			return fmt.Sprintf("error parsing arguments: %v", err)
+		}
+	}
+
+	lat, lon := 0.0, 0.0
+	label := ""
+
+	if args.Location != "" {
+		// One-off lookup — geocode without touching config.
+		loc, err := integrate.Geocode(args.Location)
+		if err != nil {
+			log.Warn("geocode failed", "query", args.Location, "err", err)
+			return fmt.Sprintf("error: couldn't find location for %q: %v", args.Location, err)
+		}
+		if loc == nil {
+			return fmt.Sprintf("error: no location found for %q", args.Location)
+		}
+		lat, lon, label = loc.Latitude, loc.Longitude, loc.DisplayName
+	} else {
+		// Use saved home location from config.
+		if ctx.Cfg == nil || (ctx.Cfg.Location.Latitude == 0 && ctx.Cfg.Location.Longitude == 0) {
+			return "error: no home location set. Call set_location first (e.g., set_location({query: \"Portland Oregon\"})) or pass a location argument to get_weather."
+		}
+		lat = ctx.Cfg.Location.Latitude
+		lon = ctx.Cfg.Location.Longitude
+		label = ctx.Cfg.Location.Name
+		if label == "" {
+			label = fmt.Sprintf("%.4f, %.4f", lat, lon)
+		}
+	}
+
+	// Pull unit prefs from config. Empty strings are handled inside Fetch
+	// (defaults to fahrenheit/mph), so we can pass them through directly.
+	tempUnit, windUnit := "", ""
+	if ctx.Cfg != nil {
+		tempUnit = ctx.Cfg.Location.TempUnit
+		windUnit = ctx.Cfg.Location.WindUnit
+	}
+
+	log.Info("get_weather", "location", label, "lat", lat, "lon", lon)
+
+	w, err := weather.Fetch(lat, lon, tempUnit, windUnit)
+	if err != nil {
+		return fmt.Sprintf("error: weather fetch failed: %v", err)
+	}
+
+	// Prefix the location label so the agent can tell the chat model
+	// which place these numbers are for — especially important for the
+	// one-off case where it's not the user's home.
+	return fmt.Sprintf("%s — %s", label, weather.Format(w))
+}

--- a/tools/get_weather/tool.yaml
+++ b/tools/get_weather/tool.yaml
@@ -1,0 +1,22 @@
+name: get_weather
+description: >-
+  Get the current weather. With no arguments, uses {{user}}'s saved home
+  location from config (set via set_location). Pass a location string
+  (e.g., "Tokyo", "Portland Oregon", "40.7,-74.0") for a one-off lookup
+  at a different place — the saved home location is NOT changed.
+  Returns temperature, conditions, precipitation, and wind. Use when
+  {{user}} asks about weather or when weather is obviously relevant to
+  what they just said (planning a walk, commenting on how it feels
+  outside, etc.).
+hot: false
+category: context
+parameters:
+  type: object
+  properties:
+    location:
+      type: string
+      description: "Optional one-off location. Omit to use the saved home location."
+  required: []
+trace:
+  emoji: "🌤"
+  format: "{{if .location}}{{.location | escape}} → {{end}}{{.Result | truncate 80 | escape}}"

--- a/tools/loader_test.go
+++ b/tools/loader_test.go
@@ -10,7 +10,7 @@ func TestYAMLLoader(t *testing.T) {
 
 	// Check that all expected tools loaded from YAML.
 	// Update this count when tools are added or removed.
-	const expectedToolCount = 12
+	const expectedToolCount = 19
 	if len(toolDefs) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolDefs))
 	}

--- a/tools/search_books/handler.go
+++ b/tools/search_books/handler.go
@@ -1,0 +1,68 @@
+// Package search_books implements the search_books tool — queries
+// Open Library for books matching a title, author, topic, or ISBN.
+//
+// Like web_search, results are accumulated into ctx.SearchContext so
+// the reply tool automatically injects them as reference material for
+// the chat model. This keeps the two "lookup" tools consistent — if
+// the agent calls search_books twice in a turn, both result sets end
+// up in the chat prompt.
+package search_books
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"her/logger"
+	"her/search"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/search_books")
+
+func init() {
+	tools.Register("search_books", Handle)
+}
+
+// Handle runs a book search and returns formatted results.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var args struct {
+		Query string `json:"query"`
+		Limit int    `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return "error: " + err.Error()
+	}
+	if args.Query == "" {
+		return "error: query is required"
+	}
+	if args.Limit <= 0 {
+		args.Limit = 3
+	}
+
+	log.Infof("  search_books: %q (limit %d)", args.Query, args.Limit)
+
+	books, err := search.SearchBooks(args.Query, args.Limit)
+	if err != nil {
+		log.Warn("book search failed", "query", args.Query, "err", err)
+		return "error: " + err.Error()
+	}
+
+	formatted := search.FormatBookResults(books)
+
+	// Accumulate in SearchContext. The reply tool reads this and passes
+	// it to the chat model as reference material — same pattern web_search
+	// uses, so books and web results compose cleanly when the agent uses
+	// both in one turn.
+	if ctx.SearchContext != "" {
+		ctx.SearchContext += "\n\n"
+	}
+	ctx.SearchContext += "## Book search results\n\n" + formatted
+
+	// Return a shorter summary for the agent to read. The full formatted
+	// block goes to the chat model via SearchContext; the agent just
+	// needs to know what came back.
+	if len(books) == 0 {
+		return fmt.Sprintf("No books found for %q.", args.Query)
+	}
+	return fmt.Sprintf("Found %d books for %q. Results available in chat context.", len(books), args.Query)
+}

--- a/tools/search_books/tool.yaml
+++ b/tools/search_books/tool.yaml
@@ -1,0 +1,23 @@
+name: search_books
+description: >-
+  Search Open Library for books by title, author, topic, or any mix.
+  Returns up to 10 hits with title, author(s), first-published year,
+  subjects, and page count. Use when {{user}} asks about a specific
+  book, wants recommendations on a topic, or mentions an author whose
+  bibliography you want to verify. Free API, no key required.
+hot: false
+category: search
+parameters:
+  type: object
+  properties:
+    query:
+      type: string
+      description: "Book search query. Title, author, topic, or ISBN (e.g., 'The Overstory Powers', 'Ursula Le Guin', 'mycology nonfiction')."
+    limit:
+      type: integer
+      description: "Max results to return (default 3, max 10)."
+  required:
+    - query
+trace:
+  emoji: "📚"
+  format: "\"{{.query | escape}}\" → {{.Result | truncate 100 | escape}}"

--- a/tools/set_location/handler.go
+++ b/tools/set_location/handler.go
@@ -1,0 +1,98 @@
+// Package set_location implements the set_location tool — sets the user's
+// HOME location so get_weather has coordinates to work with.
+//
+// This tool writes to THREE places, in order:
+//
+//  1. integrate.Geocode to resolve the query → (lat, lon, display name)
+//  2. ctx.Store.InsertLocation to record the change in location_history
+//     (source "text") — this is the DB mirror
+//  3. ctx.Cfg.SetLocation to persist coordinates + display name to
+//     config.yaml so they survive restarts
+//
+// The in-memory config is updated as a side effect of step 3 (SetLocation
+// mutates the struct before writing the file). That means the next call
+// to get_weather in the same turn will pick up the new coordinates.
+//
+// Geocoding uses integrate.Geocode (Nominatim), which handles cities,
+// addresses, landmarks, and raw "lat,lon" strings — strictly better
+// than the old Open-Meteo geocoder that only understood city names.
+package set_location
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"her/integrate"
+	"her/logger"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/set_location")
+
+func init() {
+	tools.Register("set_location", Handle)
+}
+
+// Handle geocodes the query and persists the result to both config and
+// the DB. Returns a user-friendly confirmation string.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var args struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("error parsing arguments: %v", err)
+	}
+	if args.Query == "" {
+		return "error: query is required (e.g., 'Portland Oregon' or '40.71,-74.00')"
+	}
+
+	// Step 1: geocode.
+	loc, err := integrate.Geocode(args.Query)
+	if err != nil {
+		log.Warn("geocode failed", "query", args.Query, "err", err)
+		return fmt.Sprintf("error: couldn't find location for %q: %v", args.Query, err)
+	}
+	if loc == nil {
+		return fmt.Sprintf("error: no location found for %q", args.Query)
+	}
+
+	// Step 2: DB mirror. Source "text" matches the location_history
+	// convention for geocoded addresses (see memory/store.go). Failure
+	// here is logged but doesn't block the update — config.yaml is the
+	// source of truth, DB is just an audit trail.
+	if ctx.Store != nil {
+		if err := ctx.Store.InsertLocation(loc.Latitude, loc.Longitude, loc.DisplayName, "text", ctx.ConversationID); err != nil {
+			log.Warn("failed to mirror location to DB", "err", err)
+		}
+	}
+
+	// Step 3: persist to config.yaml. This also mutates ctx.Cfg in
+	// memory, so subsequent tool calls in this turn see the new coords.
+	// Failure here means the lat/lon won't survive restart — surface
+	// that to the agent so it can tell the user.
+	configSaved := true
+	if ctx.ConfigPath != "" && ctx.Cfg != nil {
+		if err := ctx.Cfg.SetLocation(ctx.ConfigPath, loc.Latitude, loc.Longitude, loc.DisplayName); err != nil {
+			log.Warn("failed to persist location to config", "err", err)
+			configSaved = false
+		}
+	}
+
+	log.Info("set_location",
+		"query", args.Query,
+		"name", loc.DisplayName,
+		"lat", loc.Latitude,
+		"lon", loc.Longitude)
+
+	if !configSaved {
+		return fmt.Sprintf(
+			"Location set in-memory to %s (%.4f, %.4f), but couldn't write to config.yaml — may not survive restart.",
+			loc.DisplayName, loc.Latitude, loc.Longitude,
+		)
+	}
+
+	return fmt.Sprintf(
+		"Home location set to %s (%.4f, %.4f). Saved to config and location_history. get_weather will now use this.",
+		loc.DisplayName, loc.Latitude, loc.Longitude,
+	)
+}

--- a/tools/set_location/tool.yaml
+++ b/tools/set_location/tool.yaml
@@ -1,0 +1,23 @@
+name: set_location
+description: >-
+  Set {{user}}'s HOME location so get_weather knows where to fetch weather
+  for. Geocodes a city, address, landmark, or raw "lat,lon" coordinates
+  into coordinates. Persists to config.yaml AND mirrors to location_history
+  in the DB. Do NOT save a separate memory for the coordinates — this
+  tool handles all persistence. Use only when {{user}} asks to change
+  their saved home location (moved, traveling long-term, etc.). For
+  one-off weather at another place, pass the location arg to get_weather
+  directly.
+hot: false
+category: context
+parameters:
+  type: object
+  properties:
+    query:
+      type: string
+      description: "City, address, landmark, or raw coordinates (e.g., 'Portland Oregon', 'Brooklyn Public Library', '40.7128,-74.0060')"
+  required:
+    - query
+trace:
+  emoji: "📍"
+  format: "{{.query | escape}}"

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -58,10 +58,14 @@ type openMeteoResponse struct {
 // "km/h" for readability — hence the separate "display" unit strings
 // below.
 func Fetch(lat, lon float64, tempUnit, windUnit string) (*Current, error) {
-	if tempUnit == "" {
+	// Whitelist valid unit values. Open-Meteo only understands these
+	// exact strings in the URL — anything else would silently return
+	// default units, and a malformed config value could inject URL
+	// parameters via &-separation. Belt and suspenders.
+	if tempUnit != "fahrenheit" && tempUnit != "celsius" {
 		tempUnit = "fahrenheit"
 	}
-	if windUnit == "" {
+	if windUnit != "mph" && windUnit != "kmh" {
 		windUnit = "mph"
 	}
 

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -1,0 +1,178 @@
+// Package weather fetches current weather data from the Open-Meteo API.
+//
+// Open-Meteo is free, no API key, no registration. We make one HTTP call
+// per agent decision — the deferred get_weather tool is only invoked when
+// the model explicitly asks about the weather, so caching doesn't pay for
+// itself. If we ever revive the "passive weather context" layer (where
+// weather is injected into every prompt), we'd add a cache.
+//
+// Geocoding (city name → lat/lon) is handled by integrate.Geocode, which
+// uses Nominatim and handles richer input than Open-Meteo's city-level
+// geocoder. This package stays focused on the weather fetch itself.
+package weather
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"her/logger"
+)
+
+var log = logger.WithPrefix("weather")
+
+// Current holds the fields we display for a single weather snapshot.
+// The struct is intentionally flat — no nested "current" wrapper like
+// the raw Open-Meteo response. Downstream (the get_weather tool, and
+// any future passive-context layer) just needs the primitives.
+type Current struct {
+	Temperature float64 // e.g., 54.2
+	TempUnit    string  // "°F" or "°C"
+	WeatherCode int     // WMO code (0-99), https://open-meteo.com/en/docs
+	Description string  // human-readable: "partly cloudy"
+	Precip      float64 // precipitation in mm (Open-Meteo always reports mm)
+	WindSpeed   float64
+	WindUnit    string   // "mph" or "km/h"
+	FetchedAt   time.Time
+}
+
+// openMeteoResponse mirrors the JSON returned by Open-Meteo's
+// /v1/forecast endpoint with the "current" parameter. We keep the
+// struct unexported — callers only see the clean Current type.
+type openMeteoResponse struct {
+	Current struct {
+		Temperature float64 `json:"temperature_2m"`
+		WeatherCode int     `json:"weather_code"`
+		Precip      float64 `json:"precipitation"`
+		WindSpeed   float64 `json:"wind_speed_10m"`
+	} `json:"current"`
+}
+
+// Fetch calls Open-Meteo for the current conditions at lat/lon. tempUnit
+// is "fahrenheit" or "celsius"; windUnit is "mph" or "kmh". Empty strings
+// default to fahrenheit/mph.
+//
+// Note: Open-Meteo's API uses "kmh" (no slash) in the URL, but we display
+// "km/h" for readability — hence the separate "display" unit strings
+// below.
+func Fetch(lat, lon float64, tempUnit, windUnit string) (*Current, error) {
+	if tempUnit == "" {
+		tempUnit = "fahrenheit"
+	}
+	if windUnit == "" {
+		windUnit = "mph"
+	}
+
+	// Build the URL. %.4f gives ~11m precision — plenty for weather and
+	// avoids URL bloat from trailing zeros in %f.
+	url := fmt.Sprintf(
+		"https://api.open-meteo.com/v1/forecast?latitude=%.4f&longitude=%.4f"+
+			"&current=temperature_2m,weather_code,precipitation,wind_speed_10m"+
+			"&temperature_unit=%s&wind_speed_unit=%s",
+		lat, lon, tempUnit, windUnit,
+	)
+
+	// Short-lived http.Client — same pattern Tavily uses. In Go the zero
+	// value of http.Client works, but setting a Timeout is important:
+	// without it, a hung server can stall the agent forever.
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching weather: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("open-meteo returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result openMeteoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("parsing weather response: %w", err)
+	}
+
+	tempDisplay := "°F"
+	if tempUnit == "celsius" {
+		tempDisplay = "°C"
+	}
+	windDisplay := "mph"
+	if windUnit == "kmh" {
+		windDisplay = "km/h"
+	}
+
+	w := &Current{
+		Temperature: result.Current.Temperature,
+		TempUnit:    tempDisplay,
+		WeatherCode: result.Current.WeatherCode,
+		Description: wmoDescription(result.Current.WeatherCode),
+		Precip:      result.Current.Precip,
+		WindSpeed:   result.Current.WindSpeed,
+		WindUnit:    windDisplay,
+		FetchedAt:   time.Now(),
+	}
+
+	log.Info("weather fetched",
+		"temp", fmt.Sprintf("%.0f%s", w.Temperature, w.TempUnit),
+		"condition", w.Description,
+		"wind", fmt.Sprintf("%.0f %s", w.WindSpeed, w.WindUnit))
+
+	return w, nil
+}
+
+// Format renders a Current into a single readable line. Used by the
+// get_weather tool; also suitable for a future passive-context layer.
+//
+// Example: "54°F, partly cloudy, no precipitation, wind 12 mph"
+func Format(w *Current) string {
+	if w == nil {
+		return ""
+	}
+	precip := "no precipitation"
+	if w.Precip > 0 {
+		precip = fmt.Sprintf("%.1f mm precipitation", w.Precip)
+	}
+	return fmt.Sprintf("%.0f%s, %s, %s, wind %.0f %s",
+		w.Temperature, w.TempUnit,
+		w.Description,
+		precip,
+		w.WindSpeed, w.WindUnit)
+}
+
+// wmoDescription translates WMO weather codes into human-readable
+// phrases. These codes are a worldwide standard; Open-Meteo uses them
+// and so do most other weather APIs.
+//
+// Full table: https://open-meteo.com/en/docs (search "WMO Weather interpretation codes")
+func wmoDescription(code int) string {
+	switch {
+	case code == 0:
+		return "clear sky"
+	case code == 1:
+		return "mainly clear"
+	case code == 2:
+		return "partly cloudy"
+	case code == 3:
+		return "overcast"
+	case code == 45 || code == 48:
+		return "foggy"
+	case code >= 51 && code <= 57:
+		return "drizzle"
+	case code >= 61 && code <= 65:
+		return "rain"
+	case code == 66 || code == 67:
+		return "freezing rain"
+	case code >= 71 && code <= 77:
+		return "snow"
+	case code >= 80 && code <= 82:
+		return "rain showers"
+	case code == 85 || code == 86:
+		return "snow showers"
+	case code >= 95:
+		return "thunderstorm"
+	default:
+		return "unknown"
+	}
+}

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -1,0 +1,138 @@
+package weather
+
+// Tests for the pure functions in weather.go — no network calls needed.
+// wmoDescription and Format are the main targets: both have branching
+// logic that's easy to cover with table-driven tests.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWmoDescription covers every WMO code range in the switch statement.
+// The codes are a worldwide standard, so these won't change — but the
+// switch has range boundaries (51-57, 61-65, etc.) that are worth
+// exercising at the edges.
+func TestWmoDescription(t *testing.T) {
+	tests := []struct {
+		code int
+		want string
+	}{
+		{0, "clear sky"},
+		{1, "mainly clear"},
+		{2, "partly cloudy"},
+		{3, "overcast"},
+		{45, "foggy"},
+		{48, "foggy"},
+		{51, "drizzle"},
+		{55, "drizzle"},
+		{57, "drizzle"},
+		{61, "rain"},
+		{63, "rain"},
+		{65, "rain"},
+		{66, "freezing rain"},
+		{67, "freezing rain"},
+		{71, "snow"},
+		{75, "snow"},
+		{77, "snow"},
+		{80, "rain showers"},
+		{82, "rain showers"},
+		{85, "snow showers"},
+		{86, "snow showers"},
+		{95, "thunderstorm"},
+		{99, "thunderstorm"},
+		// Edge cases: codes that fall between defined ranges.
+		{4, "unknown"},
+		{50, "unknown"},
+		{60, "unknown"},
+		{70, "unknown"},
+		{90, "unknown"},
+	}
+
+	for _, tc := range tests {
+		got := wmoDescription(tc.code)
+		if got != tc.want {
+			t.Errorf("wmoDescription(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// TestFormat exercises the Format function with various Current structs.
+// Format is pure (no I/O), so we just check the output string shape.
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *Current
+		want []string // substrings that must appear
+	}{
+		{
+			name: "typical sunny day",
+			in: &Current{
+				Temperature: 72,
+				TempUnit:    "°F",
+				WeatherCode: 1,
+				Description: "mainly clear",
+				Precip:      0,
+				WindSpeed:   8,
+				WindUnit:    "mph",
+				FetchedAt:   time.Now(),
+			},
+			want: []string{"72°F", "mainly clear", "no precipitation", "wind 8 mph"},
+		},
+		{
+			name: "rainy with precipitation",
+			in: &Current{
+				Temperature: 48.5,
+				TempUnit:    "°F",
+				WeatherCode: 61,
+				Description: "rain",
+				Precip:      3.2,
+				WindSpeed:   15,
+				WindUnit:    "mph",
+				FetchedAt:   time.Now(),
+			},
+			want: []string{"48°F", "rain", "3.2 mm precipitation", "wind 15 mph"},
+		},
+		{
+			name: "celsius and km/h",
+			in: &Current{
+				Temperature: 22,
+				TempUnit:    "°C",
+				WeatherCode: 2,
+				Description: "partly cloudy",
+				Precip:      0,
+				WindSpeed:   20,
+				WindUnit:    "km/h",
+				FetchedAt:   time.Now(),
+			},
+			want: []string{"22°C", "partly cloudy", "no precipitation", "wind 20 km/h"},
+		},
+		{
+			name: "nil returns empty",
+			in:   nil,
+			want: []string{""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Format(tc.in)
+			for _, sub := range tc.want {
+				if !strings.Contains(got, sub) {
+					t.Errorf("Format() missing %q\ngot: %s", sub, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFormat_NilSafety ensures Format doesn't panic on nil input.
+// This matters because the get_weather handler could theoretically
+// pass nil if Fetch returns an error that gets swallowed.
+func TestFormat_NilSafety(t *testing.T) {
+	got := Format(nil)
+	if got != "" {
+		t.Errorf("Format(nil) = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
Brings back weather, location, and book search as deferred tools loaded
on demand via use_tools. Rewritten against the current patterns rather
than copying wholesale from _junkdrawer:

- weather/ is now stateless — no singleton client, no cache. The
  deferred tool is only invoked when the agent explicitly asks, so
  per-call HTTP is fine. If we ever revive passive weather context,
  we'll add caching then.
- set_location uses the existing integrate.Geocode (Nominatim) which
  handles addresses, landmarks, and raw coords — richer than the old
  Open-Meteo city-only geocoder.
- set_location writes to THREE places: geocode → location_history (DB
  mirror via the existing InsertLocation) → config.yaml (via a new
  surgical-edit SetLocation method modeled on SetTrace).
- get_weather reads the home location from ctx.Cfg; an optional
  location arg enables one-off lookups without overwriting home.
- search_books is a plain deferred tool in the existing search
  category, mirrors the web_search pattern (results accumulated in
  ctx.SearchContext).
- New "context" category in categories.yaml for weather + location.

No changes to tools.Context, agent.RunParams, bot.New, or cmd/run.go —
the tools reach everything they need through ctx.Cfg, ctx.ConfigPath,
and ctx.Store.