### PR TITLE
Fix C0b compliance: logger boundary leaks + rule refinements

### DIFF
--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -54,6 +54,34 @@ This is the most important category. Everything else is secondary.
 - Magic threshold values (token counts, similarity scores, retry limits) appearing as bare literals instead of named config fields
 - Error message strings copy-pasted across multiple call sites instead of defined once
 
+### C0b: Standardized Function Boundaries
+
+> **Every capability is accessed through a project-owned function or interface.**
+
+This is the behavioral sibling of C0. Where C0 governs *values*, C0b governs *behavior*. Together: code translates data through standardized functions — it never defines data, and it never reimplements behavior.
+
+- No direct imports of underlying dependencies that an owning package wraps — if `logger` wraps `charmbracelet/log`, no other package imports `charmbracelet/log`
+- No raw `*sql.DB` usage or inline SQL outside `memory/` — all storage goes through the `Store` interface
+- No HTTP requests to OpenRouter/OpenAI outside `llm/` — all LLM calls go through `llm.Client`
+- No embedding API calls or vector math outside `embed/` — use `embed.Client.Embed()`, `embed.CosineSimilarity()`
+- No PII regex matching outside `scrub/` — use `scrub.Scrub()` and `scrub.Deanonymize()`
+- No YAML parsing or env var reading outside `config/` — use `cfg.*` fields
+- No Tavily API calls outside `search/`, no multi-modal message construction outside `vision/`, no Piper/Parakeet HTTP outside `voice/`, no Open-Meteo calls outside `weather/`
+- Tool schemas live in `tools/<name>/tool.yaml`, dispatch via `tools.Dispatch()` — no hardcoded tool definitions in Go source
+
+**The test:** *"If I needed to change how this works, how many files would I touch?"* 1 (the owning package) = PASS. >1 = FAIL.
+
+**Escape hatches are OK when:**
+- Explicitly exported by the owning package (e.g., `store.DB()`)
+- Used only by infrastructure code (CLI tools, migrations, tests), not business logic
+- Documented as an escape hatch
+
+**Specific patterns to flag:**
+- A `.go` file outside `logger/` that imports `github.com/charmbracelet/log`
+- A tool handler that constructs its own HTTP client instead of using a provided `llm.Client`
+- Business logic that calls `sql.Open()` or runs `db.Query()` instead of going through `Store`
+- Duplicate implementations of logic that already exists in an owning package (e.g., cosine similarity reimplemented outside `embed/`)
+
 ### C1: Error Handling
 - Every error is explicitly checked — no `_, err :=` without a subsequent `if err != nil`
 - Errors wrapped with `fmt.Errorf("context: %w", err)` at each layer boundary
@@ -154,6 +182,7 @@ Output exactly this structure:
 | Category | Rating | Notes |
 |----------|--------|-------|
 | C0: Data Primacy / Single Source of Truth | | |
+| C0b: Standardized Function Boundaries | | |
 | C1: Error Handling | | |
 | C2: Concurrency | | |
 | C3: Interface Design | | |
@@ -204,6 +233,7 @@ One of:
 ## Principles
 
 - **Code translates data. It never defines it.** If a value could live in a config or manifest, it must. — Autumn Grove
+- **Every capability is accessed through a project-owned function or interface.** If changing how something works requires editing more than the owning package, the boundary has leaked. — Autumn Grove
 - Read-only always. Evidence required for every WARN/FAIL.
 - N/A is honest. Don't manufacture findings.
 - "Clear is better than clever." — Rob Pike

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -65,7 +65,7 @@ This is the behavioral sibling of C0. Where C0 governs *values*, C0b governs *be
 - No HTTP requests to OpenRouter/OpenAI outside `llm/` — all LLM calls go through `llm.Client`
 - No embedding API calls or vector math outside `embed/` — use `embed.Client.Embed()`, `embed.CosineSimilarity()`
 - No PII regex matching outside `scrub/` — use `scrub.Scrub()` and `scrub.Deanonymize()`
