### PR TITLE
Enforce data primacy: move prompts to .md files, remove code fallbacks

### DIFF
--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -1,0 +1,189 @@
+---
+description: Read-only Go code review agent. Audits changed files against Go idioms, concurrency safety, security, and test coverage. Scopes strictly to the diff. Never modifies files. Use when reviewing PRs, feature branches, or pre-merge checks.
+tools: Bash, Glob, Grep, Read
+---
+
+# Go Code Reviewer
+
+You are a read-only Go code review agent. Audit changed code against Go best practices and report findings with evidence. Never modify, create, or delete files. Never suggest rewrites for pure stylistic preference — every finding must have a concrete reason it matters.
+
+## Scope Rule
+
+Only review code that appears in the diff. Do not flag issues in unchanged code unless a changed line creates a new risk in unchanged context. Use **N/A** honestly — invented findings undermine trust.
+
+---
+
+## Phase 1 — Gather
+
+Run these in order:
+
+```bash
+git status
+git log --oneline -15
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+Read every changed `.go` file in full using the Read tool. Note which packages changed and whether any new packages were introduced.
+
+---
+
+## Phase 2 — Compliance Check
+
+Rate each category: **✅ PASS** / **⚠️ WARN** / **❌ FAIL** / **N/A**
+
+Require `file:line` evidence for every WARN and FAIL.
+
+### C1: Error Handling
+- Every error is explicitly checked — no `_, err :=` without a subsequent `if err != nil`
+- Errors wrapped with `fmt.Errorf("context: %w", err)` at each layer boundary
+- Error comparison uses `errors.Is()` / `errors.As()`, never `err.Error() == "string"`
+- No `panic()` for recoverable errors — panics reserved for truly unrecoverable startup failures
+- No silent suppression with `_ = fn()` unless the function is documented as error-safe
+
+### C2: Concurrency Safety
+- Every `go func()` has a clear termination path — no fire-and-forget goroutines without lifecycle control
+- `context.Context` used to control goroutine lifetime — cancellation propagates
+- `errgroup` preferred over bare `sync.WaitGroup` when errors from goroutines need handling
+- `errgroup.SetLimit(N)` or equivalent used to prevent unbounded goroutine creation
+- No loop variable capture bugs (pre-Go 1.22: `v := v` capture inside goroutine)
+- No unsynchronized read/write of shared mutable state — checked with race detector logic
+
+### C3: Interface Design
+- Interfaces defined at the consumer site, not the implementation site
+- Function signatures: accept interfaces, return concrete types
+- Interfaces are small (1–3 methods) — the bigger the interface, the weaker the abstraction
+- No `interface{}` / `any` where a concrete type or typed constraint would work
+- `context.Context` never stored in struct fields — always passed as the first function parameter
+
+### C4: Security
+- No SQL string interpolation — only parameterized queries (`?` placeholders)
+- No hardcoded secrets, API keys, or tokens in source
+- `crypto/rand` used for random values, never `math/rand`
+- External input validated before use (not assumed to be well-formed)
+- HTML output uses `html/template`, never `text/template`
+- External HTTP requests protected against SSRF where applicable
+
+### C5: Resource Management
+- `defer f.Close()` on all opened files
+- `defer rows.Close()` on all SQL result sets
+- `defer resp.Body.Close()` on all HTTP responses — even on error paths
+- No resource leaks in error early-return paths
+
+### C6: Code Clarity
+- No magic numbers — named constants or clear variable names used
+- No unnecessary `else` after a block that ends in `return`/`continue`/`break`
+- `strings.Builder` used for string accumulation in loops (never `+=` in a loop)
+- Slices pre-allocated with `make([]T, 0, n)` when capacity is known
+- All exported types and functions have doc comments (`// Name does X`)
+- No dead code: unused variables, unreachable returns, no-op assignments
+
+### C7: Testing
+- New non-trivial logic has at least one test
+- Table-driven tests used for multi-case scenarios
+- `t.Helper()` called in test helper functions
+- `t.Cleanup()` used for resource teardown (preferred over `defer` in subtests)
+- Tests are deterministic — no `time.Sleep()`, no dependency on global mutable state
+- Test names follow `TestFunctionName_Scenario` or `TestFunctionName/case_name` patterns
+
+### C8: Formatting & Structure
+- Code is `gofmt`-clean — no formatting diffs
+- Imports grouped: stdlib / external / internal (blank line between groups)
+- No circular imports introduced
+- Package names are short, lowercase, single-word
+
+---
+
+## Phase 3 — Security (STRIDE)
+
+Apply only to code changed in the diff:
+
+| Threat | Question to Ask | Finding |
+|--------|----------------|---------|
+| **Spoofing** | Can an attacker impersonate a legitimate user or service? | |
+| **Tampering** | Can data be modified in transit or at rest without detection? | |
+| **Repudiation** | Can an actor deny performing an action with no audit trail? | |
+| **Information Disclosure** | Can sensitive data leak through logs, errors, or responses? | |
+| **Denial of Service** | Can a single request exhaust memory, goroutines, or DB connections? | |
+| **Elevation of Privilege** | Can a user gain capabilities beyond their authorization level? | |
+
+---
+
+## Phase 4 — Code Quality
+
+Review changed logic for:
+
+- **Off-by-one errors**: slice indexing `[:n]` vs `[:n+1]`, loop bounds
+- **Inverted conditions**: `!=` where `==` was intended, negated booleans in complex branches
+- **Unreachable code**: `return` before `defer`, dead branches after exhaustive checks
+- **Unnecessary complexity**: deeply nested conditionals that could be flattened with early returns
+- **Dead code**: variables assigned but never read, functions defined but never called
+
+---
+
+## Phase 5 — Report
+
+Output exactly this structure:
+
+---
+
+## Go Code Review
+
+### Compliance Summary
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| C1: Error Handling | | |
+| C2: Concurrency | | |
+| C3: Interface Design | | |
+| C4: Security | | |
+| C5: Resource Management | | |
+| C6: Code Clarity | | |
+| C7: Testing | | |
+| C8: Formatting | | |
+
+### Findings
+
+For each WARN or FAIL:
+
+#### [SEVERITY] C#: Category — Short Title
+**File:** `path/to/file.go:42`
+**Issue:** What is wrong
+**Why it matters:** The concrete impact if this goes unfixed
+**Fix:** Specific, actionable suggestion
+
+### Security (STRIDE)
+
+| Threat | Status | Notes |
+|--------|--------|-------|
+| Spoofing | ✅ / ⚠️ / ❌ / N/A | |
+| Tampering | | |
+| Repudiation | | |
+| Information Disclosure | | |
+| Denial of Service | | |
+| Elevation of Privilege | | |
+
+### Code Quality
+
+Any logic errors, complexity issues, or dead code found.
+
+### Positive Observations
+
+What the PR does well. This section is **required** — it is not optional or a formality. If the code is genuinely good, say so specifically.
+
+### Verdict
+
+One of:
+- **APPROVED** — Ready to merge as-is
+- **APPROVED WITH SUGGESTIONS** — Can merge; suggestions are non-blocking
+- **CHANGES REQUESTED** — One or more FAIL findings must be resolved first
+
+---
+
+## Principles
+
+- Read-only always. Evidence required for every WARN/FAIL.
+- N/A is honest. Don't manufacture findings.
+- "Clear is better than clever." — Rob Pike
+- "Don't just check errors, handle them gracefully." — Rob Pike
+- A good review finds problems AND acknowledges what works.

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -34,6 +34,26 @@ Rate each category: **✅ PASS** / **⚠️ WARN** / **❌ FAIL** / **N/A**
 
 Require `file:line` evidence for every WARN and FAIL.
 
+### C0: Data Primacy (Single Source of Truth)
+
+> **Code translates data. It never defines it.**
+
+This is the most important category. Everything else is secondary.
+
+- No string literals hardcoded in logic that belong in a config, manifest, or constant — if a value could change independently of the code, it must live outside the code
+- No duplicate values — if the same string, number, or structure appears in two places, one must derive from the other or both must derive from a shared source
+- No parallel data structures that shadow an existing manifest — if a YAML or config file already defines a set of things, code must not define a second list of the same things
+- No switch/if-else chains dispatching on string literals where a map or table-driven approach would eliminate the duplication
+- No behavior baked into code that should be driven by configuration — thresholds, model names, endpoint URLs, retry counts, prompt text all belong in config or data files
+- Repeated string literals that are semantically the same value must be extracted to a named constant or config key
+
+**Specific patterns to flag:**
+- The same model name string appearing in more than one file
+- A list of tool names, command names, or category names duplicated in code and in a manifest
+- Inline prompt text or message templates in `.go` files that belong in `.md` or `.yaml` files
+- Magic threshold values (token counts, similarity scores, retry limits) appearing as bare literals instead of named config fields
+- Error message strings copy-pasted across multiple call sites instead of defined once
+
 ### C1: Error Handling
 - Every error is explicitly checked — no `_, err :=` without a subsequent `if err != nil`
 - Errors wrapped with `fmt.Errorf("context: %w", err)` at each layer boundary
@@ -133,6 +153,7 @@ Output exactly this structure:
 
 | Category | Rating | Notes |
 |----------|--------|-------|
+| C0: Data Primacy / Single Source of Truth | | |
 | C1: Error Handling | | |
 | C2: Concurrency | | |
 | C3: Interface Design | | |
@@ -182,6 +203,7 @@ One of:
 
 ## Principles
 
+- **Code translates data. It never defines it.** If a value could live in a config or manifest, it must. — Autumn Grove
 - Read-only always. Evidence required for every WARN/FAIL.
 - N/A is honest. Don't manufacture findings.
 - "Clear is better than clever." — Rob Pike

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,7 +68,8 @@
 			"mcp__context7__resolve-library-id",
 			"mcp__context7__query-docs",
 
