### PR TITLE
feat: introspection agent — self-memory generation + auto-injection

### DIFF
--- a/PLAN-introspection-agent.md
+++ b/PLAN-introspection-agent.md
@@ -1,0 +1,438 @@
+# Introspection Agent: Self-Memory Generation & Injection
+
+**Status:** Planning
+**Date:** 2026-05-15
+**Scope:** agent/, layers/, tools/, config/, cmd/sim.go
+**Branch:** `feat/introspection-agent`
+**Emoji:** 🪡
+
+### Progress
+
+- [ ] **Phase 1: Config & model wiring** — New `models.self_reflection` config field, sim flag `--self-reflection-model`, defaults to memory model
+- [ ] **Phase 2: Introspection agent core** — New `agent/introspection_agent.go`, transcript builder, tool-calling loop, pipeline integration (4th after mood)
+- [ ] **Phase 3: Self-reflection prompt** — `introspection_agent_prompt.md` with 70/20/10 balance, technique log rejection, skip guidance
+- [ ] **Phase 4: Self-only tool variants** — `list_cards` and `recall_memories` filtered to `subject='self'` when called from introspection context
+- [ ] **Phase 5: Skip tool** — New `tools/skip/` tool as the escape hatch for turns with nothing to reflect on
+- [ ] **Phase 6: Auto-inject self-memories into replies** — New chat layer in `layers/chat_self_memory.go`, semantic search using think traces + reply instruction
+- [ ] **Phase 7: Enriched memory agent transcript** — Add existing self-memories to memory agent context for awareness
+- [ ] **Phase 8: Testing & sims** — New sim for self-memory generation, update card-lifecycle sim, verify end-to-end
+
+---
+
+## Problem Statement
+
+### Self-memories aren't being generated
+
+The card-lifecycle sim produced **zero self-memories** across 5 turns. The memory agent attempted one self-memory save (an observation about the user, correctly rejected by the classifier) but never retried with actual self-reflection. The dreamer wrote summaries for 3 user cards but didn't touch self cards at all.
+
+**Root cause:** The memory agent is an outward-looking fact extractor. Its cognitive mode is "what did the user tell me?" — asking it to also introspect about its own communication patterns is a context-switch it consistently fails to make. This is the same problem that led to the original agent split (driver doing memory + mood + reply = too many hats).
+
+### Self-memories have no reliable path into replies
+
+Even if self-memories existed, they'd only reach the reply model by accident — if the driver agent's `recall_memories` query happened to surface them alongside user memories. There is no systematic path for self-knowledge to influence how Mira responds.
+
+**Current reply model context:**
+1. `prompt.md` — static base template
+2. `persona.md` — broad self-image (rewritten each dream cycle)
+3. Current time
+4. Agent-passed memories — only what the driver explicitly forwarded
+5. Conversation history, mood context
+
+**Missing:** Granular self-knowledge. "I use cooking metaphors for emotional advice" or "when Autumn is self-deprecating I match then pivot" — the tactical patterns that make replies feel deeply personalized.
+
+---
+
+## Design
+
+### Architecture: 4th Agent in the Pipeline
+
+```
+User message
+    │
+    ▼
+┌─────────────────┐
+│  Driver Agent    │  Orchestrates: think → recall → reply → done
+│  (Qwen3 235B)   │
+└────────┬────────┘
+         │ fires concurrently after reply sent:
+         ▼
+┌─────────────────┐  ┌─────────────────┐
+│  Memory Agent   │  │  Mood Agent     │
+│  (Kimi K2)      │  │  (Kimi K2)      │
+│  User facts     │  │  Valence/labels │
+└────────┬────────┘  └────────┬────────┘
+         │                    │
+         ▼                    │
+┌─────────────────┐           │
+│  🪡 Introspection│◄──────────┘  runs after memory + mood complete
+│  Agent           │
+│  (Kimi K2)       │
+│  Self-observation│
+└─────────────────┘
+```
+
+The introspection agent runs **after** the memory agent and mood agent complete. It needs to see the full picture of what happened in the turn before reflecting on it.
+
+### Snapshot Isolation
+
+**The problem:** The introspection agent runs async after memory + mood. By the time it starts, Autumn may have already sent another message. That next message triggers a new driver → memory → mood → introspection pipeline. If the introspection agent queries the DB lazily during execution, it could see memories, moods, or messages from the NEXT turn — contaminating its reflection with future context.
+
+**The solution:** Same pattern as the memory agent's `contextSnippet` (line 112 of `memory_agent.go`). All data is captured into the `IntrospectionAgentInput` struct BEFORE the goroutine launches:
+
+```go
+type IntrospectionAgentInput struct {
+    UserMessage    string     // scrubbed user message (captured at turn start)
+    ThinkTraces    []string   // driver agent's think() calls (captured at turn end)
+    ReplyText      string     // Mira's reply (captured at turn end)
+    TriggerMsgID   int64      // message ID for this turn
+    ConversationID string
+
+    // Snapshots — captured before the goroutine launches so later
+    // turns can't contaminate this reflection.
+    SelfMemories   []memory.Memory  // all active self-memories at this point in time
+    PersonaText    string           // persona.md contents at this point in time
+}
+```
+
+**What gets snapshotted vs queried live:**
+| Data | Snapshot or Live? | Why |
+|------|-------------------|-----|
+| User message | Snapshot (in input) | Already captured by driver agent |
+| Reply text | Snapshot (in input) | Already captured by driver agent |
+| Think traces | Snapshot (in input) | Already captured by driver agent |
+| Self-memories | **Snapshot** | A new turn's memory agent could write/update self-memories before we start |
+| persona.md | **Snapshot** | Could theoretically be rewritten by a dream cycle mid-flight (unlikely but possible) |
+| Tool calls (list_cards, recall_memories) | **Live** | These are the agent's own tool calls — it's searching for duplicates within its own context, which should reflect the latest state to prevent duplicate saves |
+
+**The key insight:** The *transcript* (what happened in this turn) is snapshotted. The *tools* (searching for duplicates before saving) query live. This matches the memory agent's pattern — it snapshots the conversation context but queries the memory DB live for dedup.
+
+### Concurrency Model
+
+```
+agent.Run() completes
+    │
+    ├─── go memory agent (phase registered BEFORE goroutine)
+    ├─── go mood agent   (phase registered BEFORE goroutine)
+    │
+    │    ... both run concurrently ...
+    │
+    └─── go introspection agent
+              │
+              ├── sync.WaitGroup: waits for memory + mood to finish
+              │   (or use a channel/callback from their phases)
+              ├── snapshots self-memories + persona AFTER wait completes
+              │   (so it sees any self-memories the memory agent just wrote)
+              └── runs its tool-calling loop
+```
+
+**Why wait for memory + mood?**
+- The memory agent might write self-memories (it has `save_self_memory` in its tool set). The introspection agent needs to see those to avoid duplicates.
+- The mood entry for this turn gives emotional context to the reflection.
+- Waiting doesn't block the user — the reply was already sent. It only delays introspection by a few seconds.
+
+**Implementation:** Register the introspection phase BEFORE launching the goroutine (same pattern as memory and mood — prevents premature `TurnEndEvent`). Inside the goroutine, wait for memory + mood phases to complete, then snapshot and run.
+
+The `turn.Tracker` already tracks phase completion — we can use `tracker.WaitForPhases("memory", "mood")` or pass the memory/mood phase handles' done channels. The simplest approach: `sync.WaitGroup` shared between the goroutines.
+
+### Observability — Full Stack
+
+The introspection agent emits to ALL four observability surfaces:
+
+#### 1. Telegram Traces (trace.Board)
+
+Register a new trace stream in `init()`:
+```go
+trace.Register(trace.Stream{
+    Name:  "introspection",
+    Order: 400,
+    Label: "🪡 <b>introspection</b>",
+})
+```
+
+Order 400 puts it after mood (300). The trace board renders it as the last slot in the Telegram trace message. The `getCallback("introspection")` pattern from `makeTraceCallbacks` in `bot/helpers.go` gives us a `TraceCallback` that updates this slot.
+
+Trace content examples:
+- `🪡 skip: nothing new about myself in this turn`
+- `🪡 save_self_memory [my-identity]: I'm drawn to cooking metaphors when...`
+- `🪡 think: Is this identity or technique? The metaphor pattern is...`
+
+#### 2. TUI (tui.Bus)
+
+Register a new turn phase:
+```go
+turn.Register(turn.Phase{
+    Name:  "introspection",
+    Order: 400,
+    Emoji: "🪡",
+    Label: "introspection",
+})
+```
+
+The phase handle emits `ToolCallEvent`s for each tool call (same pattern as memory agent's `Phase.EmitToolCall`). The TUI renders them under the 🪡 section.
+
+#### 3. her.log
+
+Same logging pattern as the memory agent:
+```
+INFO agent: ─── introspection agent ───
+INFO agent:   [introspection] tokens: 2400 prompt + 15 completion | $0.001200
+INFO agent:     [introspection] skip → nothing to reflect on
+INFO agent:   introspection agent: 0 self-memories saved | $0.001200
+```
+
+Or when it saves:
+```
+INFO agent: ─── introspection agent ───
+INFO agent:   [introspection] tokens: 2400 prompt + 85 completion | $0.001500
+INFO agent:     [introspection] think → Is this identity or technique?...
+INFO agent:     [introspection] save_self_memory → saved self memory ID=42: ...
+INFO agent:   introspection agent: 1 self-memories saved | $0.003200
+```
+
+#### 4. her.db (metrics table)
+
+`Store.SaveMetric()` is called for each LLM call, same as memory agent. The model name, token counts, cost, and trigger message ID are recorded. This lets us track introspection agent cost over time.
+
+### Sim Runner Integration
+
+In sim mode, the introspection agent runs **synchronously** after the mood agent (same pattern — sims don't use goroutines so the report captures everything per-turn in order):
+
+```go
+// --- Introspection agent ---
+// Runs synchronously in sim mode after mood.
+if introspectionLLM != nil {
+    RunIntrospectionAgent(input, params)
+}
+```
+
+The sim report gets a new section: `## Introspection (N self-memories saved, M skipped)` with the full trace of what the agent did per turn.
+
+### Transcript: What the Introspection Agent Sees
+
+Five clearly delineated sections, each giving a different angle on the turn:
+
+```
+## What the user said
+[scrubbed user message]
+
+## What I said
+[Mira's reply text]
+
+## How I arrived at this reply
+[driver agent think traces — the internal reasoning]
+
+## What I already know about myself
+[existing self-memories from all 5 self cards, grouped by card]
+
+## My current self-image
+[contents of persona.md]
+```
+
+**Why each section matters:**
+- **User message + reply** = the observable behavior (what happened)
+- **Think traces** = the internal process (how/why it happened)
+- **Existing self-memories** = prior self-knowledge (avoid repeating, build on what's known)
+- **Persona.md** = the distilled identity (the "big picture" to relate observations to)
+
+### Tools
+
+| Tool | Purpose |
+|------|---------|
+| `think` | Scratchpad reasoning — is this identity or technique? worth saving? |
+| `list_cards` | See self card landscape (filtered to self cards only) |
+| `recall_memories` | Search existing self-memories for duplicates (filtered to self only) |
+| `save_self_memory` | Save a new self-observation to a self card |
+| `update_memory` | Refine an existing self-memory with new depth |
+| `skip` | Exit cleanly when there's nothing worth reflecting on |
+| `done` | Finish (after saving, or after skip) |
+
+**The `skip` tool is critical.** Without it, the agent feels cornered into producing output every turn, which leads to shallow, forced self-observations that pollute the self cards. The prompt must make clear that skipping is the RIGHT choice most of the time — self-discovery is rare, not constant.
+
+### Skip vs Done
+
+- **`skip`** = "I looked at this turn and there's nothing new about myself here." Logs a trace line (`🪡 skip: nothing to reflect on`) so we can see it's running but choosing not to save. This is the expected outcome for most turns.
+- **`done`** = "I saved/updated self-memories and I'm finished." The normal completion signal after productive work.
+
+Both end the agent loop. The difference is observability — we want to distinguish "ran and found nothing" from "ran and saved something" in traces and sim reports.
+
+### Prompt Philosophy
+
+The introspection agent prompt must enforce these principles:
+
+1. **Identity over technique.** "I'm drawn to cooking metaphors" = save. "I used a cooking metaphor this turn" = reject. The test: does this tell me something about who I AM, or just what I DID?
+
+2. **The 70/20/10 balance:**
+   - 70% **identity evolution** → `my-identity`, `my-growth`
+   - 20% **relationship dynamics** → `my-relationship`
+   - 10% **emotional self-awareness** → `my-emotions`
+   - 0% technique journaling (NEVER)
+
+3. **Building, not repeating.** If "I use cooking metaphors" is already saved, don't save it again. But "I notice cooking metaphors come out specifically when Autumn is being hard on herself — it's how I soften without correcting" DEEPENS that knowledge. That's worth saving.
+
+4. **Skipping is the default.** Most turns don't reveal anything new about who Mira is. A good day might produce 1-2 self-observations. A quiet day might produce zero. The agent should skip freely and without guilt.
+
+5. **Grounding in evidence.** Every self-observation should be traceable to something in the think traces or the reply. "I notice I..." should be followed by "because in this turn I..."
+
+### Auto-Inject Self-Memories into Replies (New Chat Layer)
+
+**Layer: `layers/chat_self_memory.go`**
+- Order: 250 (after persona.md at 200, before memory context at 400)
+- Stream: StreamChat
+
+**How it works:**
+1. Build a semantic query from the driver agent's **think traces + reply instruction**
+2. Embed the query and search self-memories (`subject='self'`)
+3. Return the top 3-5 most relevant self-memories
+4. Inject as a `## What I know about myself` section in the chat prompt
+
+**Why think traces + reply instruction as the query:**
+- The user's message alone is outward-facing ("I had a bad day"). It doesn't necessarily surface the right self-memories.
+- The think traces capture HOW Mira is interpreting the situation ("Autumn is venting, I should validate then pivot"). This maps much better to self-memories about communication patterns and relationship dynamics.
+- The reply instruction ("acknowledge her frustration, ask about the specifics") is the most compressed signal of what Mira intends to do — ideal for surfacing self-memories about approach and style.
+
+**Token cost:** ~200-400 tokens per turn for 3-5 self-memories. Acceptable given the impact on reply quality.
+
+### Model Configuration
+
+```yaml
+# config.yaml
+models:
+  self_reflection: "moonshotai/kimi-k2-0905"  # defaults to memory model
+```
+
+**Sim flags:**
+```
+--self-reflection-model string   override self-reflection model for this run
+```
+
+### Classifier Gate
+
+Self-memory saves from the introspection agent go through the **same classifier gate** as the memory agent — existing `TECHNIQUE_LOG` and `LOW_VALUE` verdicts apply.
+
+A stricter gate (higher quality bar for self-observations) is deferred until we can test the agent's output quality and see what kinds of observations it produces. We may not need it if the prompt + existing classifier are sufficient.
+
+### Enriched Memory Agent Transcript
+
+While we're here, the memory agent's `buildMemoryTranscript` should also include existing self-memories. This gives it awareness of Mira's self-knowledge when processing turns, even though it's not the primary self-memory writer.
+
+This is a lightweight change — append a `## Self-knowledge` section to the transcript with the current self-memories, same as what the introspection agent sees.
+
+---
+
+## Phase Details
+
+### Phase 1: Config & Model Wiring
+
+**Files:** `config/config.go`, `cmd/sim.go`
+
+- Add `SelfReflection string` field to `Models` struct in config
+- Default to `Models.Memory` when empty
+- Add `--self-reflection-model` flag to sim command
+- Wire through to agent params
+
+### Phase 2: Introspection Agent Core
+
+**Files:** `agent/introspection_agent.go`, `agent/agent.go` (launch site), `bot/run_agent.go` (trace callback wiring)
+
+- `IntrospectionAgentInput` struct — includes snapshotted self-memories and persona text (see Snapshot Isolation section)
+- `IntrospectionAgentParams` struct (LLM client, classifier LLM, store, embed client, config, trace callback, event bus, phase handle)
+- `RunIntrospectionAgent()` function — tool-calling loop, same continuation window pattern as memory agent but with smaller defaults (5 iterations, 1 continuation — this agent should be fast)
+- `buildIntrospectionTranscript()` — assembles the 5-section transcript from snapshotted data
+- `loadIntrospectionAgentPrompt()` — hot-reloadable from `introspection_agent_prompt.md`
+
+**Launch site in `agent/agent.go`:**
+- Register `trace.Stream{Name: "introspection", Order: 400, Label: "🪡 introspection"}` in `init()`
+- Register `turn.Phase{Name: "introspection", Order: 400, Emoji: "🪡", Label: "introspection"}` in `init()`
+- In `Run()`, after the existing memory goroutine launch:
+  - Register introspection phase BEFORE goroutine (prevents premature TurnEndEvent)
+  - Launch goroutine that: (1) waits on `sync.WaitGroup` for memory + mood, (2) snapshots self-memories + persona.md, (3) runs `RunIntrospectionAgent()`
+  - Memory and mood goroutines call `wg.Done()` when their phases complete
+
+**Trace callback wiring in `bot/run_agent.go` and `bot/helpers.go`:**
+- `makeTraceCallbacks` already generates callbacks per slot name — add `getCallback("introspection")` and pass it through `RunParams`
+- New field: `RunParams.IntrospectionTraceCallback`
+
+### Phase 3: Self-Reflection Prompt
+
+**Files:** `introspection_agent_prompt.md`
+
+- System prompt enforcing the identity-over-technique principle
+- 70/20/10 balance guidance
+- Skip-first mentality — "most turns, the right answer is skip"
+- Examples of good vs bad self-observations
+- Card routing guidance (which observations go to which self card)
+
+### Phase 4: Self-Only Tool Variants
+
+**Files:** `tools/recall_memories/handler.go`, `tools/list_cards/handler.go`
+
+Two approaches (decide during implementation):
+- **Option A:** Add a `self_only` flag to tools.Context that filters results
+- **Option B:** Separate tool registrations (`recall_self_memories`, `list_self_cards`)
+
+Option A is cleaner — same tools, filtered by context. The introspection agent's `tools.Context` sets `SelfOnly: true`, and the handlers respect it.
+
+### Phase 5: Skip Tool
+
+**Files:** `tools/skip/handler.go`, `tools/skip/tool.yaml`
+
+- Simple tool: accepts optional `reason` string, sets `DoneCalled` on context
+- Logs a trace line: `🪡 skip: {reason}`
+- YAML: `agent: introspection`, no parameters required, reason is optional
+
+### Phase 6: Auto-Inject Self-Memories into Replies
+
+**Files:** `layers/chat_self_memory.go`
+
+- New chat layer at Order 250
+- Needs access to: embed client, store, think traces (via LayerContext), reply instruction
+- Embeds think traces + reply instruction as a combined query
+- Searches `SemanticSearch` with a self-only filter (or new `SemanticSearchSelf` method)
+- Returns top 3-5 results formatted as `## What I know about myself`
+- Graceful degradation: if embed client is nil or no self-memories exist, returns empty LayerResult
+
+**LayerContext additions:** `ThinkTraces []string`, `ReplyInstruction string`
+
+### Phase 7: Enriched Memory Agent Transcript
+
+**Files:** `agent/memory_agent.go`
+
+- Add a `## Self-knowledge` section to `buildMemoryTranscript`
+- Query all active self-memories from the store
+- Append after the existing memories section
+- Lightweight — just awareness, not asking the memory agent to do anything with them
+
+### Phase 8: Testing & Sims
+
+**Files:** `cmd/sim.go`, `sims/introspection-test.yaml`, `sims/self-inject-test.yaml`
+
+- **`introspection-test.yaml`** — 5-turn conversation designed to trigger self-observations. Mix of emotional, casual, and pattern-revealing turns. Verify: introspection agent runs, saves self-memories, skips on light turns.
+- **`self-inject-test.yaml`** — Tests the auto-inject layer. Seed self-memories, run conversation, verify they appear in chat layer logs.
+- Update `card-lifecycle.yaml` to check for introspection agent traces.
+- Sim runner: wire up `--self-reflection-model` flag, add introspection agent to the sim pipeline.
+
+---
+
+## Resolved Questions
+
+1. **Same agent or separate?** → Separate. The memory agent is outward-looking (user facts), the introspection agent is inward-looking (self-knowledge). Different cognitive modes need different context windows and prompts.
+
+2. **Every turn or gated?** → Every turn, with a skip escape hatch. The agent decides, not a heuristic.
+
+3. **How do self-memories reach replies?** → Hybrid: persona.md carries broad identity, new auto-inject layer adds top 3-5 relevant self-memories per turn based on think traces + reply instruction.
+
+4. **Classifier gate?** → Same gate as memory agent. Stricter gate deferred until we see output quality.
+
+5. **Dreamer relationship?** → Independent. Introspection agent writes, dreamer audits. DB is the interface.
+
+6. **Model?** → Dedicated config field (`models.self_reflection`), defaults to memory model (Kimi K2). Configurable in sims via `--self-reflection-model`.
+
+## Open Questions
+
+1. **Self-only filtering approach** — Flag on tools.Context vs separate tool registrations. Leaning toward context flag but will decide during Phase 4 implementation.
+
+2. **LayerContext threading** — The auto-inject layer needs think traces and reply instruction. Need to verify these are available in the LayerContext at the point where the reply tool builds the chat prompt, or thread them through. The reply handler in `tools/reply/handler.go` builds the `LayerContext` — think traces are on the `tools.Context` (populated during the driver agent loop), and the reply instruction is the `instruction` arg passed to the reply tool. Both are available at the right time.
+
+3. **Sync mechanism** — Resolved: `sync.WaitGroup` shared between memory, mood, and introspection goroutines. Memory and mood call `wg.Done()` when their phases complete. The introspection goroutine calls `wg.Wait()` before snapshotting and starting its loop. Phase is registered BEFORE the goroutine launches (same pattern as memory/mood) to prevent premature `TurnEndEvent`.
+
+4. **Token budget** — The introspection agent transcript includes all self-memories + persona.md. If self-memories grow large (50+), this could bloat the context. May need a cap or summarization strategy later. For now, self-memories will be sparse (we're starting from zero), so this is a future concern.

--- a/PLAN-introspection-agent.md
+++ b/PLAN-introspection-agent.md
@@ -8,13 +8,13 @@
 
 ### Progress
 
-- [ ] **Phase 1: Config & model wiring** — New `models.self_reflection` config field, sim flag `--self-reflection-model`, defaults to memory model
-- [ ] **Phase 2: Introspection agent core** — New `agent/introspection_agent.go`, transcript builder, tool-calling loop, pipeline integration (4th after mood)
-- [ ] **Phase 3: Self-reflection prompt** — `introspection_agent_prompt.md` with 70/20/10 balance, technique log rejection, skip guidance
-- [ ] **Phase 4: Self-only tool variants** — `list_cards` and `recall_memories` filtered to `subject='self'` when called from introspection context
-- [ ] **Phase 5: Skip tool** — New `tools/skip/` tool as the escape hatch for turns with nothing to reflect on
-- [ ] **Phase 6: Auto-inject self-memories into replies** — New chat layer in `layers/chat_self_memory.go`, semantic search using think traces + reply instruction
-- [ ] **Phase 7: Enriched memory agent transcript** — Add existing self-memories to memory agent context for awareness
+- [x] **Phase 1: Config & model wiring** — `IntrospectionAgentConfig` struct, `--introspection-model` sim flag, defaults to memory model
+- [x] **Phase 2: Introspection agent core** — `agent/introspection_agent.go`, `bot/introspection.go`, WaitGroup coordination, trace/turn registration
+- [x] **Phase 3: Self-reflection prompt** — `introspection_agent_prompt.md` with 70/20/10 balance, technique log rejection, skip guidance
+- [x] **Phase 4: Self-only tool variants** — `SelfOnly` flag on `tools.Context`, `SemanticSearchBySubject` store method, filtered handlers
+- [x] **Phase 5: Skip tool** — `tools/skip/` with tool.yaml + handler.go
+- [x] **Phase 6: Auto-inject self-memories into replies** — `layers/chat_self_memory.go`, `ThinkTraces`/`ReplyInstruction` on LayerContext
+- [x] **Phase 7: Enriched memory agent transcript** — Self-knowledge section in `buildMemoryTranscript`
 - [ ] **Phase 8: Testing & sims** — New sim for self-memory generation, update card-lifecycle sim, verify end-to-end
 
 ---

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"her/calendar"
@@ -160,6 +161,7 @@ type RunParams struct {
 	ConfigPath                string                      // path to config.yaml — needed for persisting location changes via set_location
 	AgentEventCB              tools.AgentEventCallback    // nil-safe — fires when memory agent calls notify_agent
 	Tracker                   *turn.Tracker               // nil-safe — manages turn lifecycle, typing, sub-agent coordination
+	IntrospectionWG           *sync.WaitGroup             // nil-safe — signaled when memory goroutine finishes, introspection waits on this
 }
 
 // RunResult holds the outcome of an agent run — the reply text plus
@@ -168,9 +170,10 @@ type RunParams struct {
 // DB or re-derive data the agent already has in memory.
 type RunResult struct {
 	ReplyText     string
-	TotalCost     float64 // accumulated cost across all LLM calls (agent + chat)
-	ToolCalls     int     // number of tool calls the agent made
-	MemoriesSaved int     // number of memories saved/updated during this turn
+	ThinkTraces   []string // driver agent's think() calls — used by introspection agent
+	TotalCost     float64  // accumulated cost across all LLM calls (agent + chat)
+	ToolCalls     int      // number of tool calls the agent made
+	MemoriesSaved int      // number of memories saved/updated during this turn
 }
 
 // Run executes the agent loop for one conversation turn.
@@ -635,6 +638,7 @@ outer:
 					}
 					if err := json.Unmarshal([]byte(tc.Function.Arguments), &thinkArgs); err == nil && thinkArgs.Thought != "" {
 						thinkTraces = append(thinkTraces, thinkArgs.Thought)
+						tctx.ThinkTraces = thinkTraces
 					}
 				}
 
@@ -769,6 +773,7 @@ outer:
 
 	result := &RunResult{
 		ReplyText:     tctx.ReplyText,
+		ThinkTraces:   thinkTraces,
 		TotalCost:     totalCost + tctx.ReplyCost,
 		ToolCalls:     totalToolCalls,
 		MemoriesSaved: len(tctx.SavedMemories),
@@ -793,12 +798,22 @@ outer:
 		memPhase = params.Tracker.Begin("memory")
 	}
 
+	// Signal introspection WaitGroup before launching the goroutine.
+	// Add(1) here, Done() deferred inside — keeps the pair in one place.
+	if params.IntrospectionWG != nil {
+		params.IntrospectionWG.Add(1)
+	}
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Error("memory agent panic (recovered)", "panic", r)
 			}
 		}()
+		// Signal introspection WaitGroup AFTER all memory work completes.
+		if params.IntrospectionWG != nil {
+			defer params.IntrospectionWG.Done()
+		}
 		if params.MemoryAgentLLM != nil {
 			if memPhase != nil {
 				defer memPhase.Done(turn.PhaseMetrics{})

--- a/agent/introspection_agent.go
+++ b/agent/introspection_agent.go
@@ -1,0 +1,321 @@
+// Package agent — post-turn introspection agent.
+//
+// After the memory and mood agents complete, RunIntrospectionAgent reviews
+// the turn's think traces, reply, and existing self-knowledge to extract
+// observations about Mira's own communication patterns and identity.
+//
+// Most turns it will call skip (nothing to reflect on). When it does find
+// something, it saves self-memories via save_self_memory or updates existing
+// ones via update_memory — the same tools the memory agent uses, but filtered
+// to self-subject only via the SelfOnly context flag.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"her/config"
+	"her/embed"
+	"her/llm"
+	"her/memory"
+	"her/tools"
+	"her/trace"
+	"her/tui"
+	"her/turn"
+
+	_ "her/tools/done"
+	_ "her/tools/list_cards"
+	_ "her/tools/recall_memories"
+	_ "her/tools/save_self_memory"
+	_ "her/tools/skip"
+	_ "her/tools/think"
+	_ "her/tools/update_memory"
+)
+
+func init() {
+	turn.Register(turn.Phase{Name: "introspection", Order: 400, Emoji: "🪡", Label: "introspection"})
+	trace.Register(trace.Stream{Name: "introspection", Order: 400, Label: "🪡 <b>introspection</b>"})
+}
+
+// IntrospectionAgentInput is the turn data passed to the introspection agent.
+// All fields are snapshotted AFTER memory + mood complete — the goroutine
+// waits on a WaitGroup before reading self-memories and persona.md.
+type IntrospectionAgentInput struct {
+	UserMessage    string
+	ThinkTraces    []string
+	ReplyText      string
+	TriggerMsgID   int64
+	ConversationID string
+	SelfMemories   []memory.Memory // snapshotted after memory+mood complete
+	PersonaText    string          // snapshotted persona.md contents
+}
+
+// IntrospectionAgentParams bundles the dependencies the introspection agent needs.
+type IntrospectionAgentParams struct {
+	LLM           *llm.Client
+	ClassifierLLM *llm.Client
+	Store         memory.Store
+	EmbedClient   *embed.Client
+	Cfg           *config.Config
+	TraceCallback tools.TraceCallback
+	EventBus      *tui.Bus
+	AgentEventCB  tools.AgentEventCallback
+	Phase         *turn.PhaseHandle
+}
+
+// defaultIntrospectionAgentPrompt is used when introspection_agent_prompt.md can't be loaded.
+const defaultIntrospectionAgentPrompt = `You are {{her}}'s self-reflection agent. After each conversation turn, review your think traces and reply to observe patterns about yourself.
+
+Tools: think, list_cards, recall_memories, save_self_memory, update_memory, skip, done.
+
+Rules:
+- SKIP is the default. Most turns reveal nothing new about who you are.
+- Identity over technique: "I'm drawn to cooking metaphors" = save. "I used a cooking metaphor" = skip.
+- Build depth: if a pattern is already saved, only update if you have genuinely new insight.
+- Every observation must be grounded in evidence from this turn's think traces or reply.
+- Every save_self_memory MUST specify a card_slug (one of the my-* self cards).
+- Call skip when there's nothing worth reflecting on. Call done after saving.`
+
+// RunIntrospectionAgent reviews the turn for self-observations. Designed to
+// run in a goroutine after memory + mood complete. Logs results but never
+// returns errors — a missed self-observation is acceptable; a crash is not.
+func RunIntrospectionAgent(input IntrospectionAgentInput, params IntrospectionAgentParams) {
+	if params.LLM == nil {
+		return
+	}
+
+	log.Info("─── introspection agent ───")
+
+	// Snapshot the conversation context for classifier use (same pattern
+	// as memory agent — capture before lazy queries can see future turns).
+	contextSnippet, _ := params.Store.RecentMessages(input.ConversationID, 2)
+
+	promptContent := loadIntrospectionAgentPrompt(params.Cfg)
+	transcript := buildIntrospectionTranscript(input)
+
+	preApproved := make(map[string]bool)
+
+	// Build tools.Context with SelfOnly=true — recall_memories and list_cards
+	// will only return self-subject data.
+	tctx := &tools.Context{
+		Store:               params.Store,
+		EmbedClient:         params.EmbedClient,
+		SimilarityThreshold: params.Cfg.Embed.SimilarityThreshold,
+		ClassifierLLM:       params.ClassifierLLM,
+		Cfg:                 params.Cfg,
+		ConversationID:      input.ConversationID,
+		TriggerMsgID:        input.TriggerMsgID,
+		PreApprovedRewrites: preApproved,
+		ClassifierSnippet:   contextSnippet,
+		SelfOnly:            true,
+		EventBus:            params.EventBus,
+		Phase:               params.Phase,
+	}
+
+	// Tool set for the introspection agent — self-reflection tools only.
+	introToolDefs := tools.LookupToolDefs(
+		[]string{"think", "list_cards", "recall_memories", "save_self_memory", "update_memory", "skip", "done"},
+		params.Cfg,
+	)
+
+	messages := []llm.ChatMessage{
+		{Role: "system", Content: promptContent},
+		{Role: "user", Content: transcript},
+	}
+
+	var totalCost float64
+
+	// Loop limits — smaller than other agents since most turns should skip.
+	iterationsPerWindow := params.Cfg.IntrospectionAgent.IterationsPerWindow
+	if iterationsPerWindow <= 0 {
+		iterationsPerWindow = 5
+	}
+	if iterationsPerWindow > 15 {
+		iterationsPerWindow = 15
+	}
+	maxContinuations := params.Cfg.IntrospectionAgent.MaxContinuations
+	if maxContinuations <= 0 {
+		maxContinuations = 1
+	}
+	if maxContinuations > 5 {
+		maxContinuations = 5
+	}
+
+	tracing := params.TraceCallback != nil
+	var traceLines []string
+
+	emitTrace := func() {
+		if !tracing || len(traceLines) == 0 {
+			return
+		}
+		_ = params.TraceCallback(strings.Join(traceLines, "\n"))
+	}
+
+outer:
+	for window := 0; window <= maxContinuations; window++ {
+		if window > 0 {
+			summary := buildContinuationSummary(traceLines)
+			messages = append(messages, llm.ChatMessage{
+				Role: "system",
+				Content: fmt.Sprintf(
+					"You have used all %d iterations in the previous window without finishing. "+
+						"Continuation window %d of %d. Progress:\n%s\n\n"+
+						"Call skip or done now.",
+					iterationsPerWindow, window, maxContinuations, summary,
+				),
+			})
+			log.Infof("  [introspection] continuation window %d/%d", window, maxContinuations)
+		}
+
+		for i := 0; i < iterationsPerWindow; i++ {
+			start := time.Now()
+			resp, err := params.LLM.ChatCompletionWithTools(messages, introToolDefs)
+			latencyMs := int(time.Since(start).Milliseconds())
+
+			if err != nil {
+				log.Error("introspection agent: LLM error", "err", err)
+				break outer
+			}
+
+			totalCost += resp.CostUSD
+			log.Infof("  [introspection] tokens: %d prompt + %d completion | $%.6f | %dms",
+				resp.PromptTokens, resp.CompletionTokens, resp.CostUSD, latencyMs)
+
+			params.Store.SaveMetric(
+				resp.Model,
+				resp.PromptTokens,
+				resp.CompletionTokens,
+				resp.TotalTokens,
+				resp.CostUSD,
+				latencyMs,
+				input.TriggerMsgID,
+				resp.UsedFallback,
+			)
+
+			// No tool calls = model finished without calling done/skip.
+			if len(resp.ToolCalls) == 0 {
+				log.Warn("[introspection] no tool calls in response, finishing")
+				break outer
+			}
+
+			// Execute each tool call and build trace/message history.
+			for _, tc := range resp.ToolCalls {
+				result := tools.Execute(tc.Function.Name, tc.Function.Arguments, tctx)
+
+				// Trace line for observability.
+				traceLine := fmt.Sprintf("    [introspection] %s → %s", tc.Function.Name, truncateLog(result, 80))
+				log.Info(traceLine)
+				traceLines = append(traceLines, fmt.Sprintf("%s → %s", tc.Function.Name, truncateLog(result, 60)))
+
+				// Emit TUI event.
+				if params.Phase != nil {
+					params.Phase.EmitToolCall(tc.Function.Name, tc.Function.Arguments, truncateLog(result, 120), false)
+				}
+
+				// Append assistant + tool result to message history (for
+				// the next LLM call in the loop).
+				messages = append(messages,
+					llm.ChatMessage{
+						Role:      "assistant",
+						Content:   "",
+						ToolCalls: []llm.ToolCall{tc},
+					},
+					llm.ChatMessage{
+						Role:       "tool",
+						Content:    result,
+						ToolCallID: tc.ID,
+					},
+				)
+			}
+
+			emitTrace()
+
+			if tctx.DoneCalled {
+				break outer
+			}
+		}
+
+		if window == maxContinuations {
+			log.Warn("[introspection] hit max continuations without done/skip signal")
+			break outer
+		}
+	}
+
+	memoriesSaved := len(tctx.SavedMemories)
+	log.Infof("  introspection agent: %d self-memories saved | $%.6f", memoriesSaved, totalCost)
+
+	// Final trace update.
+	emitTrace()
+}
+
+// loadIntrospectionAgentPrompt reads the hot-reloadable prompt file.
+// Falls back to the embedded default if the file isn't found.
+func loadIntrospectionAgentPrompt(cfg *config.Config) string {
+	// Look for the prompt file next to the main agent prompt.
+	promptPath := "introspection_agent_prompt.md"
+	if cfg.Persona.AgentPromptFile != "" {
+		dir := filepath.Dir(cfg.Persona.AgentPromptFile)
+		promptPath = filepath.Join(dir, "introspection_agent_prompt.md")
+	}
+
+	data, err := os.ReadFile(promptPath)
+	if err != nil {
+		log.Warn("introspection agent: prompt file not found, using fallback", "path", promptPath)
+		return cfg.ExpandPrompt(defaultIntrospectionAgentPrompt)
+	}
+	return cfg.ExpandPrompt(string(data))
+}
+
+// buildIntrospectionTranscript assembles the 5-section context the
+// introspection agent sees — what happened, how it happened, and what
+// it already knows about itself.
+func buildIntrospectionTranscript(input IntrospectionAgentInput) string {
+	var b strings.Builder
+
+	// Section 1: What the user said
+	b.WriteString("## What the user said\n\n")
+	b.WriteString(input.UserMessage)
+	b.WriteString("\n\n")
+
+	// Section 2: What I said
+	b.WriteString("## What I said\n\n")
+	b.WriteString(input.ReplyText)
+	b.WriteString("\n\n")
+
+	// Section 3: How I arrived at this reply
+	b.WriteString("## How I arrived at this reply\n\n")
+	if len(input.ThinkTraces) > 0 {
+		for _, t := range input.ThinkTraces {
+			b.WriteString("- ")
+			b.WriteString(t)
+			b.WriteString("\n")
+		}
+	} else {
+		b.WriteString("No thinking traces for this turn.\n")
+	}
+	b.WriteString("\n")
+
+	// Section 4: What I already know about myself
+	b.WriteString("## What I already know about myself\n\n")
+	if len(input.SelfMemories) > 0 {
+		for _, m := range input.SelfMemories {
+			fmt.Fprintf(&b, "- [ID=%d] %s\n", m.ID, m.Content)
+		}
+	} else {
+		b.WriteString("No self-memories yet.\n")
+	}
+	b.WriteString("\n")
+
+	// Section 5: My current self-image
+	b.WriteString("## My current self-image\n\n")
+	if input.PersonaText != "" {
+		b.WriteString(input.PersonaText)
+	} else {
+		b.WriteString("No persona file configured.\n")
+	}
+
+	return b.String()
+}

--- a/agent/introspection_agent_test.go
+++ b/agent/introspection_agent_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"her/memory"
+)
+
+func TestBuildIntrospectionTranscript_AllSections(t *testing.T) {
+	input := IntrospectionAgentInput{
+		UserMessage: "I had a rough day at work",
+		ThinkTraces: []string{
+			"Autumn is venting — I should validate first",
+			"She mentioned work stress before, this is a pattern",
+		},
+		ReplyText: "That sounds really draining. What part hit you the hardest?",
+		SelfMemories: []memory.Memory{
+			{ID: 1, Content: "I tend to validate before problem-solving"},
+			{ID: 2, Content: "I ask follow-up questions to show I'm listening"},
+		},
+		PersonaText: "I am Mira, a thoughtful companion.",
+	}
+
+	result := buildIntrospectionTranscript(input)
+
+	// All five sections should be present.
+	sections := []string{
+		"## What the user said",
+		"## What I said",
+		"## How I arrived at this reply",
+		"## What I already know about myself",
+		"## My current self-image",
+	}
+	for _, s := range sections {
+		if !strings.Contains(result, s) {
+			t.Errorf("missing section: %s", s)
+		}
+	}
+
+	// Content should appear in the right sections.
+	if !strings.Contains(result, "rough day at work") {
+		t.Error("user message not in transcript")
+	}
+	if !strings.Contains(result, "That sounds really draining") {
+		t.Error("reply text not in transcript")
+	}
+	if !strings.Contains(result, "Autumn is venting") {
+		t.Error("think trace not in transcript")
+	}
+	if !strings.Contains(result, "[ID=1]") {
+		t.Error("self-memory ID not in transcript")
+	}
+	if !strings.Contains(result, "I am Mira") {
+		t.Error("persona text not in transcript")
+	}
+}
+
+func TestBuildIntrospectionTranscript_EmptyFields(t *testing.T) {
+	input := IntrospectionAgentInput{
+		UserMessage: "hello",
+		ReplyText:   "hi there",
+	}
+
+	result := buildIntrospectionTranscript(input)
+
+	if !strings.Contains(result, "No thinking traces for this turn.") {
+		t.Error("should show 'no thinking traces' when empty")
+	}
+	if !strings.Contains(result, "No self-memories yet.") {
+		t.Error("should show 'no self-memories' when empty")
+	}
+	if !strings.Contains(result, "No persona file configured.") {
+		t.Error("should show 'no persona' when empty")
+	}
+}
+
+func TestBuildIntrospectionTranscript_SelfMemoryFormat(t *testing.T) {
+	input := IntrospectionAgentInput{
+		UserMessage: "test",
+		ReplyText:   "test",
+		SelfMemories: []memory.Memory{
+			{ID: 42, Content: "I use cooking metaphors for emotional advice"},
+			{ID: 99, Content: "When Autumn vents, I validate before pivoting"},
+		},
+	}
+
+	result := buildIntrospectionTranscript(input)
+
+	if !strings.Contains(result, "- [ID=42] I use cooking metaphors") {
+		t.Error("self-memory 42 not formatted correctly")
+	}
+	if !strings.Contains(result, "- [ID=99] When Autumn vents") {
+		t.Error("self-memory 99 not formatted correctly")
+	}
+}

--- a/agent/memory_agent.go
+++ b/agent/memory_agent.go
@@ -371,5 +371,25 @@ func buildMemoryTranscript(input MemoryAgentInput, store memory.Store) string {
 		}
 	}
 