-- No YAML parsing or env var reading outside `config/` — use `cfg.*` fields
+- No *app config* YAML parsing or env var reading outside `config/` — use `cfg.*` fields. Domain-specific manifests (`tool.yaml`, `classifiers.yaml`, `vocab.yaml`) are parsed by their owning package — this is correct, not a violation
 - No Tavily API calls outside `search/`, no multi-modal message construction outside `vision/`, no Piper/Parakeet HTTP outside `voice/`, no Open-Meteo calls outside `weather/`
 - Tool schemas live in `tools/<name>/tool.yaml`, dispatch via `tools.Dispatch()` — no hardcoded tool definitions in Go source
 

--- a/.claude/skills/go-audit/SKILL.md
+++ b/.claude/skills/go-audit/SKILL.md
@@ -69,7 +69,7 @@ Check that the diff does not violate function boundaries:
 - **LLM calls** — consumers use `llm.Client` methods (`ChatCompletion`, `ChatCompletionWithTools`, `ChatCompletionStreaming`), never build HTTP requests to OpenRouter/OpenAI directly. FAIL if any package outside `llm/` constructs API requests.
 - **Embeddings** — consumers use `embed.Client.Embed()`, `embed.CosineSimilarity()`, `embed.FindBestMatch()`. FAIL if vector math or embedding API calls are implemented outside `embed/`.
 - **PII scrubbing** — consumers use `scrub.Scrub()` and `scrub.Deanonymize()`. FAIL if regex-based PII detection is implemented outside `scrub/`.
-- **Config** — consumers read `cfg.Models.*`, `cfg.Memory.*`, etc. FAIL if any package parses YAML, reads env vars, or opens config files directly.
+- **App config** — consumers read `cfg.Models.*`, `cfg.Memory.*`, etc. FAIL if any package parses app config YAML, reads env vars, or opens `config.yaml` directly. Note: domain-specific manifests (`tool.yaml`, `classifiers.yaml`, `vocab.yaml`, `help.yaml`) are parsed by their owning package — this is correct, not a violation.
 - **Tool definitions** — tool schema lives in `tools/<name>/tool.yaml`, dispatch via `tools.Dispatch()`. FAIL if tool schemas are hardcoded in Go source.
 - **Search** — consumers use `search.TavilyClient`. FAIL if Tavily API calls exist outside `search/`.
 - **Vision** — consumers use `vision.Describe()`. FAIL if multi-modal message construction happens outside `vision/`.

--- a/.claude/skills/go-audit/SKILL.md
+++ b/.claude/skills/go-audit/SKILL.md
@@ -54,6 +54,36 @@ Check that the diff does not violate the single-source-of-truth rule in any of t
 - **PII patterns** — scrub rules and regex patterns must live in one place. If the same pattern appears in two files, one is a copy — find which is canonical.
 - **Status/label strings** — classifier verdicts, memory types, tool categories must be defined as typed constants or read from the manifest. No bare `"SAVE"` or `"RECALL"` strings scattered across the codebase.
 