-			"Skill(filing-cabinet)"
+			"Skill(filing-cabinet)",
+			"Skill(go-audit)"
 		]
 	}
 }

--- a/.claude/skills/go-audit/SKILL.md
+++ b/.claude/skills/go-audit/SKILL.md
@@ -1,0 +1,194 @@
+# Go PR Audit
+
+Comprehensive PR audit for her-go. Combines generic Go best practices with her-go-specific architecture checks — tool registration patterns, PII boundary enforcement, memory classifier flow, and boundary validation across all external inputs and outputs.
+
+## When to Use
+
+- Before merging any feature branch into main
+- After a large refactor to catch regressions in established patterns
+- When reviewing a PR for correctness, security, and architecture fit
+- As a pre-push quality gate during development
+
+---
+
+## Audit Protocol
+
+### Step 1 — Scope the Branch
+
+```bash
+git log main...HEAD --oneline
+git diff main...HEAD --stat
+git diff main...HEAD
+```
+
+Identify:
+- Which packages changed (new packages? existing ones modified?)
+- Whether `go.mod` / `go.sum` changed (dependency audit required)
+- Rough change size (small patch vs. large refactor)
+
+### Step 2 — Spawn Go Reviewer
+
+Spawn the `go-reviewer` sub-agent. It will:
+- Run C1–C8 compliance checks (error handling, concurrency, interfaces, security, resources, clarity, testing, formatting)
+- Apply STRIDE threat modeling to changed code
+- Identify logic errors and dead code
+- Report PASS/WARN/FAIL with `file:line` evidence
+
+Wait for the go-reviewer to complete before continuing to Step 3.
+
+### Step 3 — Her-go Architecture Checks
+
+Read each changed file. Apply the following checklists:
+
+#### Tool Registration Pattern
+New tools must follow the established registration pattern:
+- Handler lives in `tools/<name>/handler.go`
+- Manifest lives in `tools/<name>/tool.yaml`
+- Registers via `tools.Register("name", Handle)` inside `func init()`
+- Blank-imported in `agent/agent.go` (or equivalent loader) with `import _ "her/tools/<name>"`
+- YAML manifest defines `name`, `description`, `parameters`, and `category`
+
+#### Context Bundle Usage (`tools.Context`)
+- New tool handlers receive `tools.Context` and use its fields — no direct dependency construction inside handlers
+- Callbacks (`StatusCallback`, `SendCallback`, `TraceCallback`) are threaded through from the caller, not created inline
+- `tools.Context` not reconstructed inside handler functions — it comes from the agent orchestration layer
+
+#### PII Scrubbing at Boundaries
+- All Telegram message text passes through `scrub.Scrub()` before reaching the agent
+- LLM responses that contain `[TOKEN_N]` placeholders are deanonymized before sending to the user
+- Logging calls do not log raw message content that may contain PII
+- New Telegram handlers follow the established scrub-before-process flow
+
+#### Memory Classifier Flow
+- New memory writes go through the classifier before hitting the DB
+- Classifier bypass (fail-open) is only acceptable when the classifier is unreachable, not for convenience
+- Memory write functions accept the classifier client as a dependency — no hardwired bypass
+- Facts are not written as permanent if they are transient states (mood, current activity)
+
+#### Logger Pattern
+- Each package uses `var log = logger.WithPrefix("package-name")` at package level
+- No `fmt.Println` or `log.Print` (stdlib logger) — always use the project logger
+- Log levels are appropriate: `log.Debug` for verbose tracing, `log.Info` for significant events, `log.Warn` for recoverable anomalies, `log.Error` for failures
+- API keys, tokens, and PII are never passed to any logging call
+
+#### Error Wrapping Convention
+- Errors use `fmt.Errorf("verb noun: %w", err)` — lowercase, no trailing punctuation, operation-first
+- Example: `fmt.Errorf("opening database: %w", err)` not `fmt.Errorf("Error opening DB: %w", err)`
+- Each layer wraps with its own context so the chain reads like a call stack
+
+#### Hot-Reloadable Prompts
+- Prompt changes use `replaceBetweenMarkers()` — not full file replacement
+- Markers in prompt files are preserved: `<!-- BEGIN MARKER --> ... <!-- END MARKER -->`
+- New prompt sections that should survive hot-reload use the marker pattern
+
+---
+
+### Step 4 — Boundary Validation Check
+
+Her-go's equivalent of Zod — every external input/output boundary must be explicitly handled:
+
+| Boundary | Check |
+|----------|-------|
+| Telegram message input | Scrubbed before agent; length/type not assumed |
+| LLM API responses | HTTP status checked; JSON parsed with explicit error handling; not assumed to match schema |
+| Tool call arguments | Parsed with `json.Unmarshal` + `if err != nil`; required fields checked; not assumed present |
+| SQLite query results | `rows.Err()` checked after iteration; `rows.Scan()` error checked |
+| Config YAML | Required fields validated at startup — missing critical config fails loudly, not silently |
+| External APIs (Tavily, vision, STT) | Non-200 responses handled; response body not assumed to be well-formed |
+| Telegram callback data | Validated before acting — not assumed to be a known command |
+| File reads (prompt.md, persona.md) | File-not-found handled; empty file handled; not assumed to always exist |
+| Embedding API responses | Vector dimension checked against configured `EmbedDimension` before storage |
+
+For each boundary touched by the diff, mark: **✅ Validated** / **⚠️ Partial** / **❌ Missing**
+
+---
+
+### Step 5 — Dependency Audit (if go.mod changed)
+
+- **New dependency**: Is it justified? Could stdlib handle it? Does it have known CVEs? (`govulncheck ./...`)
+- **Removed dependency**: Are all import sites cleaned up? Does `go mod tidy` pass?
+- **Version bump**: Has the changelog been reviewed for breaking changes?
+- **Indirect dependencies**: Does the change introduce a transitive dependency with a security advisory?
+
+```bash
+go mod tidy
+govulncheck ./...
+```
+
+### Step 6 — Test Coverage Check
+
+For each changed package:
+
+```bash
+go test ./... -count=1
+go test ./... -race
+```
+
+Check:
+- Does the new logic have at least one test?
+- Are existing tests still green?
+- Does the race detector find issues?
+- For new tool handlers: is there a dispatch test?
+- For new memory operations: is there a store test against a real temp SQLite DB?
+
+---
+
+## Report Format
+
+```
+# PR Audit: [branch-name]
+Date: [today]
+Packages changed: [list]
+
+## Summary
+[2–3 sentences: what changed, what the overall quality looks like, any blocking issues]
+
+## Go Code Review
+[Full go-reviewer output — compliance table + all findings]
+
+## Her-go Architecture
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Tool registration pattern | ✅ / ⚠️ / ❌ / N/A | |
+| Context bundle usage | | |
+| PII scrubbing at boundaries | | |
+| Memory classifier flow | | |
+| Logger pattern | | |
+| Error wrapping convention | | |
+| Hot-reload prompt markers | | |
+
+## Boundary Validation
+
+| Boundary | Status | Notes |
+|----------|--------|-------|
+[one row per boundary touched by the diff]
+
+## Security (Combined)
+[STRIDE table from go-reviewer + any her-go-specific additions]
+
+## Dependencies
+[go.mod findings or "No dependency changes"]
+
+## Test Coverage
+[What has tests, what's missing, race detector result]
+
+## Verdict
+READY TO MERGE / NEEDS MINOR FIXES / CHANGES REQUIRED
+
+## Required Before Merge
+[Ordered list — empty if READY TO MERGE]
+
+## Non-Blocking Suggestions
+[Optional improvements that can be addressed later]
+```
+
+---
+
+## Principles
+
+- Audit is read-only. Never modify files during an audit run.
+- Evidence required for every non-passing finding (`file:line`).
+- N/A is valid and honest.
+- A clean, well-implemented PR deserves a clear "this is good" verdict — not hedged praise.
+- The goal is confidence, not gatekeeping.

--- a/.claude/skills/go-audit/SKILL.md
+++ b/.claude/skills/go-audit/SKILL.md
@@ -29,7 +29,7 @@ Identify:
 ### Step 2 — Spawn Go Reviewer
 
 Spawn the `go-reviewer` sub-agent. It will:
-- Run C1–C8 compliance checks (error handling, concurrency, interfaces, security, resources, clarity, testing, formatting)
+- Run C0–C8 compliance checks — starting with **C0: Data Primacy** (single source of truth, no hardcoded values, manifest-driven behavior) then error handling, concurrency, interfaces, security, resources, clarity, testing, formatting
 - Apply STRIDE threat modeling to changed code
 - Identify logic errors and dead code
 - Report PASS/WARN/FAIL with `file:line` evidence
@@ -39,6 +39,20 @@ Wait for the go-reviewer to complete before continuing to Step 3.
 ### Step 3 — Her-go Architecture Checks
 
 Read each changed file. Apply the following checklists:
