### PR TITLE
fix: non-destructive mood dedup — supersede instead of overwrite

### DIFF
--- a/bot/helpers_test.go
+++ b/bot/helpers_test.go
@@ -143,7 +143,8 @@ func (s stubStore) MoodEntriesInRange(kind memory.MoodKind, from, to time.Time) 
 func (s stubStore) SimilarMoodEntriesWithin(now time.Time, embedding []float32, window time.Duration, limit int) ([]memory.MoodEntry, error) {
 	return nil, nil
 }
-func (s stubStore) DeleteMoodEntry(id int64) error { return nil }
+func (s stubStore) DeleteMoodEntry(id int64) error                              { return nil }
+func (s stubStore) SupersedeMoodEntry(oldID, newID int64, reason string) error  { return nil }
 func (s stubStore) SavePendingMoodProposal(p *memory.PendingMoodProposal) (int64, error) {
 	return 0, nil
 }

--- a/bot/mood.go
+++ b/bot/mood.go
@@ -71,6 +71,8 @@ func (b *Bot) initMood() error {
 	// mood_agent_prompt.md lives alongside prompt.md in the project root.
 	promptDir := filepath.Dir(b.cfg.Persona.PromptFile)
 
+	updateWin := time.Duration(b.cfg.Mood.UpdateWindowMinutes) * time.Minute
+
 	b.moodRunner = &mood.Runner{
 		Deps: mood.Deps{
 			LLM:        b.moodAgentLLM,
@@ -87,6 +89,7 @@ func (b *Bot) initMood() error {
 			ConfidenceLow:   low,
 			DedupWindow:     dedupWin,
 			DedupSimilarity: dedupSim,
+			UpdateWindow:    updateWin,
 			ProposalExpiry:  proposalExpiry,
 			SessionGap:      time.Duration(b.cfg.Mood.SessionGapMinutes) * time.Minute,
 		},

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -823,6 +823,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 		if dedupSim == 0 {
 			dedupSim = 0.80
 		}
+		updateWin := time.Duration(cfg.Mood.UpdateWindowMinutes) * time.Minute
 		ctxTurns := cfg.Mood.ContextTurns
 		if ctxTurns == 0 {
 			ctxTurns = 5
@@ -856,6 +857,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 				ConfidenceLow:   low,
 				DedupWindow:     dedupWin,
 				DedupSimilarity: dedupSim,
+				UpdateWindow:    updateWin,
 			},
 		}
 		log.Info("mood agent enabled for sim (pure-inferring mode)",

--- a/config/config.go
+++ b/config/config.go
@@ -405,6 +405,10 @@ type MoodConfig struct {
 	// mood again". Default 0.80.
 	DedupSimilarity float64 `yaml:"dedup_similarity"`
 
+	// UpdateWindowMinutes is the lookback for the supersede path.
+	// Shorter than dedup window. Default 60.
+	UpdateWindowMinutes int `yaml:"update_window_minutes"`
+
 	// ProposalExpiryMinutes is how long a Telegram proposal stays
 	// tappable. Default 30.
 	ProposalExpiryMinutes int `yaml:"proposal_expiry_minutes"`

--- a/d1/schema.sql
+++ b/d1/schema.sql
@@ -165,12 +165,15 @@ CREATE TABLE IF NOT EXISTS mood_entries (
     source          TEXT NOT NULL,
     confidence      REAL NOT NULL DEFAULT 0,
     conversation_id TEXT,
-    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
-    updated_at      DATETIME
+    created_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME,
+    superseded_by    INTEGER REFERENCES mood_entries(id),
+    supersede_reason TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_mood_entries_ts ON mood_entries(ts);
 CREATE INDEX IF NOT EXISTS idx_mood_entries_kind_ts ON mood_entries(kind, ts);
+CREATE INDEX IF NOT EXISTS idx_mood_entries_superseded ON mood_entries(superseded_by);
 
 -- ---------------------------------------------------------------------------
 -- Sync Metadata

--- a/memory/store.go
+++ b/memory/store.go
@@ -126,6 +126,7 @@ type Store interface {
 	MoodEntriesInRange(kind MoodKind, from, to time.Time) ([]MoodEntry, error)
 	SimilarMoodEntriesWithin(now time.Time, embedding []float32, window time.Duration, limit int) ([]MoodEntry, error)
 	DeleteMoodEntry(id int64) error
+	SupersedeMoodEntry(oldID, newID int64, reason string) error
 	SavePendingMoodProposal(p *PendingMoodProposal) (int64, error)
 	PendingMoodProposalByMessageID(chatID, msgID int64) (*PendingMoodProposal, error)
 	DuePendingMoodProposals(now time.Time) ([]PendingMoodProposal, error)

--- a/memory/store_mood.go
+++ b/memory/store_mood.go
@@ -64,6 +64,13 @@ type MoodEntry struct {
 	Distance float64
 
 	CreatedAt time.Time
+
+	// SupersededBy is the ID of the newer entry that replaced this one.
+	// Zero means this entry is still current (not superseded).
+	SupersededBy int64
+	// SupersedeReason explains why this entry was replaced (e.g.
+	// "mood evolved (sim=0.72, valence 2→5)").
+	SupersedeReason string
 }
 
 // SaveMoodEntry inserts a new mood row and mirrors its embedding into
@@ -232,7 +239,8 @@ func (s *SQLiteStore) UpdateMoodEntry(id int64, entry *MoodEntry) error {
 // kind, or nil when none exist. Empty kind means any.
 func (s *SQLiteStore) LatestMoodEntry(kind MoodKind) (*MoodEntry, error) {
 	q := `SELECT id, ts, kind, valence, labels, associations, note, source,
-	             confidence, conversation_id, embedding, created_at
+	             confidence, conversation_id, embedding, created_at,
+	             superseded_by, supersede_reason
 	      FROM mood_entries`
 	args := []any{}
 	if kind != "" {
@@ -264,7 +272,8 @@ func (s *SQLiteStore) RecentMoodEntries(kind MoodKind, limit int) ([]MoodEntry, 
 		limit = 10
 	}
 	q := `SELECT id, ts, kind, valence, labels, associations, note, source,
-	             confidence, conversation_id, embedding, created_at
+	             confidence, conversation_id, embedding, created_at,
+	             superseded_by, supersede_reason
 	      FROM mood_entries`
 	args := []any{}
 	if kind != "" {
@@ -287,9 +296,10 @@ func (s *SQLiteStore) RecentMoodEntries(kind MoodKind, limit int) ([]MoodEntry, 
 // oldest-first, which is what charts want.
 func (s *SQLiteStore) MoodEntriesInRange(kind MoodKind, from, to time.Time) ([]MoodEntry, error) {
 	q := `SELECT id, ts, kind, valence, labels, associations, note, source,
-	             confidence, conversation_id, embedding, created_at
+	             confidence, conversation_id, embedding, created_at,
+	             superseded_by, supersede_reason
 	      FROM mood_entries
-	      WHERE ts >= ? AND ts <= ?`
+	      WHERE ts >= ? AND ts <= ? AND superseded_by IS NULL`
 	args := []any{from.UTC(), to.UTC()}
 	if kind != "" {
 		q += ` AND kind = ?`
@@ -340,12 +350,14 @@ func (s *SQLiteStore) SimilarMoodEntriesWithin(now time.Time, embedding []float3
 	rows, err := s.db.Query(`
 		SELECT m.id, m.ts, m.kind, m.valence, m.labels, m.associations, m.note,
 		       m.source, m.confidence, m.conversation_id, m.embedding, m.created_at,
+		       m.superseded_by, m.supersede_reason,
 		       v.distance
 		FROM vec_moods v
 		JOIN mood_entries m ON m.id = v.rowid
 		WHERE v.embedding MATCH ?
 		  AND k = ?
 		  AND m.ts >= ?
+		  AND m.superseded_by IS NULL
 		ORDER BY v.distance ASC`,
 		queryBytes, limit*4, cutoff,
 	)
@@ -364,11 +376,14 @@ func (s *SQLiteStore) SimilarMoodEntriesWithin(now time.Time, embedding []float3
 			sourceStr    string
 			convNullable sql.NullString
 			embData      []byte
+			supBy        sql.NullInt64
+			supReason    sql.NullString
 			distance     float64
 		)
 		if err := rows.Scan(
 			&e.ID, &e.Timestamp, &kindStr, &e.Valence, &labelsJSON, &assocJSON,
 			&e.Note, &sourceStr, &e.Confidence, &convNullable, &embData, &e.CreatedAt,
+			&supBy, &supReason,
 			&distance,
 		); err != nil {
 			return nil, fmt.Errorf("SimilarMoodEntriesWithin: scan: %w", err)
@@ -377,6 +392,12 @@ func (s *SQLiteStore) SimilarMoodEntriesWithin(now time.Time, embedding []float3
 		e.Source = MoodSource(sourceStr)
 		if convNullable.Valid {
 			e.ConversationID = convNullable.String
+		}
+		if supBy.Valid {
+			e.SupersededBy = supBy.Int64
+		}
+		if supReason.Valid {
+			e.SupersedeReason = supReason.String
 		}
 		e.Labels = unmarshalStringArray(labelsJSON)
 		e.Associations = unmarshalStringArray(assocJSON)
@@ -400,6 +421,25 @@ func (s *SQLiteStore) DeleteMoodEntry(id int64) error {
 	// vec_moods delete is best-effort — if the table doesn't exist,
 	// ignore the error (same pattern as vec_memories inserts).
 	_, _ = s.db.Exec(`DELETE FROM vec_moods WHERE rowid = ?`, id)
+	return nil
+}
+
+// SupersedeMoodEntry marks an old mood entry as replaced by a newer one.
+// The old entry stays in the DB (visible in timeline views) but is
+// excluded from the daily rollup and KNN dedup queries. Its vec_moods
+// row is deleted so future similarity searches won't match it.
+// Same pattern as SupersedeMemory in store_facts.go.
+func (s *SQLiteStore) SupersedeMoodEntry(oldID, newID int64, reason string) error {
+	_, err := s.db.Exec(
+		`UPDATE mood_entries SET superseded_by = ?, supersede_reason = ? WHERE id = ?`,
+		newID, reason, oldID,
+	)
+	if err != nil {
+		return fmt.Errorf("superseding mood %d → %d: %w", oldID, newID, err)
+	}
+	if s.EmbedDimension > 0 {
+		s.db.Exec(`DELETE FROM vec_moods WHERE rowid = ?`, oldID)
+	}
 	return nil
 }
 
@@ -586,8 +626,9 @@ func unmarshalStringArray(s string) []string {
 
 // scanMoodEntries reads rows from a SELECT that matches the order
 // (id, ts, kind, valence, labels, associations, note, source,
-// confidence, conversation_id, embedding, created_at). Distance is
-// not populated — use SimilarMoodEntriesWithin for that.
+// confidence, conversation_id, embedding, created_at, superseded_by,
+// supersede_reason). Distance is not populated — use
+// SimilarMoodEntriesWithin for that.
 func scanMoodEntries(rows *sql.Rows) ([]MoodEntry, error) {
 	var out []MoodEntry
 	for rows.Next() {
@@ -599,10 +640,13 @@ func scanMoodEntries(rows *sql.Rows) ([]MoodEntry, error) {
 			sourceStr    string
 			convNullable sql.NullString
 			embData      []byte
+			supBy        sql.NullInt64
+			supReason    sql.NullString
 		)
 		if err := rows.Scan(
 			&e.ID, &e.Timestamp, &kindStr, &e.Valence, &labelsJSON, &assocJSON,
 			&e.Note, &sourceStr, &e.Confidence, &convNullable, &embData, &e.CreatedAt,
+			&supBy, &supReason,
 		); err != nil {
 			return nil, fmt.Errorf("scanMoodEntries: %w", err)
 		}
@@ -610,6 +654,12 @@ func scanMoodEntries(rows *sql.Rows) ([]MoodEntry, error) {
 		e.Source = MoodSource(sourceStr)
 		if convNullable.Valid {
 			e.ConversationID = convNullable.String
+		}
+		if supBy.Valid {
+			e.SupersededBy = supBy.Int64
+		}
+		if supReason.Valid {
+			e.SupersedeReason = supReason.String
 		}
 		e.Labels = unmarshalStringArray(labelsJSON)
 		e.Associations = unmarshalStringArray(assocJSON)

--- a/memory/store_mood_test.go
+++ b/memory/store_mood_test.go
@@ -302,6 +302,104 @@ func TestDeleteMoodEntry(t *testing.T) {
 	}
 }
 
+func TestSupersedeMoodEntry(t *testing.T) {
+	store := newMoodTestStore(t)
+
+	oldID, err := store.SaveMoodEntry(&MoodEntry{Valence: 3, Note: "frustrated about work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newID, err := store.SaveMoodEntry(&MoodEntry{Valence: 5, Note: "hopeful about switching jobs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SupersedeMoodEntry(oldID, newID, "mood evolved"); err != nil {
+		t.Fatalf("SupersedeMoodEntry: %v", err)
+	}
+
+	// The old entry should have superseded_by set.
+	got, err := store.LatestMoodEntry("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// LatestMoodEntry doesn't filter superseded, so the newest entry
+	// (newID) comes back. Query the old entry directly.
+	var supBy, supReason *string
+	err = store.db.QueryRow(
+		`SELECT superseded_by, supersede_reason FROM mood_entries WHERE id = ?`, oldID,
+	).Scan(&supBy, &supReason)
+	if err != nil {
+		t.Fatalf("query old entry: %v", err)
+	}
+	if supBy == nil {
+		t.Fatal("superseded_by is NULL, want non-NULL")
+	}
+	if supReason == nil || *supReason != "mood evolved" {
+		t.Errorf("supersede_reason = %v, want 'mood evolved'", supReason)
+	}
+	_ = got
+}
+
+func TestMoodEntriesInRange_ExcludesSuperseded(t *testing.T) {
+	store := newMoodTestStore(t)
+
+	base := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	oldID, err := store.SaveMoodEntry(&MoodEntry{
+		Valence: 3, Note: "old mood", Timestamp: base,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newID, err := store.SaveMoodEntry(&MoodEntry{
+		Valence: 5, Note: "new mood", Timestamp: base.Add(30 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.SupersedeMoodEntry(oldID, newID, "evolved"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Range query covering both entries — only the non-superseded one should appear.
+	got, err := store.MoodEntriesInRange("", base.Add(-1*time.Hour), base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (superseded entry excluded)", len(got))
+	}
+	if got[0].ID != newID {
+		t.Errorf("got entry #%d, want #%d (the non-superseded one)", got[0].ID, newID)
+	}
+}
+
+func TestRecentMoodEntries_IncludesSuperseded(t *testing.T) {
+	store := newMoodTestStore(t)
+
+	oldID, err := store.SaveMoodEntry(&MoodEntry{Valence: 3, Note: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newID, err := store.SaveMoodEntry(&MoodEntry{Valence: 5, Note: "new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SupersedeMoodEntry(oldID, newID, "evolved"); err != nil {
+		t.Fatal(err)
+	}
+
+	// RecentMoodEntries is the timeline view — shows everything.
+	got, err := store.RecentMoodEntries("", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (timeline shows superseded entries)", len(got))
+	}
+}
+
 // --- Embedding / KNN dedup (requires EmbedDimension > 0) ---------
 
 // makeEmbedding produces a deterministic dim-sized vector for tests.

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -220,9 +220,9 @@ var syncedTableSpecs = map[string]tableSpec{
 		placeholders: "?, ?, ?, ?",
 	},
 	"mood_entries": {
-		selectCols:   "id, ts, kind, valence, labels, associations, note, source, confidence, conversation_id, created_at, updated_at",
-		d1Cols:       "id, ts, kind, valence, labels, associations, note, source, confidence, conversation_id, created_at, updated_at",
-		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
+		selectCols:   "id, ts, kind, valence, labels, associations, note, source, confidence, conversation_id, created_at, updated_at, superseded_by, supersede_reason",
+		d1Cols:       "id, ts, kind, valence, labels, associations, note, source, confidence, conversation_id, created_at, updated_at, superseded_by, supersede_reason",
+		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
 	},
 }
 
@@ -774,6 +774,16 @@ func (s *SyncedStore) UpdateMoodEntry(id int64, entry *MoodEntry) error {
 		return err
 	}
 	s.writeOutbox("mood_entries", id, "upsert")
+	return nil
+}
+
+// SupersedeMoodEntry marks a mood entry as replaced locally and records in outbox.
+// The vec_moods cleanup only happens locally — D1 has no vector tables.
+func (s *SyncedStore) SupersedeMoodEntry(oldID, newID int64, reason string) error {
+	if err := s.SQLiteStore.SupersedeMoodEntry(oldID, newID, reason); err != nil {
+		return err
+	}
+	s.writeOutbox("mood_entries", oldID, "upsert")
 	return nil
 }
 

--- a/migrations/000014_mood_supersede.up.sql
+++ b/migrations/000014_mood_supersede.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE mood_entries ADD COLUMN superseded_by INTEGER REFERENCES mood_entries(id);
+ALTER TABLE mood_entries ADD COLUMN supersede_reason TEXT;
+CREATE INDEX IF NOT EXISTS idx_mood_entries_superseded ON mood_entries(superseded_by);

--- a/mood/agent.go
+++ b/mood/agent.go
@@ -37,6 +37,7 @@ const (
 	ActionDroppedNoSignal Action = "dropped_no_signal"
 	ActionDroppedDedup    Action = "dropped_dedup"
 	ActionDroppedVocab    Action = "dropped_no_valid_labels"
+	ActionSuperseded      Action = "superseded"
 	ActionDroppedClassify Action = "dropped_classifier_rejected"
 	ActionErrored         Action = "errored"
 )
@@ -86,6 +87,11 @@ type AgentConfig struct {
 	// instead of creating a duplicate. Default 0.55.
 	UpdateSimilarity float64
 
+	// UpdateWindow is how far back we look for entries to supersede.
+	// Shorter than DedupWindow — mood shifts happen faster than
+	// topic repeats. Default 60 minutes.
+	UpdateWindow time.Duration
+
 	// UpdateMaxValenceDrift is the maximum valence difference that
 	// still counts as "same mood, evolving." Beyond this the emotional
 	// state has shifted enough to warrant a new entry. Default 1.
@@ -131,7 +137,10 @@ func (c AgentConfig) withDefaults() AgentConfig {
 		c.DedupSimilarity = embed.HighSimilarityThreshold
 	}
 	if c.UpdateSimilarity <= 0 {
-		c.UpdateSimilarity = embed.MediumSimilarityThreshold
+		c.UpdateSimilarity = 0.70
+	}
+	if c.UpdateWindow <= 0 {
+		c.UpdateWindow = 60 * time.Minute
 	}
 	if c.UpdateMaxValenceDrift <= 0 {
 		c.UpdateMaxValenceDrift = 1
@@ -420,18 +429,14 @@ func RunAgent(ctx context.Context, deps Deps, cfg AgentConfig, turns []Turn) Res
 		}
 	}
 
-	// 7. Dedup + update — only when we have an embedding + vec_moods.
+	// 7. Dedup + supersede — only when we have an embedding + vec_moods.
 	//
 	// Three tiers based on similarity to the nearest recent entry:
-	//   ≥ DedupSimilarity (0.80)  → drop (nearly identical)
-	//   ≥ UpdateSimilarity (0.55) → update existing entry in place
-	//                                (same emotional arc, more detail)
-	//   < UpdateSimilarity        → new entry (different mood)
-	//
-	// The update path also checks valence drift: if the new mood is
-	// more than ±UpdateMaxValenceDrift away from the neighbor, the
-	// emotional state has genuinely shifted and deserves its own row
-	// even if the topic is similar.
+	//   ≥ DedupSimilarity (0.80)     → drop (nearly identical)
+	//   ≥ UpdateSimilarity (0.70)    → supersede: save new entry, mark
+	//     + within UpdateWindow        old as superseded (non-destructive)
+	//     + ≤ valence drift + ≥2 labels
+	//   < UpdateSimilarity           → new entry (different mood)
 	if len(candidate.Embedding) > 0 {
 		neighbors, err := deps.Store.SimilarMoodEntriesWithin(
 			deps.Clock(), candidate.Embedding, cfg.DedupWindow, 3,
@@ -461,30 +466,41 @@ func RunAgent(ctx context.Context, deps Deps, cfg AgentConfig, turns []Turn) Res
 				}
 			}
 
-			// Label overlap: does the new mood share at least one
-			// emotional label with the existing entry? Without overlap,
-			// the feeling has qualitatively shifted even if the topic
-			// is similar (e.g., Frustrated→Relieved about the same event).
+			// Label overlap: does the new mood share enough emotional
+			// labels with the existing entry? Requiring >=2 prevents
+			// superseding when the feeling has qualitatively shifted
+			// even if the topic is similar (e.g., Frustrated→Relieved
+			// about the same event).
 			labelOverlap := countLabelOverlap(candidate.Labels, nearest.Labels)
 
-			if topSim >= cfg.UpdateSimilarity && valenceDrift <= cfg.UpdateMaxValenceDrift && labelOverlap > 0 {
-				// Tier 2: same emotional territory, evolving — update
-				// the existing entry with richer detail.
+			// Only consider supersede for entries within the shorter
+			// update window — mood shifts happen faster than topic repeats.
+			now := deps.Clock()
+			withinUpdateWindow := now.Sub(nearest.Timestamp) <= cfg.UpdateWindow
+
+			if withinUpdateWindow && topSim >= cfg.UpdateSimilarity && valenceDrift <= cfg.UpdateMaxValenceDrift && labelOverlap >= 2 {
+				// Tier 2: same emotional territory, evolving — save a
+				// new entry and supersede the old one (non-destructive).
 				candidate.Source = memory.MoodSourceInferred
-				if err := deps.Store.UpdateMoodEntry(nearest.ID, candidate); err != nil {
-					log.Error("mood update failed; falling through to new entry",
+				newID, err := deps.Store.SaveMoodEntry(candidate)
+				if err != nil {
+					log.Error("mood supersede: save new entry failed; falling through",
 						"existing_id", nearest.ID, "err", err)
 				} else {
-					candidate.ID = nearest.ID
-					tb.line(fmt.Sprintf("♻️ updated #%d (sim=%.2f, valence %d→%d)",
-						nearest.ID, topSim, nearest.Valence, candidate.Valence))
+					candidate.ID = newID
+					reason := fmt.Sprintf("mood evolved (sim=%.2f, valence %d→%d)", topSim, nearest.Valence, candidate.Valence)
+					if err := deps.Store.SupersedeMoodEntry(nearest.ID, newID, reason); err != nil {
+						log.Warn("mood supersede: marking old entry failed", "old_id", nearest.ID, "err", err)
+					}
+					tb.line(fmt.Sprintf("♻️ superseded #%d → #%d (sim=%.2f, valence %d→%d)",
+						nearest.ID, newID, topSim, nearest.Valence, candidate.Valence))
 					tb.flush(deps.Trace)
-					log.Info("mood updated existing entry",
-						"id", nearest.ID, "valence", candidate.Valence,
-						"labels", candidate.Labels, "sim", topSim)
+					log.Info("mood superseded existing entry",
+						"old_id", nearest.ID, "new_id", newID,
+						"valence", candidate.Valence, "labels", candidate.Labels, "sim", topSim)
 					return Result{
-						Action:     ActionUpdated,
-						Reason:     fmt.Sprintf("refined entry #%d (sim=%.2f)", nearest.ID, topSim),
+						Action:     ActionSuperseded,
+						Reason:     fmt.Sprintf("superseded entry #%d (sim=%.2f)", nearest.ID, topSim),
 						Confidence: confidence,
 						Inference:  inference,
 						Entry:      candidate,

--- a/mood/agent_test.go
+++ b/mood/agent_test.go
@@ -423,6 +423,12 @@ func TestRunAgent_ConfigDefaultsApplied(t *testing.T) {
 	if cfg.DedupSimilarity != 0.80 {
 		t.Errorf("DedupSimilarity default = %v, want 0.80", cfg.DedupSimilarity)
 	}
+	if cfg.UpdateSimilarity != 0.70 {
+		t.Errorf("UpdateSimilarity default = %v, want 0.70", cfg.UpdateSimilarity)
+	}
+	if cfg.UpdateWindow != 60*time.Minute {
+		t.Errorf("UpdateWindow default = %v, want 60m", cfg.UpdateWindow)
+	}
 	if cfg.ProposalExpiry != 30*time.Minute {
 		t.Errorf("ProposalExpiry default = %v, want 30m", cfg.ProposalExpiry)
 	}


### PR DESCRIPTION
## Summary

- Mood dedup Tier 2 now **supersedes** instead of overwriting — creates a new entry and marks the old one with `superseded_by`, preserving the full emotional timeline
- Raised update similarity threshold from 0.55 → 0.70 (same broad topic no longer triggers merge)
- Raised label overlap requirement from >0 → ≥2 (single shared label isn't enough)
- New `update_window_minutes` config (default 60) — shorter than the 120-min dedup window since mood shifts happen faster than topic repeats
- Superseded entries hidden from daily rollup + KNN dedup, visible in raw timeline
- Migration 000014 adds `superseded_by` and `supersede_reason` columns

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] `go test -race ./memory/... ./mood/... ./bot/...` — race-clean
- [x] New tests: `TestSupersedeMoodEntry`, `TestMoodEntriesInRange_ExcludesSuperseded`, `TestRecentMoodEntries_IncludesSuperseded`
- [x] D1 schema and synced_store table spec updated