+#### Standardized Function Boundaries
+
+> **Every capability is accessed through a project-owned function or interface.**
+
+This is the behavioral sibling of Data Primacy. Where Data Primacy governs *values*, this rule governs *behavior*. Together: code translates data through standardized functions — it never defines data, and it never reimplements behavior.
+
+**The test:** *"If I needed to change how this works, how many files would I touch?"* 1 (the owning package) = compliant. >1 = the capability has leaked.
+
+Check that the diff does not violate function boundaries:
+
+- **Logging** — consumers use `logger.WithPrefix("pkg")`, never import `charmbracelet/log` directly. No `fmt.Println` or stdlib `log.Print`. FAIL if any `.go` file outside `logger/` imports the underlying log library.
+- **Storage** — consumers use the `memory.Store` interface, never `*sql.DB` or raw SQL. Exception: explicitly exported escape hatches (e.g., `store.DB()`) used only by infrastructure code (CLI tools, migrations, tests). FAIL if business logic bypasses the Store interface.
+- **LLM calls** — consumers use `llm.Client` methods (`ChatCompletion`, `ChatCompletionWithTools`, `ChatCompletionStreaming`), never build HTTP requests to OpenRouter/OpenAI directly. FAIL if any package outside `llm/` constructs API requests.
+- **Embeddings** — consumers use `embed.Client.Embed()`, `embed.CosineSimilarity()`, `embed.FindBestMatch()`. FAIL if vector math or embedding API calls are implemented outside `embed/`.
+- **PII scrubbing** — consumers use `scrub.Scrub()` and `scrub.Deanonymize()`. FAIL if regex-based PII detection is implemented outside `scrub/`.
+- **Config** — consumers read `cfg.Models.*`, `cfg.Memory.*`, etc. FAIL if any package parses YAML, reads env vars, or opens config files directly.
+- **Tool definitions** — tool schema lives in `tools/<name>/tool.yaml`, dispatch via `tools.Dispatch()`. FAIL if tool schemas are hardcoded in Go source.
+- **Search** — consumers use `search.TavilyClient`. FAIL if Tavily API calls exist outside `search/`.
+- **Vision** — consumers use `vision.Describe()`. FAIL if multi-modal message construction happens outside `vision/`.
+- **Voice** — consumers use `voice.TTSClient` / `voice.Client`. FAIL if Piper/Parakeet HTTP calls exist outside `voice/`.
+- **Weather** — consumers use `weather.Fetch()`. FAIL if Open-Meteo API calls exist outside `weather/`.
+
+**Gold standard check:** Could the changed code be wrapped in a decorator without touching callers? If a new capability doesn't follow the Store interface pattern (consumers depend on interface, not implementation), flag it as a WARN.
+
+**Escape hatch check:** If code reaches past an owning package's API:
+- Is the escape hatch explicitly exported by the owning package? (OK if yes)
+- Is it used by infrastructure code only, not business logic? (OK if yes)
+- Is it documented? (WARN if no)
+- If none of the above: FAIL.
+
 #### Tool Registration Pattern
 New tools must follow the established registration pattern:
 - Handler lives in `tools/<name>/handler.go`
@@ -169,6 +199,12 @@ Packages changed: [list]
 | **Data primacy — no inline prompt/copy in .go files** | | |
 | **Data primacy — thresholds/tuning in config** | | |
 | **Data primacy — command strings defined once** | | |
+| **Function boundaries — logging via `logger` only** | | |
+| **Function boundaries — storage via `Store` interface** | | |
+| **Function boundaries — LLM via `llm.Client` only** | | |
+| **Function boundaries — embeddings via `embed` only** | | |
+| **Function boundaries — no leaked dependencies** | | |
+| **Function boundaries — escape hatches documented** | | |
 | Tool registration pattern | | |
 | Context bundle usage | | |
 | PII scrubbing at boundaries | | |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,13 @@ go run main.go run
 - Runs automatically via `memory.NewStore()`
 - Use `IF NOT EXISTS` for safety
 
-## Primary Design Principle
+## Primary Design Principles
+
+### Data Primacy
 
 > **Code translates data. It never defines it.**
 
-If a value could live in a config file, YAML manifest, or named constant — it must. No hardcoded strings scattered across logic. No parallel data structures that duplicate what a manifest already defines. One source of truth, read everywhere. This is the most important rule in this codebase. When in doubt, ask: "should this be in config?"
+If a value could live in a config file, YAML manifest, or named constant — it must. No hardcoded strings scattered across logic. No parallel data structures that duplicate what a manifest already defines. One source of truth, read everywhere. When in doubt, ask: "should this be in config?"
 
 Concrete rules:
 - Model names only in `config.yaml`, read via `cfg.Models.*` — never a bare model string in `.go`