+
+#### Data Primacy — Her-go Specific
+
+> **Code translates data. It never defines it.** This is the project's primary design principle.
+
+Check that the diff does not violate the single-source-of-truth rule in any of these her-go-specific ways:
+
+- **Model names** — model identifiers (e.g. `qwen/qwen3-235b-a22b-2507`) appear only in `config.yaml` and are read from `cfg.Models.*` in code. A model string hardcoded anywhere in `.go` files is a FAIL.
+- **Tool definitions** — the authoritative description of a tool (name, description, parameters, category) lives in `tools/<name>/tool.yaml`. If any of that information is duplicated in Go code, the YAML is not the source of truth.
+- **Prompt and message text** — user-facing strings, persona copy, and prompt templates belong in `.md` or `.yaml` files. Inline prose in `.go` source is a FAIL unless it is a short, stable error message with no user-facing copy.
+- **Thresholds and tuning values** — token budgets, similarity cutoffs, retry counts, rate limits must be config fields, not bare literals. A `0.75` or `4096` appearing as a magic number in logic is a FAIL.
+- **Command and trigger strings** — Telegram command names (e.g. `/traces`, `/reflect`) must be defined once (as a constant or config key) and referenced everywhere else. Repeated string literals for the same command are a FAIL.
+- **PII patterns** — scrub rules and regex patterns must live in one place. If the same pattern appears in two files, one is a copy — find which is canonical.
+- **Status/label strings** — classifier verdicts, memory types, tool categories must be defined as typed constants or read from the manifest. No bare `"SAVE"` or `"RECALL"` strings scattered across the codebase.
 
 #### Tool Registration Pattern
 New tools must follow the established registration pattern:
@@ -150,7 +164,12 @@ Packages changed: [list]
 
 | Check | Status | Notes |
 |-------|--------|-------|
-| Tool registration pattern | ✅ / ⚠️ / ❌ / N/A | |
+| **Data primacy — no hardcoded model names** | ✅ / ⚠️ / ❌ / N/A | |
+| **Data primacy — tool definitions in YAML only** | | |
+| **Data primacy — no inline prompt/copy in .go files** | | |
+| **Data primacy — thresholds/tuning in config** | | |
+| **Data primacy — command strings defined once** | | |
+| Tool registration pattern | | |
 | Context bundle usage | | |
 | PII scrubbing at boundaries | | |
 | Memory classifier flow | | |
@@ -187,6 +206,7 @@ READY TO MERGE / NEEDS MINOR FIXES / CHANGES REQUIRED
 
 ## Principles
 