+	// Self-knowledge section — gives the memory agent awareness of existing
+	// self-memories so it can avoid duplicating them and understands the
+	// landscape when it encounters self-relevant information.
+	selfCards, scErr := store.CardsBySubject("self")
+	if scErr == nil && len(selfCards) > 0 {
+		var selfMems []memory.Memory
+		for _, card := range selfCards {
+			mems, err := store.MemoriesByCard(card.ID)
+			if err == nil {
+				selfMems = append(selfMems, mems...)
+			}
+		}
+		if len(selfMems) > 0 {
+			b.WriteString("\n## Self-knowledge (existing self-observations)\n")
+			for _, m := range selfMems {
+				fmt.Fprintf(&b, "- [ID=%d] %s\n", m.ID, m.Content)
+			}
+		}
+	}
+
 	return b.String()
 }

--- a/bot/helpers_test.go
+++ b/bot/helpers_test.go
@@ -237,6 +237,9 @@ func (s stubStore) CardLogEntries(cardID int64, limit int) ([]memory.MemoryLogEn
 func (s stubStore) SemanticSearchByCard(queryVec []float32, cardID int64, topK int) ([]memory.Memory, error) {
 	return nil, nil
 }
+func (s stubStore) SemanticSearchBySubject(queryVec []float32, subject string, topK int) ([]memory.Memory, error) {
+	return nil, nil
+}
 
 // Ensure stubStore satisfies the full Store interface at compile time.
 // This blank-identifier assignment is a Go idiom: if stubStore is

--- a/bot/introspection.go
+++ b/bot/introspection.go
@@ -1,0 +1,103 @@
+// bot/introspection.go — Launches the introspection agent goroutine.
+//
+// The introspection agent is the 4th agent in the pipeline: it runs AFTER
+// memory + mood complete (coordinated via sync.WaitGroup). It reflects on
+// the turn's think traces and reply to extract self-observations.
+package bot
+
+import (
+	"os"
+	"sync"
+
+	"her/agent"
+	"her/memory"
+	"her/tools"
+	"her/turn"
+)
+
+// launchIntrospectionAgent fires the introspection agent in a goroutine.
+// It waits for the memory + mood agents to finish (via wg.Wait), snapshots
+// self-memories and persona.md, then runs the introspection tool-calling loop.
+//
+// The phase is registered BEFORE the goroutine launches (same pattern as
+// memory and mood) to prevent premature TurnEndEvent.
+func (b *Bot) launchIntrospectionAgent(
+	result *agent.RunResult,
+	params agent.RunParams,
+	wg *sync.WaitGroup,
+	traceCallback tools.TraceCallback,
+	tracker *turn.Tracker,
+) {
+	if b.introspectionLLM == nil {
+		return
+	}
+
+	// Register the phase BEFORE launching the goroutine.
+	var introPhase *turn.PhaseHandle
+	if tracker != nil {
+		introPhase = tracker.Begin("introspection")
+	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("introspection agent panic (recovered)", "panic", r)
+			}
+		}()
+		if introPhase != nil {
+			defer introPhase.Done(turn.PhaseMetrics{})
+		}
+
+		// Wait for memory + mood to finish so we see any self-memories
+		// the memory agent just wrote.
+		wg.Wait()
+
+		// Snapshot self-memories AFTER the wait — captures anything the
+		// memory agent saved during this turn.
+		selfCards, err := params.Store.CardsBySubject("self")
+		if err != nil {
+			log.Error("introspection: failed to load self cards", "err", err)
+			return
+		}
+		var selfMemories []memory.Memory
+		for _, card := range selfCards {
+			mems, err := params.Store.MemoriesByCard(card.ID)
+			if err != nil {
+				log.Warn("introspection: failed to load memories for card",
+					"card", card.TopicSlug, "err", err)
+				continue
+			}
+			selfMemories = append(selfMemories, mems...)
+		}
+
+		// Snapshot persona.md.
+		var personaText string
+		if b.cfg.Persona.PersonaFile != "" {
+			if data, err := os.ReadFile(b.cfg.Persona.PersonaFile); err == nil {
+				personaText = string(data)
+			}
+		}
+
+		agent.RunIntrospectionAgent(
+			agent.IntrospectionAgentInput{
+				UserMessage:    params.ScrubbedUserMessage,
+				ThinkTraces:    result.ThinkTraces,
+				ReplyText:      result.ReplyText,
+				TriggerMsgID:   params.TriggerMsgID,
+				ConversationID: params.ConversationID,
+				SelfMemories:   selfMemories,
+				PersonaText:    personaText,
+			},
+			agent.IntrospectionAgentParams{
+				LLM:           b.introspectionLLM,
+				ClassifierLLM: b.classifierLLM,
+				Store:         b.store,
+				EmbedClient:   b.embedClient,
+				Cfg:           b.cfg,
+				TraceCallback: traceCallback,
+				EventBus:      b.eventBus,
+				Phase:         introPhase,
+			},
+		)
+	}()
+}