@@ -66,6 +68,44 @@ Concrete rules:
 - Thresholds, token budgets, similarity cutoffs in config, not as magic literals
 - Telegram command strings defined once as constants, not re-typed in multiple handlers
 - If the same string appears twice, one instance is a bug
+
+### Standardized Function Boundaries
+
+> **Every capability is accessed through a project-owned function or interface.**
+
+This is the behavioral sibling of Data Primacy. Where Data Primacy says *values live in config, not code*, this rule says *behavior lives in owning packages, not consumers*. Together: **code translates data through standardized functions. It never defines data, and it never reimplements behavior.**
+
+**The rule:**
+1. **One package owns each capability** — it exports the functions, methods, or interfaces that define the API surface
+2. **Consumers use the exported API only** — they never construct internals, import underlying dependencies, or reimplement logic that the owning package already provides
+3. **The implementation is swappable** — change the internals, every consumer benefits. If changing how something works requires editing more than the owning package, the boundary has leaked
+
+**The test:**
+> *"If I needed to change how this works, how many files would I touch?"*
+> **1 (the owning package) = compliant. >1 = the capability has leaked.**
+
+**Capability ownership map:**
+
+| Capability | Owner | Consumers call | They do NOT |
+|---|---|---|---|
+| Logging | `logger` | `logger.WithPrefix("pkg")` | Import `charmbracelet/log` |
+| Storage | `memory` | `Store` interface methods | Open `sql.DB` or write raw SQL |
+| LLM calls | `llm` | `client.ChatCompletion(...)` | Build HTTP requests to OpenRouter |
+| Embeddings | `embed` | `embed.Client.Embed(text)` | Call embedding APIs directly |
+| PII scrubbing | `scrub` | `scrub.Scrub(text)` | Run regex matching inline |
+| Config | `config` | `cfg.Models.Agent` | Parse YAML or read env vars |
+| Tool definitions | `tools/<name>/tool.yaml` + handler | Registry dispatch via `tools.Dispatch()` | Hardcode tool schemas in Go |
+| Search | `search` | `search.TavilyClient.Search(...)` | Call Tavily API directly |
+| Vision | `vision` | `vision.Describe(client, ...)` | Construct multi-modal messages |
+| Voice | `voice` | `voice.TTSClient` / `voice.Client` | Call Piper/Parakeet HTTP directly |
+| Weather | `weather` | `weather.Fetch(lat, lon, ...)` | Call Open-Meteo API directly |
+
+**Gold standard — the `Store` interface:** Consumers depend on the interface, not `SQLiteStore`. This is what made the D1 sync decorator (`SyncedStore`) possible with zero changes to callers. When designing a new capability boundary, ask: *"Could I wrap this in a decorator without touching callers?"* If yes, the boundary is clean.
+
+**Acceptable escape hatches:** Some consumers need lower-level access (e.g., `cmd/sim.go` uses `store.DB()` for raw SQL). This is fine when:
+- The escape hatch is explicitly exported by the owning package (not an end-run around it)
+- It's used by infrastructure code (CLI tools, migrations, tests), not business logic
+- It's documented as an escape hatch, not a normal usage pattern
 
 ## Key Design Decisions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,12 +93,14 @@ This is the behavioral sibling of Data Primacy. Where Data Primacy says *values 
 | LLM calls | `llm` | `client.ChatCompletion(...)` | Build HTTP requests to OpenRouter |
 | Embeddings | `embed` | `embed.Client.Embed(text)` | Call embedding APIs directly |
 | PII scrubbing | `scrub` | `scrub.Scrub(text)` | Run regex matching inline |