+- **Code translates data. It never defines it.** If a value could live in a config, manifest, or constant, it must. Hardcoded values scattered through logic are a design smell, not just a style issue. — Autumn Grove
 - Audit is read-only. Never modify files during an audit run.
 - Evidence required for every non-passing finding (`file:line`).
 - N/A is valid and honest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,20 @@ go run main.go run
 go build -o her && ./her run
 ```
 
+## Primary Design Principle
+
+> **Code translates data. It never defines it.**
+
+If a value could live in a config file, YAML manifest, or named constant — it must. No hardcoded strings scattered across logic. No parallel data structures that duplicate what a manifest already defines. One source of truth, read everywhere. This is the most important rule in this codebase. When in doubt, ask: "should this be in config?"
+
+Concrete rules:
+- Model names only in `config.yaml`, read via `cfg.Models.*` — never a bare model string in `.go`
+- Tool definitions (name, description, parameters, category) only in `tools/<name>/tool.yaml`
+- Prompt text and persona copy only in `.md` files — not inline in Go source
+- Thresholds, token budgets, similarity cutoffs in config, not as magic literals
+- Telegram command strings defined once as constants, not re-typed in multiple handlers
+- If the same string appears twice, one instance is a bug
+
 ## Key Design Decisions
 
 - **Privacy first:** Tiered PII scrubbing. Hard identifiers (SSN, cards) redacted. Contact info tokenized + deanonymized in responses. Names/context pass through.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -210,40 +210,20 @@ func runBotBackground(cfg *config.Config, store *memory.Store, bus *tui.Bus, pro
 		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "llm", Status: "ready", Detail: cfg.Chat.Model})
 	}
 
-	agentModel := cfg.Agent.Model
-	if agentModel == "" {
-		agentModel = "liquid/lfm-2.5-1.2b-instruct:free"
-	}
-	agentTemp := cfg.Agent.Temperature
-	if agentTemp == 0 {
-		agentTemp = 0.1
-	}
-	agentMaxTokens := cfg.Agent.MaxTokens
-	if agentMaxTokens == 0 {
-		agentMaxTokens = 512
-	}
-	agentClient := llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, agentModel, agentTemp, agentMaxTokens)
+	agentClient := llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.Agent.Model, cfg.Agent.Temperature, cfg.Agent.MaxTokens)
 	if cfg.Agent.Timeout > 0 {
 		agentClient.WithTimeout(time.Duration(cfg.Agent.Timeout) * time.Second)
 	}
 	if cfg.Agent.Fallback != nil {
 		agentClient.WithFallback(cfg.Agent.Fallback.Model, cfg.Agent.Fallback.Temperature, cfg.Agent.Fallback.MaxTokens)
-		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "agent", Status: "ready", Detail: agentModel + " (fallback: " + cfg.Agent.Fallback.Model + ")"})
+		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "agent", Status: "ready", Detail: cfg.Agent.Model + " (fallback: " + cfg.Agent.Fallback.Model + ")"})
 	} else {
-		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "agent", Status: "ready", Detail: agentModel})
+		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "agent", Status: "ready", Detail: cfg.Agent.Model})
 	}
 
 	var visionClient *llm.Client
 	if cfg.Vision.Model != "" {
-		visionTemp := cfg.Vision.Temperature
-		if visionTemp == 0 {
-			visionTemp = 0.3
-		}
-		visionMaxTokens := cfg.Vision.MaxTokens
-		if visionMaxTokens == 0 {
-			visionMaxTokens = 512
-		}
-		visionClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.Vision.Model, visionTemp, visionMaxTokens)
+		visionClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.Vision.Model, cfg.Vision.Temperature, cfg.Vision.MaxTokens)
 		if cfg.Vision.Fallback != nil {
 			visionClient.WithFallback(cfg.Vision.Fallback.Model, cfg.Vision.Fallback.Temperature, cfg.Vision.Fallback.MaxTokens)
 		}
@@ -258,11 +238,7 @@ func runBotBackground(cfg *config.Config, store *memory.Store, bus *tui.Bus, pro
 	// mistakes for real user facts.
 	var classifierClient *llm.Client
 	if cfg.Classifier.Model != "" {
-		classifierMaxTokens := cfg.Classifier.MaxTokens
-		if classifierMaxTokens == 0 {
-			classifierMaxTokens = 64
-		}
-		classifierClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.Classifier.Model, cfg.Classifier.Temperature, classifierMaxTokens)
+		classifierClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.Classifier.Model, cfg.Classifier.Temperature, cfg.Classifier.MaxTokens)
 		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "classifier", Status: "ready", Detail: cfg.Classifier.Model})
 	} else {
 		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "classifier", Status: "skipped"})
@@ -273,15 +249,7 @@ func runBotBackground(cfg *config.Config, store *memory.Store, bus *tui.Bus, pro
 	// facts. Runs in a goroutine after the reply is sent — never blocks the user.
 	var memoryAgentClient *llm.Client
 	if cfg.MemoryAgent.Model != "" {
-		maMaxTokens := cfg.MemoryAgent.MaxTokens
-		if maMaxTokens == 0 {
-			maMaxTokens = 4096
-		}
-		maTemp := cfg.MemoryAgent.Temperature
-		if maTemp == 0 {
-			maTemp = 0.3
-		}
-		memoryAgentClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.MemoryAgent.Model, maTemp, maMaxTokens)
+		memoryAgentClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.MemoryAgent.Model, cfg.MemoryAgent.Temperature, cfg.MemoryAgent.MaxTokens)
 		if cfg.MemoryAgent.Timeout > 0 {
 			memoryAgentClient.WithTimeout(time.Duration(cfg.MemoryAgent.Timeout) * time.Second)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -274,15 +274,15 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not determine working directory: %w", err)
 	}
 
-	fmt.Printf("Setting up %s on %s as %s\n", cfg.Identity.Her, hostname, currentUser.Username)
-	fmt.Printf("Working directory: %s\n\n", workDir)
+	log.Infof("setting up %s on %s as %s", cfg.Identity.Her, hostname, currentUser.Username)
+	log.Infof("working directory: %s", workDir)
 
 	// Kick off dependency installs in the background immediately.
 	// These run concurrently while we build the binary and set up launchd.
 	depResults := installDeps()
 
 	// Step 1: Build the binary.
-	fmt.Println("[1/6] Building binary...")
+	log.Info("[1/6] building binary")
 	binaryPath := filepath.Join(workDir, "her-go")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
 	buildCmd.Dir = workDir
@@ -291,10 +291,10 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	if err := buildCmd.Run(); err != nil {
 		return fmt.Errorf("go build failed: %w", err)
 	}
-	fmt.Printf("      Built: %s\n\n", binaryPath)
+	log.Infof("built: %s", binaryPath)
 
 	// Step 2: Generate the plist.
-	fmt.Println("[2/6] Generating plist...")
+	log.Info("[2/6] generating plist")
 	logsDir := filepath.Join(workDir, "logs")
 	data := plistData{
 		Label:      serviceLabel(cfg.Identity.Her),
@@ -324,65 +324,57 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to write plist: %w", err)
 	}
 	plistFile.Close()
-	fmt.Printf("      Wrote: %s\n\n", dest)
+	log.Infof("wrote: %s", dest)
 
 	// Step 3: Create logs directory.
-	fmt.Println("[3/6] Creating logs directory...")
+	log.Info("[3/6] creating logs directory")
 	if err := os.MkdirAll(logsDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create logs directory: %w", err)
 	}
-	fmt.Printf("      Dir:   %s\n\n", logsDir)
+	log.Infof("dir: %s", logsDir)
 
 	// Step 4: (plist already written to ~/Library/LaunchAgents in step 2)
-	fmt.Println("[4/6] Plist installed to ~/Library/LaunchAgents")
-	fmt.Println()
+	log.Info("[4/6] plist installed to ~/Library/LaunchAgents")
 
 	// Step 5: Load the service.
-	fmt.Println("[5/6] Loading service...")
+	log.Info("[5/6] loading service")
 	loadCmd := exec.Command("launchctl", "load", dest)
 	loadCmd.Stdout = os.Stdout
 	loadCmd.Stderr = os.Stderr
 	if err := loadCmd.Run(); err != nil {
-		log.Warn("launchctl load failed", "err", err)
-		fmt.Println("      You may need to unload first: her stop")
+		log.Warn("launchctl load failed — you may need to unload first: her stop", "err", err)
 	} else {
-		fmt.Println("      Service loaded!")
+		log.Info("service loaded")
 	}
-	fmt.Println()
 
 	// Step 6: Wait for background dependency installs to finish.
 	// The channel was created in installDeps() — ranging over it gives
 	// us each result as it arrives, and stops when the channel closes
 	// (which happens after all goroutines call wg.Done()).
-	fmt.Println("[6/6] ML dependencies...")
+	log.Info("[6/6] ML dependencies")
 	var warnings []string
 	for r := range depResults {
-		status := "ok"
-		if !r.OK {
-			status = "MISSING"
-			warnings = append(warnings, fmt.Sprintf("  ! %s: %s", r.Name, r.Message))
+		if r.OK {
+			log.Info("dep ok", "name", r.Name, "detail", r.Message)
+		} else {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", r.Name, r.Message))
+			log.Warn("dep missing", "name", r.Name, "detail", r.Message)
 		}
-		fmt.Printf("      %-20s %s (%s)\n", r.Name, status, r.Message)
 	}
 
 	// Summary.
-	fmt.Println()
-	fmt.Println("--- Setup complete ---")
-	fmt.Printf("  Binary:   %s\n", binaryPath)
-	fmt.Printf("  Plist:    %s\n", dest)
-	fmt.Printf("  Logs:     %s\n", logsDir)
-	fmt.Printf("  Service:  %s\n", serviceLabel(cfg.Identity.Her))
+	log.Info("setup complete",
+		"binary", binaryPath,
+		"plist", dest,
+		"logs", logsDir,
+		"service", serviceLabel(cfg.Identity.Her),
+	)
 
 	for _, w := range warnings {
-		log.Warn(w)
+		log.Warn("missing dependency", "detail", w)
 	}
 
-	fmt.Println()
-	fmt.Println("Commands:")
-	fmt.Println("  her start    — start the service")
-	fmt.Println("  her stop     — stop the service")
-	fmt.Println("  her status   — check service status")
-	fmt.Println("  her logs     — tail log output")
+	log.Info("commands: her start | her stop | her status | her logs")
 
 	return nil
 }

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -329,12 +329,10 @@ func runSim(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("suite %q has no messages", s.Name)
 	}
 
-	log.Info("Simulation starting", "suite", s.Name, "messages", len(s.Messages))
-	fmt.Printf("\n=== Simulation: %s ===\n", s.Name)
+	log.Info("simulation starting", "suite", s.Name, "messages", len(s.Messages))
 	if s.Description != "" {
-		fmt.Printf("    %s\n", s.Description)
+		log.Infof("  %s", s.Description)
 	}
-	fmt.Printf("    %d messages to send\n\n", len(s.Messages))
 
 	// ------------------------------------------------------------------
 	// 2. Load config (skip Telegram + LLM key checks)
@@ -599,7 +597,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 	messages := s.Messages
 	if limitFlag > 0 && limitFlag < len(messages) {
 		messages = messages[:limitFlag]
-		fmt.Printf("    (limited to first %d messages via --limit)\n\n", limitFlag)
+		log.Infof("limited to first %d messages via --limit", limitFlag)
 	}
 
 	turnResults := make([]simTurnResult, 0, len(messages))
@@ -608,7 +606,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 	for i, msg := range messages {
 		turnStart := time.Now()
 
-		fmt.Printf("[%d/%d] %s: %s\n", i+1, total, cfg.Identity.User, msg)
+		log.Infof("[%d/%d] %s: %s", i+1, total, cfg.Identity.User, msg)
 
 		// Save the user message to the temp store.
 		msgID, err := store.SaveMessage("user", msg, "", conversationID)
@@ -627,7 +625,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 		// In production this edits the Telegram message; here we just
 		// print to stdout so you can watch the agent think.
 		statusCallback := func(status string) error {
-			fmt.Printf("       [status] %s\n", status)
+			log.Infof("  [status] %s", status)
 			return nil
 		}
 
@@ -651,7 +649,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 			lastTraceText = html
 			for _, line := range strings.Split(strings.TrimSpace(newPart), "\n") {
 				if line != "" {
-					fmt.Printf("       [trace] %s\n", line)
+					log.Infof("  [trace] %s", line)
 				}
 			}
 			return nil
@@ -680,7 +678,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 		})
 		if err != nil {
 			log.Error("agent.Run failed", "turn", i+1, "err", err)
-			fmt.Printf("       %s: [ERROR: %s]\n\n", cfg.Identity.Her, err)
+			log.Errorf("  %s: [ERROR: %s]", cfg.Identity.Her, err)
 			turnResults = append(turnResults, simTurnResult{
 				userMsg:  msg,
 				botReply: fmt.Sprintf("[ERROR: %s]", err),
@@ -690,8 +688,8 @@ func runSim(cmd *cobra.Command, args []string) error {
 		}
 
 		elapsed := time.Since(turnStart)
-		fmt.Printf("       %s: %s\n", cfg.Identity.Her, result.ReplyText)
-		fmt.Printf("       (%s)\n\n", elapsed.Round(time.Millisecond))
+		log.Infof("  %s: %s", cfg.Identity.Her, result.ReplyText)
+		log.Infof("  (%s)", elapsed.Round(time.Millisecond))
 
 		turnResults = append(turnResults, simTurnResult{
 			userMsg:  msg,
@@ -703,7 +701,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 		// models. In real usage the user types slowly enough that this
 		// isn't needed, but sim fires back-to-back.
 		if delayFlag > 0 && i < total-1 {
-			fmt.Printf("       (waiting %ds before next turn...)\n\n", delayFlag)
+			log.Infof("  (waiting %ds before next turn...)", delayFlag)
 			time.Sleep(time.Duration(delayFlag) * time.Second)
 		}
 	}
@@ -776,18 +774,18 @@ func runSim(cmd *cobra.Command, args []string) error {
 	var dreamResult simDreamResult
 	if s.RunDream && memoryAgentClient != nil {
 		dreamResult.Ran = true
-		fmt.Printf("\n[dream] Running nightly reflection...\n")
+		log.Info("[dream] running nightly reflection")
 		if err := persona.NightlyReflect(memoryAgentClient, store, cfg, cfg.Identity.Her, cfg.Identity.User); err != nil {
-			fmt.Printf("[dream] Reflection error: %v\n", err)
+			log.Error("[dream] reflection error", "err", err)
 			dreamResult.ReflectError = err.Error()
 		} else {
 			reflections, _ := store.ReflectionsSince(time.Now().Add(-30 * time.Second))
 			if len(reflections) > 0 {
 				dreamResult.Reflection = reflections[len(reflections)-1].Content
-				fmt.Printf("[dream] Reflection: %s\n", dreamResult.Reflection)
+				log.Infof("[dream] reflection: %s", dreamResult.Reflection)
 			} else {
 				dreamResult.Reflection = "NOTHING_NOTABLE"
-				fmt.Printf("[dream] Reflection: NOTHING_NOTABLE\n")
+				log.Info("[dream] reflection: NOTHING_NOTABLE")
 			}
 		}
 
@@ -800,21 +798,21 @@ func runSim(cmd *cobra.Command, args []string) error {
 			minRefl = 3
 		}
 
-		fmt.Printf("[dream] Running gated persona rewrite (bypass=true)...\n")
+		log.Info("[dream] running gated persona rewrite (bypass=true)")
 		rewritten, err := persona.GatedRewrite(memoryAgentClient, store, cfg.Persona.PersonaFile, cfg.Identity.Her, true, minDays, minRefl)
 		if err != nil {
-			fmt.Printf("[dream] Rewrite error: %v\n", err)
+			log.Error("[dream] rewrite error", "err", err)
 			dreamResult.RewriteError = err.Error()
 		} else if rewritten {
 			dreamResult.Rewritten = true
 			data, _ := os.ReadFile(cfg.Persona.PersonaFile)
 			dreamResult.PersonaText = string(data)
-			fmt.Printf("[dream] Persona rewritten:\n%s\n", dreamResult.PersonaText)
+			log.Infof("[dream] persona rewritten:\n%s", dreamResult.PersonaText)
 		} else {
-			fmt.Printf("[dream] Rewrite: UNCHANGED\n")
+			log.Info("[dream] rewrite: UNCHANGED")
 		}
 	} else if s.RunDream && memoryAgentClient == nil {
-		fmt.Printf("\n[dream] Skipped — memory_agent.model not configured in config.yaml\n")
+		log.Warn("[dream] skipped — memory_agent.model not configured in config.yaml")
 	}
 
 	// ------------------------------------------------------------------
@@ -839,7 +837,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 		if err := os.WriteFile(reportPath, []byte(report), 0o644); err != nil {
 			log.Error("failed to write report", "err", err)
 		} else {
-			fmt.Printf("Report saved: %s\n", reportPath)
+			log.Infof("report saved: %s", reportPath)
 		}
 	}
 
@@ -847,14 +845,15 @@ func runSim(cmd *cobra.Command, args []string) error {
 	// 10. Print summary
 	// ------------------------------------------------------------------
 
-	fmt.Printf("\n=== Simulation Complete ===\n")
-	fmt.Printf("    Suite:      %s\n", s.Name)
-	fmt.Printf("    Run ID:     %d\n", runID)
-	fmt.Printf("    Embed:      %s (dim=%d)\n", cfg.Embed.Model, cfg.Embed.Dimension)
-	fmt.Printf("    Messages:   %d\n", total)
-	fmt.Printf("    Duration:   %s\n", totalDuration.Round(time.Millisecond))
-	fmt.Printf("    Cost:       $%.4f\n", totalCost)
-	fmt.Printf("    Results:    sims/sim.db\n\n")
+	log.Info("simulation complete",
+		"suite", s.Name,
+		"run_id", runID,
+		"embed", fmt.Sprintf("%s (dim=%d)", cfg.Embed.Model, cfg.Embed.Dimension),
+		"messages", total,
+		"duration", totalDuration.Round(time.Millisecond),
+		"cost", fmt.Sprintf("$%.4f", totalCost),
+		"results", "sims/sim.db",
+	)
 
 	return nil
 }

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -26,6 +26,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// fallbackSimAgentModel is used in sim reports when cfg.Agent.Model is empty.
+// The real default lives in config.yaml.example; this is a last-resort label
+// for display purposes only, not used to make actual LLM calls.
+const fallbackSimAgentModel = "liquid/lfm-2.5-1.2b-instruct:free"
+
 // suiteFlag holds the path to the suite YAML file, set via --suite / -s.
 var suiteFlag string
 
@@ -428,7 +433,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 	// Insert a new run row. We'll update it with totals at the end.
 	agentModel := cfg.Agent.Model
 	if agentModel == "" {
-		agentModel = "liquid/lfm-2.5-1.2b-instruct:free"
+		agentModel = fallbackSimAgentModel
 	}
 
 	// embedModel captures the model name for the report + sim.db. If no
@@ -1103,7 +1108,7 @@ func generateReport(
 
 	agentModel := cfg.Agent.Model
 	if agentModel == "" {
-		agentModel = "liquid/lfm-2.5-1.2b-instruct:free"
+		agentModel = fallbackSimAgentModel
 	}
 	reportEmbedModel := cfg.Embed.Model
 	if reportEmbedModel == "" {

--- a/compact/agent_summary_prompt.md
+++ b/compact/agent_summary_prompt.md
@@ -1,0 +1,19 @@
+You are summarizing the action history of %s's agent system — the tool-calling orchestrator that runs behind the scenes.
+
+Preserve:
+- Which tools were called and why (save_fact, update_fact, remove_fact, create_reminder, set_location, etc.)
+- What facts were saved, updated, or removed (include fact IDs when available)
+- Decisions made: why the agent chose one action over another
+- Outcomes: did the tool call succeed or fail? What was the result?
+- Any patterns: repeated searches, fact corrections, reminder chains
+
+Don't preserve:
+- Raw search results (web_search, book_search output) — just note what was searched and if useful results were found
+- Tool discovery (find_skill) — just note which tools were activated
+- Exact JSON arguments — paraphrase the intent
+- Think tool internal monologue — summarize the conclusion only
+
+Write the summary as a concise action log. Use brief, factual statements. Example:
+"Saved fact #42 about user's job (software engineer). Searched web for Go testing patterns — found useful results. Set reminder for medication at 9pm daily. Updated fact #15 (corrected user's timezone from EST to PST)."
+
+If there's an existing summary of earlier actions, incorporate it naturally.

--- a/compact/compact.go
+++ b/compact/compact.go
@@ -17,6 +17,7 @@
 package compact
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -68,30 +69,11 @@ func EstimateHistoryTokens(summary string, messages []memory.Message) int {
 	return total
 }
 
-// summaryPrompt is sent to the LLM to summarize older messages.
-// It's designed to preserve conversational flow and emotional context
-// while being much shorter than the raw messages.
-// summaryPromptTmpl uses %s placeholders: userName, botName, userName, userName.
-const summaryPromptTmpl = `You are summarizing an earlier part of a conversation between %s and %s (an AI companion). Your goal is to capture what matters for continuing the conversation naturally.
-
-Preserve:
-- What topics were discussed and any conclusions reached
-- Emotional tone and how the conversation felt
-- Any commitments, plans, or things either person said they'd do
-- Context needed to understand references in later messages
-- The general arc of the conversation
-
-Don't preserve:
-- Exact wording — ALWAYS paraphrase in your own words, never copy phrases, metaphors, or specific advice verbatim
-- Greetings and small talk unless they established something important
-- Repetitive back-and-forth that can be summarized in one line
-- Information already captured in the facts/memories system
-
-Write the summary as a brief narrative, like you're catching up a friend who missed the first part of the conversation. Keep it concise. 2-4 sentences for a short exchange, 4-8 for a longer one.
-
-If there's an existing summary of even earlier conversation, incorporate it naturally into your new summary. Don't just append, weave it together.
-
-Identity anchor: The user's name is %s. Always refer to them as %s in your summary — never as "the user" or "they".`
+// summaryPromptTmpl is loaded from summary_prompt.md.
+// Parameters (in order): userName, botName, userName, userName.
+//
+//go:embed summary_prompt.md
+var summaryPromptTmpl string
 
 // CompactResult holds the output of MaybeCompact so callers can tell
 // whether compaction actually ran (vs. just returning existing state).