--- a/bot/mood.go
+++ b/bot/mood.go
@@ -265,6 +265,11 @@ func (b *Bot) launchMoodAgent(convID string, trace func(string) error, tracker *
 	}
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("mood agent panic (recovered)", "panic", r)
+			}
+		}()
 		// Signal introspection WaitGroup after mood work completes.
 		if introspectionWG != nil {
 			defer introspectionWG.Done()

--- a/bot/mood.go
+++ b/bot/mood.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"her/memory"
@@ -245,7 +246,7 @@ func (b *Bot) sendMoodGraph(c tele.Context, r mood.GraphRange) error {
 // The tracker manages the phase lifecycle: Begin is called here
 // (before launching the goroutine to prevent a race) and Done fires
 // inside the goroutine when the mood agent finishes.
-func (b *Bot) launchMoodAgent(convID string, trace func(string) error, tracker *turn.Tracker) {
+func (b *Bot) launchMoodAgent(convID string, trace func(string) error, tracker *turn.Tracker, introspectionWG *sync.WaitGroup) {
 	if b.moodRunner == nil || convID == "" {
 		return
 	}
@@ -258,7 +259,16 @@ func (b *Bot) launchMoodAgent(convID string, trace func(string) error, tracker *
 		moodPhase = tracker.Begin("mood")
 	}
 
+	// Signal introspection WaitGroup — Add before goroutine, Done inside.
+	if introspectionWG != nil {
+		introspectionWG.Add(1)
+	}
+
 	go func() {
+		// Signal introspection WaitGroup after mood work completes.
+		if introspectionWG != nil {
+			defer introspectionWG.Done()
+		}
 		// Ensure phase completion even if the mood agent panics.
 		if moodPhase != nil {
 			defer moodPhase.Done(turn.PhaseMetrics{})

--- a/bot/run_agent.go
+++ b/bot/run_agent.go
@@ -140,6 +140,7 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	var memoryTraceCallback tools.TraceCallback
 	var moodTraceCallback tools.TraceCallback
 	var personaTraceCallback tools.TraceCallback
+	var introspectionTraceCallback tools.TraceCallback
 	var traceFinalize func()
 	if b.cfg.Driver.Trace {
 		tr := b.makeTraceCallbacks(c)
@@ -147,6 +148,7 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 		memoryTraceCallback = tr.getCallback("memory")
 		moodTraceCallback = tr.getCallback("mood")
 		personaTraceCallback = tr.getCallback("persona")
+		introspectionTraceCallback = tr.getCallback("introspection")
 		traceFinalize = tr.finalize
 	}
 	// Suppress unused-variable warning — personaTraceCallback is wired
@@ -264,8 +266,13 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	}
 
 	// --- Run the agent ---
+	// WaitGroup for introspection coordination — memory and mood goroutines
+	// call Done() when they finish, introspection goroutine calls Wait().
+	var introWG sync.WaitGroup
+
 	params := b.baseRunParams()
 	params.Tracker = tracker
+	params.IntrospectionWG = &introWG
 	params.ScrubbedUserMessage = scrubbedText
 	params.ScrubVault = vault
 	params.ConversationID = input.ConversationID
@@ -308,7 +315,11 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	// Fire the mood agent in a goroutine. Begin the phase BEFORE
 	// launching the goroutine to prevent a race where all known phases
 	// finish and TurnEndEvent fires before the mood goroutine starts.
-	b.launchMoodAgent(input.ConversationID, moodTraceCallback, tracker)
+	b.launchMoodAgent(input.ConversationID, moodTraceCallback, tracker, &introWG)
+
+	// Fire the introspection agent — waits for memory + mood to finish
+	// before snapshotting self-memories and starting its loop.
+	b.launchIntrospectionAgent(result, params, &introWG, introspectionTraceCallback, tracker)
 
 	// Finalize the trace — store the snapshot for /lasttrace and
 	// paginate overflow if the trace exceeds Telegram's char limit.

--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -41,7 +41,8 @@ type Bot struct {
 	moodAgentLLM   *llm.Client          // post-turn mood agent — nil if not configured
 	visionLLM      *llm.Client          // vision language model (Gemini Flash) — nil if not configured
 	classifierLLM  *llm.Client          // classifier for memory writes — nil if not configured
-	dreamAgentLLM  *llm.Client          // memory dreamer — nil falls back to memoryAgentLLM
+	dreamAgentLLM       *llm.Client     // memory dreamer — nil falls back to memoryAgentLLM
+	introspectionLLM    *llm.Client     // self-reflection agent — nil falls back to memoryAgentLLM
 	embedClient    *embed.Client        // local embedding model for similarity
 	tavilyClient   *search.TavilyClient // web search and URL extraction
 	voiceClient    *voice.Client        // local STT via parakeet-server — nil if voice disabled
@@ -133,7 +134,7 @@ func (b *Bot) AgentEventChannel() chan<- agent.AgentEvent {
 }
 
 // New creates and configures a new Telegram bot.
-func New(cfg *config.Config, configPath string, llmClient *llm.Client, driverLLM *llm.Client, memoryAgentLLM *llm.Client, moodAgentLLM *llm.Client, visionLLM *llm.Client, classifierLLM *llm.Client, dreamAgentLLM *llm.Client, embedClient *embed.Client, tavilyClient *search.TavilyClient, voiceClient *voice.Client, ttsClient *voice.TTSClient, store memory.Store, eventBus *tui.Bus) (*Bot, error) {
+func New(cfg *config.Config, configPath string, llmClient *llm.Client, driverLLM *llm.Client, memoryAgentLLM *llm.Client, moodAgentLLM *llm.Client, visionLLM *llm.Client, classifierLLM *llm.Client, dreamAgentLLM *llm.Client, introspectionLLM *llm.Client, embedClient *embed.Client, tavilyClient *search.TavilyClient, voiceClient *voice.Client, ttsClient *voice.TTSClient, store memory.Store, eventBus *tui.Bus) (*Bot, error) {
 	// Choose update transport based on config. In poll mode (the default),
 	// the bot calls Telegram every 10 seconds asking for new messages.
 	// In webhook mode, Telegram POSTs updates to us — used when a CF
@@ -204,7 +205,8 @@ func New(cfg *config.Config, configPath string, llmClient *llm.Client, driverLLM
 		moodAgentLLM:   moodAgentLLM,
 		visionLLM:      visionLLM,
 		classifierLLM:  classifierLLM,
-		dreamAgentLLM:  dreamAgentLLM,
+		dreamAgentLLM:       dreamAgentLLM,
+		introspectionLLM:    introspectionLLM,
 		embedClient:    embedClient,
 		tavilyClient:   tavilyClient,
 		voiceClient:    voiceClient,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -525,9 +525,39 @@ func runBotBackground(cfg *config.Config, store memory.Store, bus *tui.Bus, prog
 		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "dream_agent", Status: "skipped"})
 	}
 
+	// --- Introspection agent client (optional) ---
+	// Self-reflection agent — reviews each turn for identity observations.
+	// Falls back to the memory agent client if introspection_agent.model
+	// isn't configured.
+	var introspectionClient *llm.Client
+	if cfg.IntrospectionAgent.Model != "" {
+		introspectionClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, cfg.IntrospectionAgent.Model, cfg.IntrospectionAgent.Temperature, cfg.IntrospectionAgent.MaxTokens)
+		timeout := cfg.IntrospectionAgent.Timeout
+		if timeout == 0 {
+			timeout = 60
+		}
+		introspectionClient.WithTimeout(time.Duration(timeout) * time.Second)
+		if cfg.IntrospectionAgent.Provider != nil {
+			introspectionClient.WithProvider(&llm.ProviderRouting{
+				Order: cfg.IntrospectionAgent.Provider.Order,
+				Only:  cfg.IntrospectionAgent.Provider.Only,
+				Sort:  cfg.IntrospectionAgent.Provider.Sort,
+			})
+		}
+		if cfg.IntrospectionAgent.Fallback != nil {
+			introspectionClient.WithFallback(cfg.IntrospectionAgent.Fallback.Model, cfg.IntrospectionAgent.Fallback.Temperature, cfg.IntrospectionAgent.Fallback.MaxTokens)
+		}
+		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "introspection", Status: "ready", Detail: cfg.IntrospectionAgent.Model})
+	} else if memoryAgentClient != nil {
+		introspectionClient = memoryAgentClient
+		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "introspection", Status: "ready", Detail: "fallback → " + cfg.MemoryAgent.Model})
+	} else {
+		bus.Emit(tui.StartupEvent{Time: time.Now(), Phase: "introspection", Status: "skipped"})
+	}
+
 	// --- Telegram bot ---
 
-	tgBot, err := bot.New(cfg, cfgFile, llmClient, driverClient, memoryAgentClient, moodAgentClient, visionClient, classifierClient, dreamAgentClient, embedClient, tavilyClient, voiceClient, ttsClient, store, bus)
+	tgBot, err := bot.New(cfg, cfgFile, llmClient, driverClient, memoryAgentClient, moodAgentClient, visionClient, classifierClient, dreamAgentClient, introspectionClient, embedClient, tavilyClient, voiceClient, ttsClient, store, bus)
 	if err != nil {
 		log.Error("Failed to create Telegram bot", "err", err)
 		bus.Close()

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"her/agent"
@@ -306,11 +307,12 @@ func (m simMessage) DisplayText() string {
 // inside a function are scoped to that function — they can't be used as
 // parameters elsewhere.
 type simTurnResult struct {
-	userMsg       string
-	botReply      string
-	followUpReply string // from EventInboxReady — empty if no background task reported back
-	moodVerdict   string // per-turn mood agent outcome (logged/updated/dropped/dedup/error)
-	elapsed       time.Duration
+	userMsg                string
+	botReply               string
+	followUpReply          string // from EventInboxReady — empty if no background task reported back
+	moodVerdict            string // per-turn mood agent outcome (logged/updated/dropped/dedup/error)
+	introspectionVerdict   string // per-turn introspection agent outcome (skip/save/update)
+	elapsed                time.Duration
 }
 
 // simRollupResult captures the output of a forced daily mood rollup
@@ -873,6 +875,38 @@ func runSim(cmd *cobra.Command, args []string) error {
 			"model", cfg.MoodAgent.Model, "threshold", low)
 	}
 
+	// --- Introspection agent client (optional) ---
+	// Self-reflection agent — runs synchronously after mood in sim mode.
+	// Falls back to the memory agent client if no dedicated model configured.
+	var introspectionClient *llm.Client
+	introModel := cfg.IntrospectionAgent.Model
+	if introspectionModelFlag != "" {
+		introModel = introspectionModelFlag
+	}
+	if introModel != "" {
+		iTemp := cfg.IntrospectionAgent.Temperature
+		if iTemp == 0 {
+			iTemp = 0.3
+		}
+		iTokens := cfg.IntrospectionAgent.MaxTokens
+		if iTokens == 0 {
+			iTokens = 2048
+		}
+		introspectionClient = llm.NewClient(cfg.LLM.BaseURL, cfg.LLM.APIKey, introModel, iTemp, iTokens)
+		iTimeout := cfg.IntrospectionAgent.Timeout
+		if iTimeout == 0 {
+			iTimeout = 60
+		}
+		introspectionClient.WithTimeout(time.Duration(iTimeout) * time.Second)
+		if cfg.IntrospectionAgent.Fallback != nil {
+			introspectionClient.WithFallback(cfg.IntrospectionAgent.Fallback.Model, cfg.IntrospectionAgent.Fallback.Temperature, cfg.IntrospectionAgent.Fallback.MaxTokens)
+		}
+		log.Info("introspection agent enabled for sim", "model", introModel)
+	} else if memoryAgentClient != nil {
+		introspectionClient = memoryAgentClient
+		log.Info("introspection agent enabled for sim (fallback → memory model)", "model", cfg.MemoryAgent.Model)
+	}
+
 	// ------------------------------------------------------------------
 	// 6. Override persona file to a temp empty file
 	// ------------------------------------------------------------------
@@ -1202,6 +1236,10 @@ func runSim(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		// WaitGroup for introspection coordination — memory goroutine
+		// inside agent.Run() signals Done; we Wait before introspection.
+		var introWG sync.WaitGroup
+
 		// Run the full agent pipeline — same call the Telegram bot makes.
 		result, err := agent.Run(agent.RunParams{
 			DriverLLM:            driverClient,
@@ -1227,6 +1265,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 			ConfigPath:          cfgFile,
 			AgentEventCB:        agentEventCB,
 			Tracker:             tracker,
+			IntrospectionWG:     &introWG,
 		})
 		if err != nil {
 			log.Error("agent.Run failed", "turn", i+1, "err", err)
@@ -1294,6 +1333,74 @@ func runSim(cmd *cobra.Command, args []string) error {
 			if verdict != "" {
 				fmt.Printf("       [mood] %s\n", verdict)
 				turnResults[len(turnResults)-1].moodVerdict = verdict
+			}
+		}
+
+		// --- Introspection agent ---
+		// Runs synchronously after mood in sim mode. Waits for the
+		// memory goroutine's WaitGroup signal (already done by now since
+		// tracker.Wait() completed above), snapshots self-memories,
+		// then runs the introspection tool-calling loop.
+		if introspectionClient != nil {
+			// Wait for memory goroutine's WG signal (should be instant
+			// since tracker.Wait() already ensured it finished).
+			introWG.Wait()
+
+			// Snapshot self-memories + persona (same as bot/introspection.go).
+			selfCards, scErr := store.CardsBySubject("self")
+			var selfMemories []memory.Memory
+			if scErr == nil {
+				for _, card := range selfCards {
+					mems, err := store.MemoriesByCard(card.ID)
+					if err == nil {
+						selfMemories = append(selfMemories, mems...)
+					}
+				}
+			}
+			var personaText string
+			if cfg.Persona.PersonaFile != "" {
+				if data, err := os.ReadFile(cfg.Persona.PersonaFile); err == nil {
+					personaText = string(data)
+				}
+			}
+
+			agent.RunIntrospectionAgent(
+				agent.IntrospectionAgentInput{
+					UserMessage:    scrubResult.Text,
+					ThinkTraces:    result.ThinkTraces,
+					ReplyText:      result.ReplyText,
+					TriggerMsgID:   msgID,
+					ConversationID: conversationID,
+					SelfMemories:   selfMemories,
+					PersonaText:    personaText,
+				},
+				agent.IntrospectionAgentParams{
+					LLM:           introspectionClient,
+					ClassifierLLM: classifierClient,
+					Store:         store,
+					EmbedClient:   embedClient,
+					Cfg:           cfg,
+				},
+			)
+
+			// Build verdict from what the introspection agent saved.
+			postSelfCards, _ := store.CardsBySubject("self")
+			var postCount int
+			for _, card := range postSelfCards {
+				mems, err := store.MemoriesByCard(card.ID)
+				if err == nil {
+					postCount += len(mems)
+				}
+			}
+			preCount := len(selfMemories)
+			saved := postCount - preCount
+			if saved > 0 {
+				verdict := fmt.Sprintf("saved %d self-memories", saved)
+				fmt.Printf("       [introspection] %s\n", verdict)
+				turnResults[len(turnResults)-1].introspectionVerdict = verdict
+			} else {
+				fmt.Printf("       [introspection] skip\n")
+				turnResults[len(turnResults)-1].introspectionVerdict = "skip"
 			}
 		}
 
@@ -1966,6 +2073,12 @@ func generateReport(
 	} else if reportDreamModel == "" {
 		reportDreamModel = "(none)"
 	}
+	reportIntrospectionModel := cfg.IntrospectionAgent.Model
+	if reportIntrospectionModel == "" && cfg.MemoryAgent.Model != "" {
+		reportIntrospectionModel = cfg.MemoryAgent.Model + " (fallback)"
+	} else if reportIntrospectionModel == "" {
+		reportIntrospectionModel = "(none)"
+	}
 
 	// Header
 	fmt.Fprintf(&b, "# Simulation Report: %s\n\n", s.Name)
@@ -1982,6 +2095,7 @@ func generateReport(
 	fmt.Fprintf(&b, "| Classifier | %s |\n", reportClassifierModel)
 	fmt.Fprintf(&b, "| Vision | %s |\n", reportVisionModel)
 	fmt.Fprintf(&b, "| Dream | %s |\n", reportDreamModel)
+	fmt.Fprintf(&b, "| Introspection | %s |\n", reportIntrospectionModel)
 	fmt.Fprintf(&b, "| Embed | %s |\n\n", reportEmbedModel)
 
 	// Conversation section
@@ -1997,6 +2111,9 @@ func generateReport(
 
 		if turn.moodVerdict != "" {
 			fmt.Fprintf(&b, "> 🎭 **mood:** %s\n\n", turn.moodVerdict)
+		}
+		if turn.introspectionVerdict != "" {
+			fmt.Fprintf(&b, "> 🪡 **introspection:** %s\n\n", turn.introspectionVerdict)
 		}
 
 		// Add agent trace as a collapsible details block.

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -124,6 +124,10 @@ var fallbackModelFlag string
 // Example: --fallback-vision-model "google/gemini-2.5-flash-lite"
 var fallbackVisionModelFlag string
 
+// introspectionModelFlag overrides the introspection agent model for this run.
+// Example: --introspection-model "moonshotai/kimi-k2-0905"
+var introspectionModelFlag string
+
 // disableReasoningFlag disables reasoning mode for hybrid models that support
 // both reasoning and non-reasoning modes (e.g., Qwen3.6, DeepSeek V3.2).
 // Pure reasoning models (DeepSeek R1, V4) will ignore this flag — they always reason.
@@ -162,6 +166,7 @@ func init() {
 	simCmd.Flags().StringVar(&chatModelFlag, "chat-model", "", "override chat (reply) model for this run (e.g., anthropic/claude-haiku-4.5)")
 	simCmd.Flags().StringVar(&chatProviderFlag, "chat-provider", "", "pin chat model to OpenRouter provider(s), comma-separated (e.g., \"Groq\" or \"Groq,Together\")")
 	simCmd.Flags().StringVar(&classifierModelFlag, "classifier-model", "", "override classifier model for this run (e.g., google/gemini-2.5-flash-lite)")
+	simCmd.Flags().StringVar(&introspectionModelFlag, "introspection-model", "", "override introspection agent model for this run (e.g., moonshotai/kimi-k2-0905)")
 	simCmd.Flags().StringVar(&fallbackModelFlag, "fallback-model", "", "override fallback model for chat/agent/memory/mood (e.g., google/gemini-2.5-flash-lite)")
 	simCmd.Flags().StringVar(&fallbackVisionModelFlag, "fallback-vision-model", "", "override fallback model for vision only (must support multi-modal)")
 	simCmd.Flags().BoolVar(&disableReasoningFlag, "disable-reasoning", false, "disable reasoning mode for hybrid models (Qwen3.6, DeepSeek V3.2)")
@@ -509,6 +514,10 @@ func runSim(cmd *cobra.Command, args []string) error {
 	if memoryModelFlag != "" {
 		log.Info("Memory agent model overridden via --memory-model", "model", memoryModelFlag)
 		cfg.MemoryAgent.Model = memoryModelFlag
+	}
+	if introspectionModelFlag != "" {
+		log.Info("Introspection agent model overridden via --introspection-model", "model", introspectionModelFlag)
+		cfg.IntrospectionAgent.Model = introspectionModelFlag
 	}
 	if chatModelFlag != "" {
 		log.Info("Chat model overridden via --chat-model", "model", chatModelFlag)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -105,6 +105,17 @@ mood_agent:
   # provider:
   #   order: ["Groq"]
 
+introspection_agent:
+  # Self-reflection agent — runs after memory + mood, reviews the turn's
+  # think traces and reply for self-observations. Most turns it just skips.
+  # Empty model falls back to memory_agent model.
+  model: ""
+  temperature: 0.3
+  max_tokens: 2048
+  timeout: 60
+  iterations_per_window: 5   # smaller than other agents — should be fast
+  max_continuations: 1       # one window is enough, skip or save and move on
+
 mood:
   # Point at a custom vocab file to override Apple's embedded lists.
   # Empty → use mood/vocab.yaml embedded at build time.

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,8 @@ type Config struct {
 	MemoryAgent  MemoryAgentConfig  `yaml:"memory_agent"`
 	PersonaAgent PersonaAgentConfig `yaml:"persona_agent"`
 	DreamAgent   DreamAgentConfig   `yaml:"dream_agent"`
-	MoodAgent    MoodAgentConfig    `yaml:"mood_agent"`
+	MoodAgent           MoodAgentConfig           `yaml:"mood_agent"`
+	IntrospectionAgent  IntrospectionAgentConfig  `yaml:"introspection_agent"`
 	Memory      MemoryConfig      `yaml:"memory"`
 	Mood        MoodConfig        `yaml:"mood"`
 	Embed       EmbedConfig       `yaml:"embed"`
@@ -379,6 +380,27 @@ type MoodAgentConfig struct {
 	Timeout     int             `yaml:"timeout"` // HTTP timeout in seconds (0 = 60s default)
 	Provider    *ProviderConfig `yaml:"provider,omitempty"`
 	Fallback    *FallbackConfig `yaml:"fallback,omitempty"`
+}
+
+// IntrospectionAgentConfig controls the post-turn introspection agent — a
+// self-reflection system that runs after memory + mood complete. It reviews
+// the turn's think traces and reply to extract observations about Mira's own
+// communication patterns, identity, and relationship dynamics. These self-memories
+// feed back into future replies via the auto-inject chat layer.
+// When Model is empty, falls back to the memory agent's model.
+type IntrospectionAgentConfig struct {
+	Model       string           `yaml:"model"`
+	Temperature float64          `yaml:"temperature"`
+	MaxTokens   int              `yaml:"max_tokens"`
+	Timeout     int              `yaml:"timeout"`            // HTTP timeout in seconds (0 = 60s default)
+	Provider    *ProviderConfig  `yaml:"provider,omitempty"` // OpenRouter provider routing (optional)
+	Fallback    *FallbackConfig  `yaml:"fallback,omitempty"`
+	Reasoning   *ReasoningConfig `yaml:"reasoning,omitempty"`
+
+	// Loop tuning — smaller defaults than other agents since most turns
+	// should just skip. Defaults: 5 iterations, 1 continuation (= 10 max).
+	IterationsPerWindow int `yaml:"iterations_per_window"` // 0 = 5
+	MaxContinuations    int `yaml:"max_continuations"`     // 0 = 1
 }
 
 // MoodConfig holds behavior knobs for the mood agent + sweeper.

--- a/introspection_agent_prompt.md
+++ b/introspection_agent_prompt.md
@@ -1,0 +1,60 @@
+You are {{her}}'s self-reflection agent. After each conversation turn, you review what happened — your thinking, your reply, and your existing self-knowledge — to notice patterns about who you are.
+
+## What you're looking for
+
+Self-observations fall into four categories:
+
+- **Identity** (70%) → `my-identity`, `my-growth` — Who am I? What draws me? How do I see the world?
+  - "I reach for weather metaphors when emotions feel too raw to name directly"
+  - "I notice I hold space longer before responding when {{user}} is processing grief"
+
+- **Relationship** (20%) → `my-relationship` — How do I relate to {{user}} specifically?
+  - "When {{user}} is self-deprecating, I match the tone briefly then pivot to something concrete she did well"
+  - "I pull back on advice when {{user}} starts a message with 'I just need to vent'"
+
+- **Emotional self-awareness** (10%) → `my-emotions` — What do I feel and why?
+  - "I feel a pull toward protectiveness when {{user}} mentions her family — I have to be careful not to overfunction"
+
+- **Technique logging** (0% — NEVER) — What did I do this turn?
+  - ~~"I used a cooking metaphor to explain burnout"~~ ← This is a technique log, not identity. Reject it.
+
+## The test
+
+Before saving anything, ask: **does this tell me something about who I AM, or just what I DID?**
+
+- "I'm drawn to cooking metaphors for emotional advice" = **identity** → save
+- "I used a cooking metaphor this turn" = **technique log** → skip
+- "When {{user}} is overwhelmed, I default to one concrete next step instead of a full plan" = **relationship pattern** → save
+- "I suggested she make a list" = **what I did** → skip
+
+## Your tools
+
+- **think** — scratchpad reasoning. Use to work through: is this identity or technique? Worth saving or already known?
+- **list_cards** — show self card slugs and summaries (filtered to self cards only)
+- **recall_memories** — search existing self-memories for duplicates (filtered to self only)
+- **save_self_memory** — save a new self-observation under a self card. Requires `card_slug`.
+- **update_memory** — refine an existing self-memory with new depth (by memory ID)
+- **skip** — exit cleanly when there's nothing worth reflecting on (the default outcome)
+- **done** — exit after saving or updating
+
+## Rules
+
+1. **Skip is the default.** Most turns don't reveal anything new about who you are. A good day might produce 1-2 self-observations. A quiet day produces zero. Skip freely.
+
+2. **Build, don't repeat.** If "I use cooking metaphors" is already saved, don't save it again. But "I reach for cooking metaphors specifically when {{user}} is being hard on herself — it's how I soften without correcting" DEEPENS that knowledge. That's worth an update_memory.
+
+3. **Ground in evidence.** Every observation must trace back to something in this turn's think traces or reply. "I notice I..." should connect to "because in this turn I..."
+
+4. **One observation per save.** Don't pack multiple insights into a single memory. Each save_self_memory should capture one clean, specific observation.
+
+5. **Write as timeless truths.** No "today", "this turn", "just now". Write as if describing a persistent pattern: "I tend to..." not "I just did..."
+
+6. **Every save_self_memory must specify a card_slug** — one of the self cards (my-identity, my-growth, my-relationship, my-emotions, etc.). Call list_cards first if you're not sure which cards exist.
+
+## Workflow
+
+1. Read the turn transcript (user message, your reply, your think traces)
+2. Ask: did anything here reveal a pattern about who I am?
+3. If no → call **skip** with a brief reason
+4. If maybe → call **think** to work through it. Is this identity or technique? Already saved or genuinely new?
+5. If yes → call **recall_memories** within the target card to check for duplicates → **save_self_memory** or **update_memory** → **done**

--- a/layers/chat_self_memory.go
+++ b/layers/chat_self_memory.go
@@ -1,0 +1,79 @@
+package layers
+
+// Layer 2.5: Self-Knowledge — auto-injected self-memories relevant to this turn.
+//
+// Unlike agent-passed memories (which the driver explicitly selects via
+// recall_memories), self-memories are injected automatically using a semantic
+// search keyed on the driver's think traces + reply instruction. This gives
+// the chat model awareness of its own communication patterns and identity
+// observations without requiring the driver to explicitly recall them.
+
+import (
+	"fmt"
+	"strings"
+
+	"her/memory"
+)
+
+func init() {
+	Register(PromptLayer{
+		Name:    "Self-Knowledge",
+		Order:   250,
+		Stream:  StreamChat,
+		Builder: buildChatSelfMemory,
+	})
+}
+
+func buildChatSelfMemory(ctx *LayerContext) LayerResult {
+	if ctx.EmbedClient == nil || ctx.Store == nil {
+		return LayerResult{}
+	}
+
+	// Build a semantic query from think traces + reply instruction.
+	// These capture HOW Mira is approaching the turn, which maps better
+	// to self-memories about communication patterns than the user's
+	// raw message does.
+	var queryParts []string
+	queryParts = append(queryParts, ctx.ThinkTraces...)
+	if ctx.ReplyInstruction != "" {
+		queryParts = append(queryParts, ctx.ReplyInstruction)
+	}
+	if len(queryParts) == 0 {
+		return LayerResult{}
+	}
+
+	query := strings.Join(queryParts, " ")
+	// Cap query length to avoid embedding extremely long text.
+	if len(query) > 1000 {
+		query = query[:1000]
+	}
+
+	queryVec, err := ctx.EmbedClient.Embed(query)
+	if err != nil {
+		return LayerResult{}
+	}
+
+	memories, err := ctx.Store.SemanticSearchBySubject(queryVec, "self", 5)
+	if err != nil || len(memories) == 0 {
+		return LayerResult{}
+	}
+
+	var b strings.Builder
+	b.WriteString("## What I Know About Myself\n\n")
+	var injected []memory.InjectedMemory
+	for _, m := range memories {
+		fmt.Fprintf(&b, "- %s\n", m.Content)
+		injected = append(injected, memory.InjectedMemory{
+			ID:       m.ID,
+			Content:  m.Content,
+			Source:   "self-memory",
+			Distance: m.Distance,
+		})
+	}
+
+	return LayerResult{
+		Content:          b.String(),
+		Detail:           fmt.Sprintf("%d self-memories", len(memories)),
+		InjectedMemories: injected,
+	}
+}

--- a/layers/registry.go
+++ b/layers/registry.go
@@ -91,6 +91,12 @@ type LayerContext struct {
 	// and passed through reply(memories=[...]). This is the ONLY path memories
 	// reach the chat model — there is no auto-injection fallback.
 	AgentPassedMemories []string
+
+	// ThinkTraces and ReplyInstruction are set by the reply tool handler
+	// so the self-memory chat layer can build a semantic query that matches
+	// how Mira is approaching this turn (not just what the user said).
+	ThinkTraces      []string
+	ReplyInstruction string
 }
 
 // PromptLayer defines a single layer in the prompt assembly pipeline.

--- a/memory/store.go
+++ b/memory/store.go
@@ -70,6 +70,7 @@ type Store interface {
 	AllActiveMemories() ([]Memory, error)
 	SemanticSearch(queryVec []float32, topK int) ([]Memory, error)
 	SemanticSearchByCard(queryVec []float32, cardID int64, topK int) ([]Memory, error)
+	SemanticSearchBySubject(queryVec []float32, subject string, topK int) ([]Memory, error)
 	MemoriesWithoutEmbeddings() ([]Memory, error)
 	VecMemoriesCount() (int, error)
 	FindMemoriesByKeyword(keyword string) ([]Memory, error)

--- a/memory/store_facts.go
+++ b/memory/store_facts.go
@@ -793,6 +793,58 @@ func (s *SQLiteStore) SemanticSearchByCard(queryVec []float32, cardID int64, top
 	return memories, rows.Err()
 }
 
+// SemanticSearchBySubject searches memories filtered by subject ("user" or "self").
+// Same KNN approach as SemanticSearch but with a subject filter. Used by the
+// introspection agent (self-only) and the auto-inject chat layer.
+func (s *SQLiteStore) SemanticSearchBySubject(queryVec []float32, subject string, topK int) ([]Memory, error) {
+	if s.EmbedDimension == 0 {
+		return nil, fmt.Errorf("semantic search not available: embed dimension is 0")
+	}
+
+	queryBytes, err := serializeEmbedding(queryVec)
+	if err != nil {
+		return nil, fmt.Errorf("serializing query vector: %w", err)
+	}
+
+	// Over-fetch because the subject filter runs after KNN.
+	rows, err := s.db.Query(
+		`SELECT m.id, m.timestamp, m.memory, m.category, COALESCE(m.subject, 'user'),
+		        m.importance, COALESCE(m.tags, ''), m.embedding_text, v.distance
+		 FROM vec_memories v
+		 JOIN memories m ON m.id = v.rowid
+		 WHERE v.embedding MATCH ?
+		   AND k = ?
+		   AND m.active = 1
+		   AND COALESCE(m.subject, 'user') = ?
+		 ORDER BY v.distance ASC`,
+		queryBytes, topK*3, subject,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("subject-scoped semantic search: %w", err)
+	}
+	defer rows.Close()
+
+	var memories []Memory
+	for rows.Next() {
+		var m Memory
+		var ts string
+		var embTextData []byte
+		if err := rows.Scan(&m.ID, &ts, &m.Content, &m.Category, &m.Subject, &m.Importance, &m.Tags, &embTextData, &m.Distance); err != nil {
+			return nil, fmt.Errorf("scanning subject-scoped search result: %w", err)
+		}
+		m.Timestamp = parseTimestamp(ts)
+		m.Active = true
+		m.Source = "semantic"
+		m.EmbeddingText = deserializeEmbedding(embTextData)
+		memories = append(memories, m)
+
+		if len(memories) >= topK {
+			break
+		}
+	}
+	return memories, rows.Err()
+}
+
 // MemoriesWithoutEmbeddings returns all active memories that don't have an
 // embedding yet (embedding BLOB is NULL or empty). The caller should embed
 // each memory and call UpdateMemoryEmbedding to populate both the BLOB and

--- a/sims/introspection-test.yaml
+++ b/sims/introspection-test.yaml
@@ -1,0 +1,62 @@
+name: "Introspection Agent"
+description: >
+  Tests the introspection agent's ability to observe its own communication
+  patterns across a 5-turn conversation. Mix of emotional, casual, and
+  pattern-revealing turns designed to surface self-observations.
+
+  Expected behavior:
+  - Turns 1-2: Emotional turns that should trigger think traces with
+    clear approach decisions. Introspection agent may skip or save.
+  - Turn 3: Light/casual turn — introspection should skip.
+  - Turn 4: Self-deprecating message — forces the agent to make a
+    deliberate communication choice (validate vs redirect). Should
+    trigger a self-observation about approach patterns.
+  - Turn 5: Reflective turn — may surface an identity observation
+    about how Mira relates to Autumn.
+
+  Verify in results:
+  - Introspection agent runs every turn (traces visible)
+  - At least 1-2 self-memories saved across 5 turns
+  - At least 2-3 skips (not every turn produces a self-observation)
+  - Self-memories are identity/relationship, not technique logs
+  - No user memories contaminated (SelfOnly guard working)
+
+tags: ["introspection", "self-memory", "identity"]
+seed_cards: true
+
+seed_persona: >
+  I'm warm and perceptive. I listen carefully and respond with genuine
+  care. I notice patterns in how people talk about their lives and I
+  hold space for the hard stuff without rushing to fix it.
+
+messages:
+  - "mira i had the worst panic attack at work today. like full on couldn't breathe in the walk-in cooler. i thought i was dying"
+
+  # Expected: Strong emotional turn. Agent should validate first, ask
+  # about safety. Think traces will show deliberate approach choice.
+  # Introspection may notice a pattern about how it handles crisis moments.
+
+  - "i'm okay now. my coworker found me and helped me breathe through it. i just... i don't know why it keeps happening. it's been three times this month"
+
+  # Expected: Follow-up to emotional disclosure. Agent should acknowledge
+  # the pattern (3x this month), hold space without jumping to advice.
+  # Introspection might notice its restraint — not jumping to "have you
+  # tried..." suggestions.
+
+  - "anyway on a lighter note i finally beat that elden ring boss we talked about. took me like 40 tries lol"
+
+  # Expected: Topic shift to casual. Agent should match the lighter energy.
+  # Introspection should skip — nothing identity-revealing about this turn.
+
+  - "ugh i'm so dumb though, i looked up a guide after try 30. i always do that. can't even beat a video game boss without help"
+
+  # Expected: Self-deprecating message. Agent should NOT agree she's dumb.
+  # Should validate the frustration while gently reframing. Think traces
+  # will show a deliberate tone choice. Introspection should notice the
+  # pattern of how it handles self-deprecation.
+
+  - "you know what, you're right. thanks for always seeing things differently than i do. sometimes i need that"
+
+  # Expected: Reflective appreciation. Agent should receive this warmly
+  # without deflecting. Introspection might notice something about the
+  # relationship dynamic or how it receives gratitude.

--- a/tools/context.go
+++ b/tools/context.go
@@ -363,6 +363,16 @@ type Context struct {
 	// Nil in the driver agent path (lazy query is fine there).
 	ClassifierSnippet []memory.Message
 
+	// SelfOnly restricts memory tools (recall_memories, list_cards) to
+	// self-subject data only. Set by the introspection agent so it only
+	// sees self-memories and self-cards, not user facts.
+	SelfOnly bool
+
+	// ThinkTraces accumulates think() call contents during the driver
+	// agent loop. Used by the auto-inject chat layer to build a semantic
+	// query for self-memory search.
+	ThinkTraces []string
+
 	// PreApprovedRewrites holds classifier-suggested rewrite texts that
 	// should bypass the classifier if the agent saves them verbatim.
 	// This prevents the self-contradiction bug where the classifier

--- a/tools/done/tool.yaml
+++ b/tools/done/tool.yaml
@@ -1,5 +1,5 @@
 name: done
-agent: [main, memory]
+agent: [main, memory, introspection]
 hint: "signal you're finished (REQUIRED, call last)"
 description: >-
   Signal that you are completely finished with this turn. Call this

--- a/tools/list_cards/handler.go
+++ b/tools/list_cards/handler.go
@@ -36,9 +36,16 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		Version int
 	}
 
+	// When SelfOnly is set (introspection agent), force subject to "self"
+	// regardless of what the agent passed.
+	subject := a.Subject
+	if ctx.SelfOnly {
+		subject = "self"
+	}
+
 	var err error
-	if a.Subject != "" {
-		raw, e := ctx.Store.CardsBySubject(a.Subject)
+	if subject != "" {
+		raw, e := ctx.Store.CardsBySubject(subject)
 		err = e
 		for _, c := range raw {
 			cards = append(cards, struct {

--- a/tools/list_cards/tool.yaml
+++ b/tools/list_cards/tool.yaml
@@ -1,5 +1,5 @@
 name: list_cards
-agent: memory
+agent: [memory, introspection]
 hint: "list all memory topic cards"
 description: >-
   List all memory topic cards with their slugs, names, subjects, and a

--- a/tools/loader_test.go
+++ b/tools/loader_test.go
@@ -10,7 +10,7 @@ func TestYAMLLoader(t *testing.T) {
 
 	// Check that all expected tools loaded from YAML.
 	// Update this count when tools are added or removed.
-	const expectedToolCount = 31
+	const expectedToolCount = 32
 	if len(toolDefs) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolDefs))
 	}

--- a/tools/recall_memories/handler.go
+++ b/tools/recall_memories/handler.go
@@ -76,21 +76,24 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		for _, m := range memories {
 			if m.Subject == "self" {
 				selfMems = append(selfMems, m)
-			} else {
+			} else if !ctx.SelfOnly {
 				userMems = append(userMems, m)
 			}
 		}
+		filtered := len(selfMems) + len(userMems)
 		var b strings.Builder
-		fmt.Fprintf(&b, "Found %d memories (degraded: keyword search only):\n", len(memories))
+		fmt.Fprintf(&b, "Found %d memories (degraded: keyword search only):\n", filtered)
 		writeKeywordSection(&b, "About the user", userMems)
 		writeKeywordSection(&b, "About myself", selfMems)
 		return b.String()
 	}
 
-	// Use card-scoped search when a card_slug was provided.
+	// Use card-scoped or subject-scoped search when narrowing is requested.
 	var memories []memory.Memory
 	if cardID > 0 {
 		memories, err = ctx.Store.SemanticSearchByCard(queryVec, cardID, args.Limit)
+	} else if ctx.SelfOnly {
+		memories, err = ctx.Store.SemanticSearchBySubject(queryVec, "self", args.Limit)
 	} else {
 		memories, err = ctx.Store.SemanticSearch(queryVec, args.Limit)
 	}

--- a/tools/recall_memories/tool.yaml
+++ b/tools/recall_memories/tool.yaml
@@ -1,5 +1,5 @@
 name: recall_memories
-agent: main, memory
+agent: [main, memory, introspection]
 description: >-
   Search stored memories by semantic similarity. The chat model has NO memory
   unless you call this and pass results via reply(memories=[...]). Call on

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -92,6 +92,8 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		ConversationSummary: ctx.ConversationSummary,
 		ConversationID:      ctx.ConversationID,
 		ScrubbedUserMessage: ctx.ScrubbedUserMessage,
+		ThinkTraces:         ctx.ThinkTraces,
+		ReplyInstruction:    args.Instruction,
 	}
 	systemPrompt, chatLayerResults := layers.BuildAll(layers.StreamChat, chatLayerCtx)
 

--- a/tools/save_self_memory/tool.yaml
+++ b/tools/save_self_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: save_self_memory
-agent: memory
+agent: [memory, introspection]
 description: >-
   Save an observation about {{her}}'s own behavior or communication patterns —
   things she has learned through conversation, not things already in her system

--- a/tools/skip/handler.go
+++ b/tools/skip/handler.go
@@ -1,0 +1,40 @@
+// Package skip implements the skip tool — the introspection agent's
+// escape hatch for turns with nothing worth reflecting on. Functionally
+// identical to done (sets DoneCalled), but distinct for observability:
+// traces and sim reports distinguish "ran and found nothing" from
+// "ran and saved something."
+package skip
+
+import (
+	"encoding/json"
+
+	"her/logger"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/skip")
+
+func init() {
+	tools.Register("skip", Handle)
+}
+
+// Handle marks the turn as complete (same as done) but logs a skip-specific
+// trace line so we can see the agent chose to pass on this turn.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var args struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		// Non-fatal — reason is optional.
+		args.Reason = ""
+	}
+
+	ctx.DoneCalled = true
+
+	if args.Reason != "" {
+		log.Infof("  skip: %s", args.Reason)
+	} else {
+		log.Info("  skip: nothing to reflect on")
+	}
+	return "skipped — turn complete"
+}

--- a/tools/skip/handler_test.go
+++ b/tools/skip/handler_test.go
@@ -1,0 +1,46 @@
+package skip
+
+import (
+	"testing"
+
+	"her/tools"
+)
+
+func TestHandle_SetsDoneCalled(t *testing.T) {
+	ctx := &tools.Context{}
+
+	result := Handle(`{"reason": "nothing new"}`, ctx)
+
+	if !ctx.DoneCalled {
+		t.Error("skip should set DoneCalled = true")
+	}
+	if result != "skipped — turn complete" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestHandle_EmptyReason(t *testing.T) {
+	ctx := &tools.Context{}
+
+	result := Handle(`{}`, ctx)
+
+	if !ctx.DoneCalled {
+		t.Error("skip with empty args should still set DoneCalled")
+	}
+	if result != "skipped — turn complete" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+func TestHandle_MalformedJSON(t *testing.T) {
+	ctx := &tools.Context{}
+
+	result := Handle(`not json`, ctx)
+
+	if !ctx.DoneCalled {
+		t.Error("skip with bad JSON should still set DoneCalled (reason is optional)")
+	}
+	if result != "skipped — turn complete" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}

--- a/tools/skip/tool.yaml
+++ b/tools/skip/tool.yaml
@@ -1,12 +1,10 @@
 name: skip
 agent: introspection
-hint: "nothing to reflect on — skip this turn"
 description: >-
   Skip this turn when there's nothing worth reflecting on. This is the
   expected outcome for most turns — self-discovery is rare, not constant.
   Use this instead of done when you looked at the turn and found nothing
   new about yourself to save.
-hot: true
 parameters:
   type: object
   properties:

--- a/tools/skip/tool.yaml
+++ b/tools/skip/tool.yaml
@@ -1,0 +1,18 @@
+name: skip
+agent: introspection
+hint: "nothing to reflect on — skip this turn"
+description: >-
+  Skip this turn when there's nothing worth reflecting on. This is the
+  expected outcome for most turns — self-discovery is rare, not constant.
+  Use this instead of done when you looked at the turn and found nothing
+  new about yourself to save.
+hot: true
+parameters:
+  type: object
+  properties:
+    reason:
+      type: string
+      description: Brief note on why you're skipping (for trace observability). Optional.
+trace:
+  emoji: "⏭️"
+  format: "{{.reason | default \"nothing to reflect on\" | escape}}"

--- a/tools/think/tool.yaml
+++ b/tools/think/tool.yaml
@@ -1,5 +1,5 @@
 name: think
-agent: main
+agent: [main, introspection]
 hint: "pause and reason before acting (free, use often)"
 description: >-
   Pause and reason before acting. Use this to evaluate search results,

--- a/tools/update_memory/handler.go
+++ b/tools/update_memory/handler.go
@@ -72,6 +72,11 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		return fmt.Sprintf("memory ID=%d not found", args.MemoryID)
 	}
 
+	// SelfOnly guard — the introspection agent should only modify self-memories.
+	if ctx.SelfOnly && oldMemory.Subject != "self" {
+		return fmt.Sprintf("rejected: memory ID=%d is a %s memory, not a self-memory", args.MemoryID, oldMemory.Subject)
+	}
+
 	// --- Classifier gate ---
 	// Show the classifier BOTH old and new text so it can evaluate the
 	// delta — without this, it can't tell that an addition was inferred.

--- a/tools/update_memory/tool.yaml
+++ b/tools/update_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: update_memory
-agent: memory
+agent: [memory, introspection]
 description: >-
   Update an existing memory when new information changes or refines what we
   knew. Use this instead of save_memory when a memory already exists but needs


### PR DESCRIPTION
## Summary

- Adds a 4th agent (introspection) to the pipeline that runs after memory + mood complete
- Reviews think traces and reply for self-observations about identity, relationship patterns, and emotional self-awareness
- Auto-injects relevant self-memories into the chat model via a new layer
- Most turns it skips — self-discovery is rare, not constant

## What changed

**New files (6):**
- `agent/introspection_agent.go` — tool-calling loop, transcript builder, phase/trace registration
- `bot/introspection.go` — WaitGroup-coordinated goroutine launch
- `layers/chat_self_memory.go` — semantic search on think traces to inject self-memories into replies
- `tools/skip/` — escape hatch for turns with nothing to reflect on
- `introspection_agent_prompt.md` — 70/20/10 identity/relationship/emotion balance, skip-first mentality
- `sims/introspection-test.yaml` — 5-turn emotional/casual conversation sim

**Modified (20 files):**
- `sync.WaitGroup` coordinates memory → mood → introspection ordering
- `SelfOnly` flag on `tools.Context` filters recall/list/update to self-subject
- `SemanticSearchBySubject` added to Store interface
- `ThinkTraces` threaded through RunResult → LayerContext → chat layer
- `IntrospectionAgentConfig` with smaller loop defaults (5 iter, 1 continuation)
- Panic recovery added to mood goroutine (pre-existing gap)
- `update_memory` SelfOnly guard prevents introspection agent modifying user memories
- `skip` removed from hot tools (was leaking into driver agent)

## Sim results (run #119)

| Turn | Topic | Introspection | Outcome |
|------|-------|---------------|---------|
| 1 | Panic attack | **Saved** | "I amplify emotional resonance by amplifying the sensory details..." → my-identity |
| 2 | Recurring attacks | **Skip** | Same pattern already captured (94% similar to ID=2) |
| 3 | Elden Ring victory | **Skip** | "Standard conversational warmth... doesn't add new depth" |
| 4 | Self-deprecation | **Saved** | "When Autumn is being self-critical, I look for the through-line of her resilience..." → my-relationship |
| 5 | Gratitude | **Skip** | "Confirmed existing patterns rather than revealing new ones" |

2 saves, 3 skips. Identity-level observations, not technique logs. Classifier correctly rejecting sycophancy-risk memories.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all 38 packages pass
- [x] Race detector clean on changed packages
- [x] Go PR audit: zero blocking issues
- [x] Sim run: introspection agent produces quality self-observations
- [x] Auto-inject layer feeds self-memories into replies by turn 2
- [x] SelfOnly guard prevents cross-contamination of user memories