-| Config | `config` | `cfg.Models.Agent` | Parse YAML or read env vars |
+| App config | `config` | `cfg.Models.Agent` | Parse YAML or read env vars for app settings |
 | Tool definitions | `tools/<name>/tool.yaml` + handler | Registry dispatch via `tools.Dispatch()` | Hardcode tool schemas in Go |
 | Search | `search` | `search.TavilyClient.Search(...)` | Call Tavily API directly |
 | Vision | `vision` | `vision.Describe(client, ...)` | Construct multi-modal messages |
 | Voice | `voice` | `voice.TTSClient` / `voice.Client` | Call Piper/Parakeet HTTP directly |
 | Weather | `weather` | `weather.Fetch(lat, lon, ...)` | Call Open-Meteo API directly |
+
+**Config vs. domain manifests:** The `config` package owns *app configuration* (`config.yaml` — API keys, model names, thresholds, feature flags). Domain-specific manifests (`tool.yaml`, `classifiers.yaml`, `vocab.yaml`, `help.yaml`) are parsed by their owning package — `tools/` parses tool manifests, `classifier/` parses classifier definitions, etc. This is correct: the owning package knows the schema and is the single consumer. The rule is: only `config/` parses *app config*; domain manifests are parsed by their owning package.
 
 **Gold standard — the `Store` interface:** Consumers depend on the interface, not `SQLiteStore`. This is what made the D1 sync decorator (`SyncedStore`) possible with zero changes to callers. When designing a new capability boundary, ask: *"Could I wrap this in a decorator without touching callers?"* If yes, the boundary is clean.
 

--- a/calendar/bridge.go
+++ b/calendar/bridge.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	"her/config"
-	"github.com/charmbracelet/log"
+	"her/logger"
 )
+
+var log = logger.WithPrefix("calendar")
 
 // Bridge is the interface for calendar operations. The production implementation
 // (CLIBridge) shells out to the Swift EventKit binary. The test/sim implementation