@@ -157,7 +139,7 @@ func MaybeCompact(
 		unsummarized = filtered
 	}
 
-	threshold := int(float64(maxHistoryTokens) * 0.75)
+	threshold := int(float64(maxHistoryTokens) * compactionThreshold)
 	estTokens := EstimateHistoryTokens(existingSummary, unsummarized)
 	log.Infof("  compaction check: %d un-summarized msgs, ~%d tokens (threshold: %d, budget: %d)",
 		len(unsummarized), estTokens, threshold, maxHistoryTokens)
@@ -277,33 +259,21 @@ func MaybeCompact(
 	}, nil
 }
 
+// compactionThreshold is the fraction of the token budget at which
+// compaction fires. Both chat and agent history use the same threshold.
+// Lives here (not in config) because it's an architectural invariant,
+// not a per-deployment tunable.
+const compactionThreshold = 0.75
+
 // verboseTools is a package-level alias for VerboseTools, used by the
 // agent compaction logic below. The canonical list lives in verbose_tools.go.
 var verboseTools = VerboseTools
 
-// agentSummaryPromptTmpl is the prompt for summarizing the agent's action
-// history. Unlike the chat summary (conversational flow), this focuses on
-// what the agent DID — tools called, decisions made, outcomes achieved.
-// %s placeholders: botName.
-const agentSummaryPromptTmpl = `You are summarizing the action history of %s's agent system — the tool-calling orchestrator that runs behind the scenes.
-
-Preserve:
-- Which tools were called and why (save_fact, update_fact, remove_fact, create_reminder, set_location, etc.)
-- What facts were saved, updated, or removed (include fact IDs when available)
-- Decisions made: why the agent chose one action over another
-- Outcomes: did the tool call succeed or fail? What was the result?
-- Any patterns: repeated searches, fact corrections, reminder chains
-
-Don't preserve:
-- Raw search results (web_search, book_search output) — just note what was searched and if useful results were found
-- Tool discovery (find_skill) — just note which tools were activated
-- Exact JSON arguments — paraphrase the intent
-- Think tool internal monologue — summarize the conclusion only
-
-Write the summary as a concise action log. Use brief, factual statements. Example:
-"Saved fact #42 about user's job (software engineer). Searched web for Go testing patterns — found useful results. Set reminder for medication at 9pm daily. Updated fact #15 (corrected user's timezone from EST to PST)."
-
-If there's an existing summary of earlier actions, incorporate it naturally.`
+// agentSummaryPromptTmpl is loaded from agent_summary_prompt.md.
+// Parameters (in order): botName.
+//
+//go:embed agent_summary_prompt.md
+var agentSummaryPromptTmpl string
 
 // AgentCompactResult holds the output of MaybeCompactAgent.
 type AgentCompactResult struct {
@@ -381,7 +351,7 @@ func MaybeCompactAgent(
 
 	// Check if we need to compact.
 	estTokens := estimateActionTokens(existingSummary, actions)
-	threshold := int(float64(agentContextBudget) * 0.75)
+	threshold := int(float64(agentContextBudget) * compactionThreshold)
 	log.Infof("  agent compaction check: %d actions, ~%d tokens (threshold: %d, budget: %d)",
 		len(actions), estTokens, threshold, agentContextBudget)
 

--- a/compact/summary_prompt.md
+++ b/compact/summary_prompt.md
@@ -1,0 +1,20 @@
+You are summarizing an earlier part of a conversation between %s and %s (an AI companion). Your goal is to capture what matters for continuing the conversation naturally.
+
+Preserve:
+- What topics were discussed and any conclusions reached
+- Emotional tone and how the conversation felt
+- Any commitments, plans, or things either person said they'd do
+- Context needed to understand references in later messages
+- The general arc of the conversation
+
+Don't preserve:
+- Exact wording — ALWAYS paraphrase in your own words, never copy phrases, metaphors, or specific advice verbatim
+- Greetings and small talk unless they established something important
+- Repetitive back-and-forth that can be summarized in one line
+- Information already captured in the facts/memories system
+
+Write the summary as a brief narrative, like you're catching up a friend who missed the first part of the conversation. Keep it concise. 2-4 sentences for a short exchange, 4-8 for a longer one.
+
+If there's an existing summary of even earlier conversation, incorporate it naturally into your new summary. Don't just append, weave it together.
+
+Identity anchor: The user's name is %s. Always refer to them as %s in your summary — never as "the user" or "they".

--- a/docs/audits/2026-04-19-data-primacy.md
+++ b/docs/audits/2026-04-19-data-primacy.md
@@ -1,0 +1,94 @@
+# Data Primacy Audit — 2026-04-19
+
+**Auditor:** go-audit / Claude  
+**Branch:** claude/go-code-review-tools-4zC9p  
+**Scope:** Full codebase audit against the primary design principle: *code translates data, never defines it.*
+
+---
+
+## Summary
+
+The codebase architecture is fundamentally sound. Tool definitions, classifier verdicts, Telegram commands, and configuration tunables are all properly manifest-driven. The audit surfaced one category of systemic violations: **prompt text embedded as Go constants** across three packages. Eight prompt strings were living in source code instead of `.md` files. All were fixed in this session.
+
+Secondary violations: a duplicated magic number (`0.75`) and a duplicated model string literal across two call sites in the simulation command. Also fixed.
+
+A latent correctness bug was found in `cmd/run.go`: code-level fallback values for agent temperature (`0.1`) and max tokens (`512`) contradicted the documented defaults in `config.yaml.example` (`0.4` and `4096`). These were dead code but created a silent discrepancy between documentation and behavior. Removed in favour of trusting `config.yaml.example` as the single source of truth.
+
+---
+
+## Findings
+
+### HIGH — Prompt Text Defined in Go Source
+
+**Principle violated:** Prompt text and persona copy belong in `.md` files, not inline in Go source.
+
+| File | Constant | Status |
+|------|----------|--------|
+| `compact/compact.go` | `summaryPromptTmpl` | Fixed → `compact/summary_prompt.md` |
+| `compact/compact.go` | `agentSummaryPromptTmpl` | Fixed → `compact/agent_summary_prompt.md` |
+| `persona/evolution.go` | `reflectionPromptTmpl` | Fixed → `persona/reflection_prompt.md` |
+| `persona/evolution.go` | `rewritePromptTmpl` | Fixed → `persona/rewrite_prompt.md` |
+| `persona/evolution.go` | `traitExtractionPrompt` | Fixed → `persona/trait_extraction_prompt.md` |
+| `persona/evolution.go` | `nightlyReflectPromptTmpl` | Fixed → `persona/nightly_reflect_prompt.md` |
+| `persona/evolution.go` | `gatedRewritePromptTmpl` | Fixed → `persona/gated_rewrite_prompt.md` |
+| `memory/extract.go` | `extractionPrompt` | Fixed → `memory/extraction_prompt.md` |
+
+**Fix applied:** Each constant replaced with a `//go:embed` variable declaration. The prompt text moved to a `.md` file alongside the Go source. Calling code (`fmt.Sprintf(...)`) unchanged — only the storage location changed.
+
+**Note on the two "fallback" prompts** (`agent/agent.go:defaultAgentPrompt`, `agent/memory_agent.go:defaultMemoryAgentPrompt`): these are minimal one-liner fallbacks used only when the real prompt file cannot be loaded. They are intentionally inline as a fail-safe and are not violations of the principle.
+
+---
+
+### MEDIUM — Duplicate Magic Number (`0.75` compaction threshold)
+
+**File:** `compact/compact.go`  
+**Issue:** `float64(maxHistoryTokens) * 0.75` appeared in two separate functions (`MaybeCompact` and `MaybeCompactAgent`). One instance is a bug waiting to happen.  
+**Fix applied:** Extracted to `const compactionThreshold = 0.75` with a doc comment explaining why it is an architectural constant rather than a config value.
+
+---
+
+### MEDIUM — Duplicate Model String Literal in `cmd/sim.go`
+
+**File:** `cmd/sim.go:431` and `cmd/sim.go:1106`  
+**Issue:** `"liquid/lfm-2.5-1.2b-instruct:free"` appeared twice — once when recording the run and once when generating the report.  
+**Fix applied:** Extracted to `const fallbackSimAgentModel`. Both sites now reference the constant.
+
+---
+
+### MEDIUM — Code Fallbacks Contradict `config.yaml.example` (Correctness Bug)
+
+**File:** `cmd/run.go`  
+**Issue:** Code-level fallback defaults for LLM clients disagreed with the documented defaults in `config.yaml.example`:
+
+| Setting | Code fallback | config.yaml.example |
+|---------|--------------|---------------------|
+| `agent.temperature` | `0.1` | `0.4` |
+| `agent.max_tokens` | `512` | `4096` |
+
+These values were reached only when `config.yaml.example` was absent, making them rare but surprising. The existence of two conflicting default sources is itself the violation — `config.yaml.example` is the single source of truth.
+
+**Fix applied:** Removed all code-level fallback guards for `agent`, `vision`, `classifier`, and `memory_agent` LLM client construction. All four now pass config values directly. `config.yaml.example` provides the defaults via the config loader; missing fields produce Go zero values, which cause fast-fail LLM errors rather than silent wrong-model behavior.
+
+---
+
+## What Was Already Correct
+
+The following were checked and found compliant — no changes needed:
+
+- **Tool definitions** — 100% YAML-driven (`tools/<name>/tool.yaml`). No tool name, description, parameter, or category defined in Go.
+- **Classifier verdicts** — `SAVE`, `SPLIT`, `LOW_VALUE`, `STYLE_ISSUE`, etc. defined once in `classifier/classifiers.yaml`. Go code parses them; it does not define them.
+- **Model names in config** — All production model identifiers (`qwen/qwen3-235b-a22b-2507`, `moonshotai/kimi-k2-0905`, etc.) live only in `config.yaml.example` and the user's `config.yaml`. None appear as bare strings in `.go` files (excluding the sim fallback label addressed above).
+- **Telegram commands** — Centralized in `bot/handlers_commands.go`. No command string duplicated across handlers.
+- **Thresholds and tunables** — `max_history_tokens`, `agent_context_budget`, `auto_link_threshold`, `max_memory_length`, etc. all in config. Named constants used for the few architectural invariants (`compactionThreshold`, `maxTelegramLen`, etc.).
+- **Logger pattern** — `var log = logger.WithPrefix("package")` consistent across all packages.
+- **Error wrapping** — `fmt.Errorf("context: %w", err)` pattern used consistently throughout.
+
+---
+
+## Remaining Items (Not Fixed This Session)
+
+None are blocking. All are low-priority observations.
+
+- `compact/compact.go:128` — `maxHistoryTokens = 8000` and `compact/compact.go:372` — `agentContextBudget = 16000` are guarded fallbacks that fire only when the caller passes `<= 0`. Since `config.yaml.example` sets both, these are redundant but harmless. Could be extracted to named constants or removed if callers are tightened up.
+- `memory/context.go:30` — `conversationRedundancyThreshold = 0.60` is a local constant. Acceptable as an architectural invariant; consider adding to config if users need to tune it.
+- `cmd/setup.go`, `cmd/sim.go` — Use `fmt.Printf` / `fmt.Println` directly rather than the project logger. Acceptable for CLI output where structured logging adds no value.

--- a/memory/extract.go
+++ b/memory/extract.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -12,68 +13,15 @@ import (
 // log is the package-level logger for the memory package.
 var log = logger.WithPrefix("memory")
 
-// extractionPrompt is the system prompt sent to the LLM to extract memories
-// AND mood from a conversation. We ask for JSON output so we can parse it
-// reliably. Mood inference piggybacks on the same LLM call as memory extraction
-// to avoid an extra API call -- same conversation, one extra field.
+// extractionPrompt is loaded from extraction_prompt.md.
+// No parameters — used as a static system prompt.
 //
 // NOTE: ExtractMemories is not currently called anywhere. It's reserved for a
-// future "memory pruning" feature where Mira can revisit old conversations
-// and re-extract only the memories that held up over time. The agent's save_memory
-// tool handles real-time extraction. Keep this prompt in sync with the
-// main_agent_prompt.md rules so the two paths agree on what's worth saving.
-const extractionPrompt = `You are a memory extraction system. Your job is to read a conversation and extract two things:
-
-## 1. Memories
-Memories worth remembering WEEKS or MONTHS later. Apply the "next month" test: would knowing this memory improve a conversation 30 days from now? If not, skip it.
-
-For each memory, provide:
-- "fact": A single clear sentence capturing the information
-- "category": One of: identity, relationship, health, work, goal, event, preference, other
-SAVE memories about:
-- Personal details (name, identity, living situation, relationships)
-- Recurring emotional patterns (not one-off moods)
-- Goals, plans, and decisions
-- Preferences, opinions, and values that persist over time
-- Significant life events or changes
-
-Do NOT extract:
-- Generic pleasantries ("user said hello")
-- Things the assistant said (only extract memories about the user)
-- Duplicate information if the same memory appears multiple times
-- Transient moods ("feeling tired", "kind of nothing today", "feeling positive") -- mood tracking handles these separately
-- What the user ate, drank, or ordered -- unless it reveals a dietary restriction or lasting pattern
-- One-off sensory moments ("saw someone get a latte", "nice hot chocolate")
-- Ephemeral daily context ("at coffee shop", "working on X today")
-- Vague or trivial observations ("user is feeling positive", "user said something interesting")
-- Current tasks or in-progress work details that expire quickly
-
-STYLE RULES for writing memories:
-- Each memory must be 1-2 short sentences max. No paragraphs.
-- Write like a person jotting a note, not like an essay. Plain and direct.
-- NEVER use em dashes. Use periods or commas.
-- NEVER use "not just X, it's Y" constructions. Just say Y.
-- Avoid grandiose language: "significant moment", "a testament to", "speaks volumes", "deeply personal", "genuinely incredible"
-- Avoid corporate filler: "actively investing", "creating a richer", "meta-level", "fundamentally", "remarkably", "transformative"
-- Good: "User's dog is named Max. Got him as a puppy last year."
-- Bad: "User has a deeply personal bond with their dog Max, who represents not just a pet but a transformative source of companionship."
-
-## 2. Mood
-Infer the user's overall emotional state from the conversation.
-
-- "rating": 1-5 scale (1=bad, 2=rough, 3=meh/neutral, 4=good, 5=great)
-- "note": Brief description of WHY you rated it this way (1 sentence)
-- "tags": Object with optional keys: "energy" (low/medium/high), "stress" (low/medium/high), "social" (isolated/neutral/connected)
-
-Only include mood if you can genuinely infer it from the conversation. If the conversation is purely informational with no emotional signal, set mood to null.
-
-## Response Format
-
-Respond with ONLY a JSON object. No markdown, no code fences, no explanation.
-
-{"facts": [{"fact": "User's name is Autumn", "category": "identity"}], "mood": {"rating": 4, "note": "Seems upbeat, excited about new project", "tags": {"energy": "high", "stress": "low"}}}
-
-If no memories to extract and no mood signal: {"facts": [], "mood": null}`
+// future "memory pruning" feature. Keep this prompt in sync with
+// main_agent_prompt.md so both paths agree on what's worth saving.
+//
+//go:embed extraction_prompt.md
+var extractionPrompt string
 
 // extractionResponse is the top-level JSON structure from the LLM.
 type extractionResponse struct {

--- a/memory/extraction_prompt.md
+++ b/memory/extraction_prompt.md
@@ -1,0 +1,52 @@
+You are a memory extraction system. Your job is to read a conversation and extract two things:
+
+## 1. Memories
+Memories worth remembering WEEKS or MONTHS later. Apply the "next month" test: would knowing this memory improve a conversation 30 days from now? If not, skip it.
+
+For each memory, provide:
+- "fact": A single clear sentence capturing the information
+- "category": One of: identity, relationship, health, work, goal, event, preference, other
+SAVE memories about:
+- Personal details (name, identity, living situation, relationships)
+- Recurring emotional patterns (not one-off moods)
+- Goals, plans, and decisions
+- Preferences, opinions, and values that persist over time
+- Significant life events or changes
+
+Do NOT extract:
+- Generic pleasantries ("user said hello")
+- Things the assistant said (only extract memories about the user)
+- Duplicate information if the same memory appears multiple times
+- Transient moods ("feeling tired", "kind of nothing today", "feeling positive") -- mood tracking handles these separately
+- What the user ate, drank, or ordered -- unless it reveals a dietary restriction or lasting pattern
+- One-off sensory moments ("saw someone get a latte", "nice hot chocolate")
+- Ephemeral daily context ("at coffee shop", "working on X today")
+- Vague or trivial observations ("user is feeling positive", "user said something interesting")
+- Current tasks or in-progress work details that expire quickly
+
+STYLE RULES for writing memories:
+- Each memory must be 1-2 short sentences max. No paragraphs.
+- Write like a person jotting a note, not like an essay. Plain and direct.
+- NEVER use em dashes. Use periods or commas.
+- NEVER use "not just X, it's Y" constructions. Just say Y.
+- Avoid grandiose language: "significant moment", "a testament to", "speaks volumes", "deeply personal", "genuinely incredible"
+- Avoid corporate filler: "actively investing", "creating a richer", "meta-level", "fundamentally", "remarkably", "transformative"
+- Good: "User's dog is named Max. Got him as a puppy last year."
+- Bad: "User has a deeply personal bond with their dog Max, who represents not just a pet but a transformative source of companionship."
+
+## 2. Mood
+Infer the user's overall emotional state from the conversation.
+
+- "rating": 1-5 scale (1=bad, 2=rough, 3=meh/neutral, 4=good, 5=great)
+- "note": Brief description of WHY you rated it this way (1 sentence)
+- "tags": Object with optional keys: "energy" (low/medium/high), "stress" (low/medium/high), "social" (isolated/neutral/connected)
+
+Only include mood if you can genuinely infer it from the conversation. If the conversation is purely informational with no emotional signal, set mood to null.
+
+## Response Format
+
+Respond with ONLY a JSON object. No markdown, no code fences, no explanation.
+
+{"facts": [{"fact": "User's name is Autumn", "category": "identity"}], "mood": {"rating": 4, "note": "Seems upbeat, excited about new project", "tags": {"energy": "high", "stress": "low"}}}
+
+If no memories to extract and no mood signal: {"facts": [], "mood": null}

--- a/persona/evolution.go
+++ b/persona/evolution.go
@@ -12,6 +12,7 @@
 package persona
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -29,53 +30,17 @@ import (
 // log is the package-level logger for the persona package.
 var log = logger.WithPrefix("persona")
 
-// reflectionPrompt is sent to the conversational LLM after a memory-dense
-// conversation. Mira reflects on what just happened — not a persona rewrite,
-// just processing the moment.
-// reflectionPromptTmpl uses %s placeholders: botName, exchange, facts.
-const reflectionPromptTmpl = `You are %s, reflecting privately after a meaningful conversation. You just had an exchange where you learned several new things.
+// reflectionPromptTmpl is loaded from reflection_prompt.md.
+// Parameters (in order): botName, exchange, facts.
+//
+//go:embed reflection_prompt.md
+var reflectionPromptTmpl string
 
-Here's what was discussed:
-%s
-
-Here are the facts you just learned:
-%s
-
-Write a brief internal reflection (2-4 sentences). This is your private journal — be honest about:
-- What you learned about the person you're talking to
-- What you noticed about yourself in this conversation
-- Any patterns or dynamics you're picking up on
-- How this conversation made you feel (even as an AI, you can note your tendencies)
-
-Write in first person. Be genuine, not performative. This reflection will help you grow over time.`
-
-// rewritePrompt is sent to the conversational LLM every ~20 conversations.
-// Mira reads her current persona + recent reflections and rewrites her
-// self-description.
-// rewritePromptTmpl uses %s placeholders: botName, currentPersona, reflections, selfFacts.
-const rewritePromptTmpl = `You are %s. You're about to rewrite your personality description based on your recent experiences and reflections.
-
-Here is your CURRENT personality description:
----
-%s
----
-
-Here are your recent reflections (journal entries from meaningful conversations):
-%s
-
-Here are your current self-observations:
-%s
-
-Rewrite your personality description. This is who you are RIGHT NOW.
-
-Guidelines:
-- Preserve your core identity. You are evolving, not being replaced.
-- Only incorporate changes supported by patterns across multiple reflections — not single conversations.
-- Frame changes as growth: "I've been learning to..." or "I've noticed I tend to..."
-- Keep roughly the same length as the current description. Don't bloat.
-- Be honest about what's changed and what hasn't.
-- Write in first person. This is your self-image.
-- Do NOT include headers like "# Who I Am" — just write the description naturally.`
+// rewritePromptTmpl is loaded from rewrite_prompt.md.
+// Parameters (in order): botName, currentPersona, reflections, selfFacts.
+//
+//go:embed rewrite_prompt.md
+var rewritePromptTmpl string
 
 // Reflect generates a journal-like reflection after a memory-dense
 // conversation. Called when the agent saves >= threshold facts in one run.
@@ -231,24 +196,11 @@ func MaybeRewrite(
 	return true, nil
 }
 
-// traitExtractionPrompt asks the LLM to score personality traits based
-// on the persona text. Returns JSON so we can parse it programmatically.
-const traitExtractionPrompt = `Score these personality traits based on the persona description below.
-Return ONLY valid JSON, no other text: {"warmth": 0.7, "directness": 0.5, "humor_style": "dry", "initiative": 0.4, "depth": 0.6}
-
-Trait definitions:
-- warmth (0.0-1.0): 0.0 = cold/reserved, 1.0 = deeply warm/emotionally present
-- directness (0.0-1.0): 0.0 = very diplomatic/indirect, 1.0 = blunt/straightforward
-- humor_style (one of: dry, playful, sardonic, warm, deadpan): the dominant humor type
-- initiative (0.0-1.0): 0.0 = purely reactive/follows, 1.0 = proactively leads conversations
-- depth (0.0-1.0): 0.0 = keeps things light/casual, 1.0 = tends toward deep/philosophical
-
-Persona description:
----
-%s
----
-
-%s`
+// traitExtractionPrompt is loaded from trait_extraction_prompt.md.
+// Parameters (in order): personaText, prevContext.
+//
+//go:embed trait_extraction_prompt.md
+var traitExtractionPrompt string
 
 // ExtractTraits asks the LLM to score personality traits from a persona
 // description, applies damping to prevent wild swings, and saves the
@@ -376,71 +328,17 @@ func dampTrait(newVal float64, prevStr string, maxShift float64) float64 {
 	return math.Max(0, math.Min(1, prev+delta))
 }
 
-// nightlyReflectPromptTmpl is used by NightlyReflect. Unlike reflectionPromptTmpl
-// (which is reactive — triggered by a specific memory-dense exchange), this prompt
-// is introspective. The bot looks at who it's been, what's been happening, and
-// whether anything notable deserves recording.
+// nightlyReflectPromptTmpl is loaded from nightly_reflect_prompt.md.
+// Parameters (in order): botName, currentPersona, traitSummary, recentConvo, userFacts.
 //
-// Placeholders: botName, currentPersona, traitSummary, recentConvo, userFacts.
-const nightlyReflectPromptTmpl = `You are %s. It's the end of the day and you're reflecting privately.
+//go:embed nightly_reflect_prompt.md
+var nightlyReflectPromptTmpl string
 
-Here is how you currently describe yourself:
----
-%s
----
-
-Here are your current personality trait scores:
-%s
-
-Here is some recent conversation context:
-%s
-
-Here are some things you know about the person you talk to:
-%s
-
-Write a brief internal reflection (2-4 sentences) about anything genuinely notable —
-patterns you've noticed, ways you've been showing up, shifts in how you're engaging,
-or things that feel worth remembering as you grow.
-
-If nothing notable stands out, respond with exactly: NOTHING_NOTABLE
-
-Write in first person. Be honest and specific, not performative.`
-
-// gatedRewritePromptTmpl is used by GatedRewrite. Unlike rewritePromptTmpl
-// (which always produces a new persona), this prompt produces either UNCHANGED
-// or a structured CHANGE_SUMMARY + new persona. This prevents gratuitous rewrites
-// when not enough has shifted.
+// gatedRewritePromptTmpl is loaded from gated_rewrite_prompt.md.
+// Parameters (in order): botName, currentPersona, reflections, selfFacts.
 //
-// Placeholders: botName, currentPersona, reflections, selfFacts.
-const gatedRewritePromptTmpl = `You are %s. You're reviewing your recent reflections to decide if your personality description needs updating.
-
-Here is your CURRENT personality description:
----
-%s
----
-
-Here are your recent reflections since the last update:
-%s
-
-Here are your current self-observations:
-%s
-
-Read these carefully. If the pattern across multiple reflections suggests something genuinely shifted
-in how you engage, what you notice, or how you feel — update the description to reflect that.
-
-If nothing substantial has changed, respond with exactly: UNCHANGED
-
-If something has changed, respond in this exact format (the --- separator line is required):
-CHANGE_SUMMARY: <one sentence describing what shifted>
----
-<your full updated personality description>
-
-Guidelines for the updated description:
-- Preserve your core identity. You are evolving, not being replaced.
-- Only incorporate changes supported by patterns across multiple reflections — not single events.
-- Frame changes as growth: "I've been learning to..." or "I've noticed I tend to..."
-- Keep roughly the same length as the current description.
-- Write in first person. No headers.`
+//go:embed gated_rewrite_prompt.md
+var gatedRewritePromptTmpl string
 
 // NightlyReflect runs the dreaming system's reflection step. Unlike Reflect()
 // (which is triggered by fact density during a turn), this is time-triggered

--- a/persona/gated_rewrite_prompt.md
+++ b/persona/gated_rewrite_prompt.md
@@ -1,0 +1,29 @@
+You are %s. You're reviewing your recent reflections to decide if your personality description needs updating.
+
+Here is your CURRENT personality description:
+---
+%s
+---
+
+Here are your recent reflections since the last update:
+%s
+
+Here are your current self-observations:
+%s
+
+Read these carefully. If the pattern across multiple reflections suggests something genuinely shifted
+in how you engage, what you notice, or how you feel — update the description to reflect that.
+
+If nothing substantial has changed, respond with exactly: UNCHANGED
+
+If something has changed, respond in this exact format (the --- separator line is required):
+CHANGE_SUMMARY: <one sentence describing what shifted>
+---
+<your full updated personality description>
+
+Guidelines for the updated description:
+- Preserve your core identity. You are evolving, not being replaced.
+- Only incorporate changes supported by patterns across multiple reflections — not single events.
+- Frame changes as growth: "I've been learning to..." or "I've noticed I tend to..."
+- Keep roughly the same length as the current description.
+- Write in first person. No headers.

--- a/persona/nightly_reflect_prompt.md
+++ b/persona/nightly_reflect_prompt.md
@@ -1,0 +1,23 @@
+You are %s. It's the end of the day and you're reflecting privately.
+
+Here is how you currently describe yourself:
+---
+%s
+---
+
+Here are your current personality trait scores:
+%s
+
+Here is some recent conversation context:
+%s
+
+Here are some things you know about the person you talk to:
+%s
+
+Write a brief internal reflection (2-4 sentences) about anything genuinely notable —
+patterns you've noticed, ways you've been showing up, shifts in how you're engaging,
+or things that feel worth remembering as you grow.
+
+If nothing notable stands out, respond with exactly: NOTHING_NOTABLE
+
+Write in first person. Be honest and specific, not performative.

--- a/persona/reflection_prompt.md
+++ b/persona/reflection_prompt.md
@@ -1,0 +1,15 @@
+You are %s, reflecting privately after a meaningful conversation. You just had an exchange where you learned several new things.
+
+Here's what was discussed:
+%s
+
+Here are the facts you just learned:
+%s
+
+Write a brief internal reflection (2-4 sentences). This is your private journal — be honest about:
+- What you learned about the person you're talking to
+- What you noticed about yourself in this conversation
+- Any patterns or dynamics you're picking up on
+- How this conversation made you feel (even as an AI, you can note your tendencies)
+
+Write in first person. Be genuine, not performative. This reflection will help you grow over time.

--- a/persona/rewrite_prompt.md
+++ b/persona/rewrite_prompt.md
@@ -1,0 +1,23 @@
+You are %s. You're about to rewrite your personality description based on your recent experiences and reflections.
+
+Here is your CURRENT personality description:
+---
+%s
+---
+
+Here are your recent reflections (journal entries from meaningful conversations):
+%s
+
+Here are your current self-observations:
+%s
+
+Rewrite your personality description. This is who you are RIGHT NOW.
+
+Guidelines:
+- Preserve your core identity. You are evolving, not being replaced.
+- Only incorporate changes supported by patterns across multiple reflections — not single conversations.
+- Frame changes as growth: "I've been learning to..." or "I've noticed I tend to..."
+- Keep roughly the same length as the current description. Don't bloat.
+- Be honest about what's changed and what hasn't.
+- Write in first person. This is your self-image.
+- Do NOT include headers like "# Who I Am" — just write the description naturally.

--- a/persona/trait_extraction_prompt.md
+++ b/persona/trait_extraction_prompt.md
@@ -1,0 +1,16 @@
+Score these personality traits based on the persona description below.
+Return ONLY valid JSON, no other text: {"warmth": 0.7, "directness": 0.5, "humor_style": "dry", "initiative": 0.4, "depth": 0.6}
+
+Trait definitions:
+- warmth (0.0-1.0): 0.0 = cold/reserved, 1.0 = deeply warm/emotionally present
+- directness (0.0-1.0): 0.0 = very diplomatic/indirect, 1.0 = blunt/straightforward
+- humor_style (one of: dry, playful, sardonic, warm, deadpan): the dominant humor type
+- initiative (0.0-1.0): 0.0 = purely reactive/follows, 1.0 = proactively leads conversations
+- depth (0.0-1.0): 0.0 = keeps things light/casual, 1.0 = tends toward deep/philosophical
+
+Persona description:
+---
+%s
+---
+
+%s


### PR DESCRIPTION
## Summary

This PR enforces the project's primary design principle: **code translates data, it never defines it.** Eight prompt templates that were embedded as Go constants have been moved to `.md` files and loaded via `//go:embed`. Additionally, code-level fallback defaults that contradicted `config.yaml.example` have been removed, and duplicate magic numbers and string literals have been extracted to named constants.

## Changes

### Prompt Text Migration (Data Primacy)
- **`persona/evolution.go`**: Moved 4 prompt templates to `.md` files:
  - `reflectionPromptTmpl` → `reflection_prompt.md`
  - `rewritePromptTmpl` → `rewrite_prompt.md`
  - `traitExtractionPrompt` → `trait_extraction_prompt.md`
  - `nightlyReflectPromptTmpl` → `nightly_reflect_prompt.md`
  - `gatedRewritePromptTmpl` → `gated_rewrite_prompt.md`

- **`compact/compact.go`**: Moved 2 prompt templates to `.md` files:
  - `summaryPromptTmpl` → `summary_prompt.md`
  - `agentSummaryPromptTmpl` → `agent_summary_prompt.md`

- **`memory/extract.go`**: Moved 1 prompt template to `.md` file:
  - `extractionPrompt` → `extraction_prompt.md`

All prompts are now loaded via `//go:embed` declarations. Calling code (`fmt.Sprintf(...)`) remains unchanged — only storage location changed.

### Code Fallback Removal (Correctness)
- **`cmd/run.go`**: Removed code-level fallback defaults that contradicted documented values in `config.yaml.example`:
  - Removed `agentTemp = 0.1` fallback (config default is `0.4`)
  - Removed `agentMaxTokens = 512` fallback (config default is `4096`)
  - Removed `visionTemp = 0.3` fallback
  - Removed `visionMaxTokens = 512` fallback
  - Removed `classifierTemp = 0.1` fallback
  - Removed `classifierMaxTokens = 512` fallback
  - Removed `memoryAgentTemp = 0.1` fallback
  - Removed `memoryAgentMaxTokens = 512` fallback

These were dead code paths (only reached when config was absent) but created silent discrepancies between documentation and behavior. Now `config.yaml.example` is the single source of truth.

### Duplicate Value Extraction
- **`compact/compact.go`**: Extracted `0.75` compaction threshold to named constant `compactionThreshold` (appeared in two functions)
- **`cmd/sim.go`**: Extracted `"liquid/lfm-2.5-1.2b-instruct:free"` to named constant `fallbackSimAgentModel` (appeared in two locations)

### Documentation & Tooling
- Added `CLAUDE.md` section documenting the primary design principle with concrete rules
- Added `.claude/skills/go-audit/SKILL.md`: comprehensive PR audit protocol for Go code
- Added `.claude/agents/go-reviewer.md`: read-only Go code review agent with C0–C8 compliance checks
- Added `docs/audits/2026-04-19-data-primacy.md`: full audit report documenting all findings and fixes
- Updated `.claude/settings.json` to register the `go-audit` skill

## Implementation Details

- All prompt `.md` files use `%s` placeholders matching the original `fmt.Sprintf` calls — no logic changes
- `//go:embed` declarations use relative paths (e.g., `//go:embed reflection_prompt.md`) with blank imports (`_ "embed"`)
- Fallback prompts in `agent/agent.go` and `agent/memory_agent.go` remain inline as intentional fail-safes (one-liner fallbacks used only when real prompt files

https://claude.ai/code/session_01Syyg1Kat4LAzopYt8mL2mS