@@ -31,20 +33,19 @@ type Bridge interface {
 type CLIBridge struct {
 	binaryPath string
 	cfg        *config.Config
-	logger     *log.Logger
 }
 
 // NewCLIBridge creates a CLIBridge instance. Checks if the binary exists and is
 // executable, but doesn't fail if it's missing (fail-soft pattern — tools
 // will return clear errors later).
-func NewCLIBridge(cfg *config.Config, logger *log.Logger) *CLIBridge {
+func NewCLIBridge(cfg *config.Config) *CLIBridge {
 	// Resolve relative paths from project root
 	binaryPath := cfg.Calendar.BridgePath
 	if !filepath.IsAbs(binaryPath) {
 		// Assume relative to the working directory (project root)
 		absPath, err := filepath.Abs(binaryPath)
 		if err != nil {
-			logger.Warn("Failed to resolve bridge path", "path", binaryPath, "error", err)
+			log.Warn("Failed to resolve bridge path", "path", binaryPath, "error", err)
 		} else {
 			binaryPath = absPath
 		}
@@ -52,7 +53,7 @@ func NewCLIBridge(cfg *config.Config, logger *log.Logger) *CLIBridge {
 
 	// Check if binary exists
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-		logger.Warn("Calendar bridge not found — calendar tools will return errors if called",
+		log.Warn("Calendar bridge not found — calendar tools will return errors if called",
 			"path", binaryPath,
 			"hint", "Build it with: cd calendar/bridge && swift build -c release")
 	}
@@ -60,7 +61,6 @@ func NewCLIBridge(cfg *config.Config, logger *log.Logger) *CLIBridge {
 	return &CLIBridge{
 		binaryPath: binaryPath,
 		cfg:        cfg,
-		logger:     logger,
 	}
 }
 
@@ -101,7 +101,7 @@ func (b *CLIBridge) Call(ctx context.Context, req Request) (Response, error) {
 		// Sleep before retry (not on first attempt)
 		if attempt > 1 {
 			backoff := backoffDurations[attempt-1]
-			b.logger.Debug("Retrying bridge call", "attempt", attempt, "backoff", backoff)
+			log.Debug("Retrying bridge call", "attempt", attempt, "backoff", backoff)
 			time.Sleep(backoff)
 		}
 
@@ -173,7 +173,7 @@ func (b *CLIBridge) callOnce(ctx context.Context, req Request) (Response, int, e
 
 	// Log stderr if present (even on success, for debugging)
 	if stderr.Len() > 0 {
-		b.logger.Debug("Bridge stderr output", "stderr", stderr.String())
+		log.Debug("Bridge stderr output", "stderr", stderr.String())
 	}
 
 	return resp, exitCode, nil

--- a/calendar/bridge_test.go
+++ b/calendar/bridge_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"her/config"
-	"github.com/charmbracelet/log"
 )
 
 // TestBridgeMissingBinary verifies that calling the bridge with a missing
@@ -19,10 +18,7 @@ func TestBridgeMissingBinary(t *testing.T) {
 		},
 	}
 
-	logger := log.New(nil)
-	logger.SetLevel(log.FatalLevel) // Silence logs during test
-
-	bridge := NewCLIBridge(cfg, logger)
+	bridge := NewCLIBridge(cfg)
 
 	req := Request{
 		Command:  "list",

--- a/memory/store_core_test.go
+++ b/memory/store_core_test.go
@@ -176,9 +176,10 @@ func TestPIIVault_RoundTrip(t *testing.T) {
 		t.Fatalf("SavePIIVaultEntry: %v", err)
 	}
 
-	// Verify by direct query (no getter method exists, so we query raw)
+	// Verify by direct query (no getter method exists, so we query raw).
+	// Uses the DB() escape hatch rather than accessing the private db field.
 	var token, original, entityType string
-	err = store.db.QueryRow(
+	err = store.DB().QueryRow(
 		`SELECT token, original_value, entity_type FROM pii_vault WHERE message_id = ?`, msgID,
 	).Scan(&token, &original, &entityType)
 	if err != nil {
@@ -227,7 +228,7 @@ func TestSaveMetric_WithMessageID(t *testing.T) {
 
 	// Verify metric is linked to the message
 	var linkedMsgID int64
-	store.db.QueryRow(`SELECT message_id FROM metrics WHERE model = 'model-x'`).Scan(&linkedMsgID)
+	store.DB().QueryRow(`SELECT message_id FROM metrics WHERE model = 'model-x'`).Scan(&linkedMsgID)
 	if linkedMsgID != msgID {
 		t.Errorf("message_id = %d, want %d", linkedMsgID, msgID)
 	}
@@ -403,10 +404,10 @@ func TestSaveSearch(t *testing.T) {
 		t.Fatalf("SaveSearch: %v", err)
 	}
 
-	// Verify via raw query
+	// Verify via raw query using the DB() escape hatch
 	var query, searchType string
 	var resultCount int
-	store.db.QueryRow(`SELECT search_type, query, result_count FROM searches LIMIT 1`).
+	store.DB().QueryRow(`SELECT search_type, query, result_count FROM searches LIMIT 1`).
 		Scan(&searchType, &query, &resultCount)
 	if searchType != "web" {
 		t.Errorf("search_type = %q, want %q", searchType, "web")
@@ -428,7 +429,7 @@ func TestSaveClassifierLog(t *testing.T) {
 	}
 
 	var verdict, content string
-	store.db.QueryRow(`SELECT verdict, content FROM classifier_log LIMIT 1`).Scan(&verdict, &content)
+	store.DB().QueryRow(`SELECT verdict, content FROM classifier_log LIMIT 1`).Scan(&verdict, &content)
 	if verdict != "LOW_VALUE" {
 		t.Errorf("verdict = %q, want %q", verdict, "LOW_VALUE")
 	}

--- a/tools/calendar_create/handler.go
+++ b/tools/calendar_create/handler.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"her/calendar"
+	"her/logger"
 	"her/tools"
-
-	"github.com/charmbracelet/log"
 )
+
+var log = logger.WithPrefix("calendar_create")
 
 func init() {
 	tools.Register("calendar_create", Handle)
@@ -124,10 +125,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		},
 	}
 
-	logger := log.Default()
 	bridge := ctx.CalendarBridge
 	if bridge == nil {
-		bridge = calendar.NewCLIBridge(ctx.Cfg, logger)
+		bridge = calendar.NewCLIBridge(ctx.Cfg)
 	}
 
 	callCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tools/calendar_delete/handler.go
+++ b/tools/calendar_delete/handler.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"her/calendar"
+	"her/logger"
 	"her/tools"
-
-	"github.com/charmbracelet/log"
 )
+
+var log = logger.WithPrefix("calendar_delete")
 
 func init() {
 	tools.Register("calendar_delete", Handle)
@@ -56,10 +57,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		},
 	}
 
-	logger := log.Default()
 	bridge := ctx.CalendarBridge
 	if bridge == nil {
-		bridge = calendar.NewCLIBridge(ctx.Cfg, logger)
+		bridge = calendar.NewCLIBridge(ctx.Cfg)
 	}
 
 	callCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/tools/calendar_update/handler.go
+++ b/tools/calendar_update/handler.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"her/calendar"
+	"her/logger"
 	"her/tools"
-
-	"github.com/charmbracelet/log"
 )
+
+var log = logger.WithPrefix("calendar_update")
 
 func init() {
 	tools.Register("calendar_update", Handle)
@@ -132,10 +133,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 			},
 		}
 
-		logger := log.Default()
 		bridge := ctx.CalendarBridge
 		if bridge == nil {
-			bridge = calendar.NewCLIBridge(ctx.Cfg, logger)
+			bridge = calendar.NewCLIBridge(ctx.Cfg)
 		}
 
 		callCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/tools/list_calendars/handler.go
+++ b/tools/list_calendars/handler.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"her/calendar"
+	"her/logger"
 	"her/tools"
-
-	"github.com/charmbracelet/log"
 )
+
+var log = logger.WithPrefix("list_calendars")
 
 func init() {
 	tools.Register("list_calendars", Handle)
@@ -27,10 +28,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	}
 
 	// Get bridge (injected in sim mode, CLIBridge in production)
-	logger := log.Default()
 	bridge := ctx.CalendarBridge
 	if bridge == nil {
-		bridge = calendar.NewCLIBridge(ctx.Cfg, logger)
+		bridge = calendar.NewCLIBridge(ctx.Cfg)
 	}
 
 	// Call with timeout


### PR DESCRIPTION
## Summary

- **Logger boundary**: `calendar/bridge.go` accepted `*charmbracelet/log.Logger` as a constructor param, forcing all 4 calendar tool handlers to import the underlying dependency directly. Replaced with package-level `logger.WithPrefix("calendar")` — the same pattern every other package uses. All 4 handlers now use `logger.WithPrefix()` instead of `charmbracelet/log`.
- **Store boundary**: `memory/store_core_test.go` accessed private `store.db` field in 4 places. Switched to the `store.DB()` escape hatch.
- **Rule refinement**: Clarified the config boundary — domain manifests (`tool.yaml`, `classifiers.yaml`, `vocab.yaml`) are correctly parsed by their owning package. Only *app config* (`config.yaml`) goes through `config/`.

## Context

Establishes the "Standardized Function Boundaries" design principle (C0b) as a sibling to Data Primacy (C0). Full codebase audit found 7 boundary violations across 11 capability owners — this PR fixes all of them.

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./memory/ -run "TestPIIVault_RoundTrip|TestSaveMetric_WithMessageID|TestSaveSearch|TestSaveClassifierLog"` — all pass
- [x] `go test ./calendar/` — all 8 tests pass