### PR TITLE
feat: YAML-driven tool loading — make agent field functional

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -102,7 +102,7 @@ func loadAgentPrompt(path string, cfg *config.Config) string {
 // Markers look like <!-- BEGIN HOT_TOOLS --> ... <!-- END HOT_TOOLS -->.
 // If markers are missing, the content is returned unchanged.
 func expandToolSections(content string) string {
-	content = replaceBetweenMarkers(content, "HOT_TOOLS", tools.RenderHotToolsList())
+	content = replaceBetweenMarkers(content, "HOT_TOOLS", tools.RenderHotToolsList("main"))
 	content = replaceBetweenMarkers(content, "CATEGORY_TABLE", tools.RenderCategoryTable())
 	return content
 }
@@ -357,10 +357,11 @@ func Run(params RunParams) (*RunResult, error) {
 	// Start with only the hot tools (7 instead of 26). The agent can
 	// load deferred tools on demand via use_tools(["search"]) etc.
 	// This reduces context pressure on the agent model significantly.
-	toolDefs := tools.HotToolDefs(params.Cfg)
+	toolDefs := tools.HotToolDefs("main", params.Cfg)
 
 	// Build the tool context with everything the tools need.
 	tctx := &tools.Context{
+		AgentName:                 "main",
 		Store:                     params.Store,
 		EmbedClient:               params.EmbedClient,
 		SimilarityThreshold:       params.SimilarityThreshold,

--- a/agent/introspection_agent.go
+++ b/agent/introspection_agent.go
@@ -101,6 +101,7 @@ func RunIntrospectionAgent(input IntrospectionAgentInput, params IntrospectionAg
 	// Build tools.Context with SelfOnly=true — recall_memories and list_cards
 	// will only return self-subject data.
 	tctx := &tools.Context{
+		AgentName:           "introspection",
 		Store:               params.Store,
 		EmbedClient:         params.EmbedClient,
 		SimilarityThreshold: params.Cfg.Embed.SimilarityThreshold,
@@ -115,11 +116,8 @@ func RunIntrospectionAgent(input IntrospectionAgentInput, params IntrospectionAg
 		Phase:               params.Phase,
 	}
 
-	// Tool set for the introspection agent — self-reflection tools only.
-	introToolDefs := tools.LookupToolDefs(
-		[]string{"think", "list_cards", "recall_memories", "save_self_memory", "update_memory", "skip", "done"},
-		params.Cfg,
-	)
+	// Tool set for the introspection agent — driven by tool.yaml agent fields.
+	introToolDefs := tools.ToolDefsForAgent("introspection", params.Cfg)
 
 	messages := []llm.ChatMessage{
 		{Role: "system", Content: promptContent},

--- a/agent/memory_agent.go
+++ b/agent/memory_agent.go
@@ -127,6 +127,7 @@ func RunMemoryAgent(input MemoryAgentInput, params MemoryAgentParams) {
 	// fact_helpers doesn't re-query the DB (which may have newer messages
 	// from subsequent turns by the time classification runs).
 	tctx := &tools.Context{
+		AgentName:           "memory",
 		Store:               params.Store,
 		EmbedClient:         params.EmbedClient,
 		SimilarityThreshold: params.Cfg.Embed.SimilarityThreshold,
@@ -139,12 +140,8 @@ func RunMemoryAgent(input MemoryAgentInput, params MemoryAgentParams) {
 		AgentEventCB:        params.AgentEventCB,
 	}
 
-	// Tool definitions for the memory agent — the 4 memory tools plus done.
-	// These are loaded from the same YAML registry as all other tools.
-	memToolDefs := tools.LookupToolDefs(
-		[]string{"list_cards", "recall_memories", "save_memory", "save_self_memory", "update_memory", "remove_memory", "split_memory", "create_card", "notify_agent", "done"},
-		params.Cfg,
-	)
+	// Tool definitions for the memory agent — driven by tool.yaml agent fields.
+	memToolDefs := tools.ToolDefsForAgent("memory", params.Cfg)
 
 	messages := []llm.ChatMessage{
 		{Role: "system", Content: promptContent},

--- a/agent/tools.go
+++ b/agent/tools.go
@@ -18,6 +18,6 @@ package agent
 // The agent calls use_tools(["memory", "scheduling"]) to load deferred tools
 // on demand. Loaded tools persist for the rest of the agent loop.
 //
-// All tool management functions (HotToolDefs, LookupToolDefs, ExpandToolIdentity,
+// All tool management functions (HotToolDefs, ToolDefsForAgent, ExpandToolIdentity,
 // UseToolsDef) live in the tools package (tools/loader.go). The agent package
 // just calls them.

--- a/layers/agent_tools.go
+++ b/layers/agent_tools.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func buildAgentTools(ctx *LayerContext) LayerResult {
-	hotDefs := tools.HotToolDefs(ctx.Cfg)
+	hotDefs := tools.HotToolDefs("main", ctx.Cfg)
 
 	// Marshal the tool definitions to JSON to get a realistic token
 	// estimate. The API sends these as JSON, so this reflects what

--- a/persona/memory_dreamer.go
+++ b/persona/memory_dreamer.go
@@ -111,17 +111,15 @@ func RunMemoryDreamer(params MemoryDreamerParams) MemoryDreamerResult {
 	// Build tools.Context.
 	dryRun := params.Cfg.Dream.DryRun
 	tctx := &tools.Context{
+		AgentName:           "dream",
 		Store:               params.Store,
 		EmbedClient:         params.EmbedClient,
 		SimilarityThreshold: params.Cfg.Embed.SimilarityThreshold,
 		Cfg:                 params.Cfg,
 	}
 
-	// Load tool definitions — card-based tools for the dreamer.
-	dreamerToolDefs := tools.LookupToolDefs(
-		[]string{"think", "list_cards", "read_card", "update_card", "create_card", "remove_memory", "merge_memories", "done"},
-		params.Cfg,
-	)
+	// Tool definitions for the dream agent — driven by tool.yaml agent fields.
+	dreamerToolDefs := tools.ToolDefsForAgent("dream", params.Cfg)
 
 	messages := []llm.ChatMessage{
 		{Role: "system", Content: promptContent},

--- a/tools/calendar_create/tool.yaml
+++ b/tools/calendar_create/tool.yaml
@@ -1,5 +1,5 @@
 name: calendar_create
-agent: main
+agent: [main]
 description: >-
   Create one or more calendar events. Also handles work shifts — pass a "job"
   param per event to auto-fill location and position from config, store the

--- a/tools/calendar_delete/tool.yaml
+++ b/tools/calendar_delete/tool.yaml
@@ -1,5 +1,5 @@
 name: calendar_delete
-agent: main
+agent: [main]
 description: >-
   Delete a calendar event by ID. Get the event ID from calendar_list.
   This is a soft delete — the row is preserved in the DB (active=0) for

--- a/tools/calendar_list/tool.yaml
+++ b/tools/calendar_list/tool.yaml
@@ -1,5 +1,5 @@
 name: calendar_list
-agent: main
+agent: [main]
 description: >-
   Read events from all configured calendars in a date range. Returns a unified
   timeline with each event tagged with its source calendar. For shift events,

--- a/tools/calendar_update/tool.yaml
+++ b/tools/calendar_update/tool.yaml
@@ -1,5 +1,5 @@
 name: calendar_update
-agent: main
+agent: [main]
 description: >-
   Edit a calendar event in place by ID. Get the event ID from calendar_list.
   Pass only the fields you want to change — omitted fields are left unchanged.

--- a/tools/context.go
+++ b/tools/context.go
@@ -180,6 +180,11 @@ func FormatPlaceCards(cards []PlaceCard) string {
 // tool call. Mutable fields (ReplyCalled, DoneCalled, etc.) track
 // execution state across the agent loop.
 type Context struct {
+	// AgentName identifies which agent is running ("main", "memory",
+	// "introspection", "dream"). Used by tools like use_tools to scope
+	// deferred loading to the agent's declared tool set.
+	AgentName string
+
 	// Ctx is the parent context for this turn. Tools that spawn retries
 	// or background work should derive from this so they respect shutdown
 	// and turn cancellation. Defaults to context.Background() if unset.

--- a/tools/create_card/tool.yaml
+++ b/tools/create_card/tool.yaml
@@ -1,5 +1,5 @@
 name: create_card
-agent: memory
+agent: [memory, dream]
 hint: "create a new memory topic card"
 description: >-
   Create a new topic card when information doesn't fit any existing

--- a/tools/done/tool.yaml
+++ b/tools/done/tool.yaml
@@ -1,5 +1,5 @@
 name: done
-agent: [main, memory, introspection]
+agent: [main, memory, introspection, dream]
 hint: "signal you're finished (REQUIRED, call last)"
 description: >-
   Signal that you are completely finished with this turn. Call this

--- a/tools/get_time/tool.yaml
+++ b/tools/get_time/tool.yaml
@@ -1,5 +1,5 @@
 name: get_time
-agent: main
+agent: [main]
 hint: "check the current date and time"
 description: >-
   Return the current date and time in the configured timezone. Use this

--- a/tools/get_weather/tool.yaml
+++ b/tools/get_weather/tool.yaml
@@ -1,5 +1,5 @@
 name: get_weather
-agent: main
+agent: [main]
 description: >-
   Get the current weather. With no arguments, uses {{user}}'s saved home
   location from config (set via set_location). Pass a location string

--- a/tools/list_calendars/tool.yaml
+++ b/tools/list_calendars/tool.yaml
@@ -1,5 +1,5 @@
 name: list_calendars
-agent: main
+agent: [main]
 hint: "discover available calendars"
 description: >-
   List all available calendars that events can be added to. Use this to discover

--- a/tools/list_cards/tool.yaml
+++ b/tools/list_cards/tool.yaml
@@ -1,5 +1,5 @@
 name: list_cards
-agent: [memory, introspection]
+agent: [memory, introspection, dream]
 hint: "list all memory topic cards"
 description: >-
   List all memory topic cards with their slugs, names, subjects, and a

--- a/tools/loader.go
+++ b/tools/loader.go
@@ -27,9 +27,27 @@ import (
 // YAML schema types — these map directly to the tool.yaml format
 // ---------------------------------------------------------------------------
 
+// agentList is a custom type for the YAML "agent" field. It always
+// expects a YAML sequence (e.g., [main, memory]) — bare strings are
+// rejected at parse time so every tool.yaml uses a consistent format.
+type agentList []string
+
+func (a *agentList) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.SequenceNode {
+		return fmt.Errorf("agent field must be a YAML array (e.g., [main, memory]), got %v", node.Tag)
+	}
+	var list []string
+	if err := node.Decode(&list); err != nil {
+		return fmt.Errorf("decoding agent list: %w", err)
+	}
+	*a = list
+	return nil
+}
+
 // toolManifest is the top-level structure of a tool.yaml file.
 type toolManifest struct {
 	Name        string         `yaml:"name"`
+	Agent       agentList      `yaml:"agent"`
 	Description string         `yaml:"description"`
 	Hint        string         `yaml:"hint,omitempty"`
 	Hot         bool           `yaml:"hot"`
@@ -72,8 +90,13 @@ type propertyDef struct {
 // This is the source of truth for all tool schemas.
 var toolDefs = map[string]llm.ToolDef{}
 
-// hotTools lists tool names where hot: true in the YAML.
-var hotTools []string
+// agentTools maps agent name → tool names belonging to that agent.
+// Built from the "agent" field in each tool's YAML. This is the
+// inverted index: YAML stores tool→agents, this gives us agent→tools.
+var agentTools = map[string][]string{}
+
+// agentHotTools maps agent name → hot tool names for that agent.
+var agentHotTools = map[string][]string{}
 
 // categories maps category name → list of tool names.
 // Built from the "category" field in each tool's YAML.
@@ -164,11 +187,16 @@ func init() {
 
 		toolDefs[manifest.Name] = def
 
-		if manifest.Hot {
-			hotTools = append(hotTools, manifest.Name)
-			if manifest.Hint != "" {
-				hotToolHints[manifest.Name] = manifest.Hint
+		// Build the agent→tools inverted index.
+		for _, agentName := range manifest.Agent {
+			agentTools[agentName] = append(agentTools[agentName], manifest.Name)
+			if manifest.Hot {
+				agentHotTools[agentName] = append(agentHotTools[agentName], manifest.Name)
 			}
+		}
+
+		if manifest.Hot && manifest.Hint != "" {
+			hotToolHints[manifest.Name] = manifest.Hint
 		}
 
 		if manifest.Category != "" {
@@ -187,9 +215,14 @@ func init() {
 	}
 
 	// Sort for deterministic output (map iteration order is random in Go).
-	sort.Strings(hotTools)
 	for cat := range categories {
 		sort.Strings(categories[cat])
+	}
+	for agent := range agentTools {
+		sort.Strings(agentTools[agent])
+	}
+	for agent := range agentHotTools {
+		sort.Strings(agentHotTools[agent])
 	}
 
 	// Parse category hints from categories.yaml.
@@ -208,8 +241,8 @@ func init() {
 		Format: "{{.Result | truncate 100 | escape}}",
 	})
 
-	log.Infof("loaded %d tool definitions from YAML (%d hot, %d categories)",
-		len(toolDefs), len(hotTools), len(categories))
+	log.Infof("loaded %d tool definitions from YAML (%d agents, %d categories)",
+		len(toolDefs), len(agentTools), len(categories))
 }
 
 // convertParameters turns the YAML parametersDef into the
@@ -287,11 +320,6 @@ func LookupDef(name string) (llm.ToolDef, bool) {
 	return def, ok
 }
 
-// HotToolNames returns the names of all tools marked hot: true in YAML.
-func HotToolNames() []string {
-	return hotTools
-}
-
 // Categories returns the category → tool names map built from YAML.
 func Categories() map[string][]string {
 	return categories
@@ -322,19 +350,14 @@ func CategoryDescription() string {
 // ---------------------------------------------------------------------------
 
 // RenderHotToolsList returns a markdown bullet list of hot tools for the
-// agent prompt. Each bullet has the tool name bolded and its hint.
+// named agent's prompt. Each bullet has the tool name bolded and its hint.
 // Output is deterministic (sorted by tool name).
-//
-// Example output:
-//
-//	- **done** — signal you're finished (REQUIRED, call last)
-//	- **reply** — generate and send a response (REQUIRED every turn)
-func RenderHotToolsList() string {
+func RenderHotToolsList(agentName string) string {
+	names := agentHotTools[agentName]
 	var lines []string
-	for _, name := range hotTools {
+	for _, name := range names {
 		hint := hotToolHints[name]
 		if hint == "" {
-			// Fallback: use first sentence of the tool's description.
 			if def, ok := toolDefs[name]; ok {
 				hint = firstSentence(def.Function.Description)
 			}
@@ -387,36 +410,6 @@ func firstSentence(s string) string {
 		return s[:i]
 	}
 	return s
-}
-
-// RegisterDef adds a Go-defined tool to the registry. Used by agent/
-// for tools still defined in Go code (reply, etc.) so there's one
-// unified registry. Also adds to hotTools/categories if applicable.
-func RegisterDef(def llm.ToolDef, hot bool, category string) {
-	name := def.Function.Name
-	toolDefs[name] = def
-
-	if hot {
-		// Avoid duplicates.
-		for _, h := range hotTools {
-			if h == name {
-				goto skipHot
-			}
-		}
-		hotTools = append(hotTools, name)
-	skipHot:
-	}
-
-	if category != "" {
-		members := categories[category]
-		for _, m := range members {
-			if m == name {
-				goto skipCat
-			}
-		}
-		categories[category] = append(categories[category], name)
-	skipCat:
-	}
 }
 
 // ExpandToolIdentity replaces {{her}} and {{user}} placeholders in a tool's
@@ -483,46 +476,47 @@ func ExpandToolIdentity(t llm.ToolDef, cfg *config.Config) llm.ToolDef {
 	return t
 }
 
-// HotToolDefs returns the always-loaded tools plus the use_tools meta-tool.
-// This is what gets passed to ChatCompletionWithTools on the first iteration.
-// The cfg parameter is used to expand {{her}}/{{user}} placeholders.
-func HotToolDefs(cfg *config.Config) []llm.ToolDef {
-	result := make([]llm.ToolDef, 0, len(hotTools)+1)
-	for _, name := range hotTools {
+// ToolDefsForAgent returns all tool definitions for the named agent.
+// The agent field in each tool.yaml drives the mapping.
+func ToolDefsForAgent(agentName string, cfg *config.Config) []llm.ToolDef {
+	names := agentTools[agentName]
+	result := make([]llm.ToolDef, 0, len(names))
+	for _, name := range names {
 		if t, ok := toolDefs[name]; ok {
 			result = append(result, ExpandToolIdentity(t, cfg))
 		}
 	}
-	// Add the use_tools meta-tool for loading deferred tools.
-	result = append(result, UseToolsDef())
 	return result
 }
 
-// LookupToolDefs resolves a mix of tool names and category names into
-// full tool definitions. Unknown names are silently skipped.
-func LookupToolDefs(names []string, cfg *config.Config) []llm.ToolDef {
-	seen := make(map[string]bool)
-	var result []llm.ToolDef
-
+// HotToolDefs returns the hot (always-loaded) tools for the named agent.
+// For the driver agent ("main"), also appends the use_tools meta-tool.
+func HotToolDefs(agentName string, cfg *config.Config) []llm.ToolDef {
+	names := agentHotTools[agentName]
+	result := make([]llm.ToolDef, 0, len(names)+1)
 	for _, name := range names {
-		// Check if it's a category first.
-		if members, ok := categories[name]; ok {
-			for _, member := range members {
-				if !seen[member] {
-					if t, ok := toolDefs[member]; ok {
-						result = append(result, ExpandToolIdentity(t, cfg))
-						seen[member] = true
-					}
-				}
-			}
-			continue
+		if t, ok := toolDefs[name]; ok {
+			result = append(result, ExpandToolIdentity(t, cfg))
 		}
-		// Otherwise treat it as a tool name.
-		if !seen[name] {
-			if t, ok := toolDefs[name]; ok {
-				result = append(result, ExpandToolIdentity(t, cfg))
-				seen[name] = true
-			}
+	}
+	if agentName == "main" {
+		result = append(result, UseToolsDef())
+	}
+	return result
+}
+
+// CategoryMembersForAgent returns tool names in a category that also
+// belong to the named agent. Used by use_tools to scope deferred
+// tool loading to the requesting agent's tool set.
+func CategoryMembersForAgent(category, agentName string) []string {
+	agentSet := make(map[string]bool, len(agentTools[agentName]))
+	for _, name := range agentTools[agentName] {
+		agentSet[name] = true
+	}
+	var result []string
+	for _, name := range categories[category] {
+		if agentSet[name] {
+			result = append(result, name)
 		}
 	}
 	return result

--- a/tools/loader_test.go
+++ b/tools/loader_test.go
@@ -1,7 +1,10 @@
 package tools
 
 import (
+	"sort"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestYAMLLoader(t *testing.T) {
@@ -35,26 +38,26 @@ func TestYAMLLoader(t *testing.T) {
 		t.Logf("  loaded: %s (desc=%d chars)", name, len(def.Function.Description))
 	}
 
-	// Check hot tools.
-	hots := HotToolNames()
-	t.Logf("  hot tools: %v", hots)
+	// Check hot tools via agent-scoped index.
+	mainHot := agentHotTools["main"]
+	t.Logf("  main hot tools: %v", mainHot)
 
 	hotSet := map[string]bool{}
-	for _, h := range hots {
+	for _, h := range mainHot {
 		hotSet[h] = true
 	}
 	if !hotSet["think"] {
-		t.Error("think should be hot")
+		t.Error("think should be hot for main")
 	}
 	if !hotSet["done"] {
-		t.Error("done should be hot")
+		t.Error("done should be hot for main")
 	}
 	// Deferred tools (loaded on demand) must NOT be hot.
 	if hotSet["web_search"] {
 		t.Error("web_search should NOT be hot (it's a deferred search tool)")
 	}
 	if !hotSet["recall_memories"] {
-		t.Error("recall_memories should be hot")
+		t.Error("recall_memories should be hot for main")
 	}
 
 	// Check categories.
@@ -103,5 +106,160 @@ func TestYAMLLoader(t *testing.T) {
 	}
 	if len(required) != 1 || required[0] != "thought" {
 		t.Errorf("think required = %v, want [thought]", required)
+	}
+}
+
+func TestAgentToolsIndex(t *testing.T) {
+	// The agentTools index should contain entries for all 4 agents.
+	for _, agent := range []string{"main", "memory", "introspection", "dream"} {
+		tools := agentTools[agent]
+		if len(tools) == 0 {
+			t.Errorf("agent %q has no tools in agentTools index", agent)
+		}
+		t.Logf("  %s: %d tools %v", agent, len(tools), tools)
+
+		// Should be sorted (deterministic output).
+		if !sort.StringsAreSorted(tools) {
+			t.Errorf("agent %q tools not sorted", agent)
+		}
+	}
+}
+
+func TestAgentToolsMapping(t *testing.T) {
+	// Spot-check key tool→agent assignments from the mapping table.
+	tests := []struct {
+		tool   string
+		agents []string
+	}{
+		{"think", []string{"main", "introspection"}},
+		{"done", []string{"main", "memory", "introspection", "dream"}},
+		{"reply", []string{"main"}},
+		{"skip", []string{"introspection"}},
+		{"save_memory", []string{"memory"}},
+		{"merge_memories", []string{"dream"}},
+		{"update_persona", []string{"dream"}},
+		{"read_card", []string{"memory", "introspection", "dream"}},
+		{"recall_memories", []string{"main", "memory", "introspection"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			for _, agent := range tt.agents {
+				found := false
+				for _, name := range agentTools[agent] {
+					if name == tt.tool {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("tool %q should belong to agent %q but doesn't", tt.tool, agent)
+				}
+			}
+		})
+	}
+}
+
+func TestToolDefsForAgent_UnknownAgent(t *testing.T) {
+	// Unknown agent should return empty slice, not panic.
+	defs := ToolDefsForAgent("nonexistent", nil)
+	if len(defs) != 0 {
+		t.Errorf("expected 0 defs for unknown agent, got %d", len(defs))
+	}
+}
+
+func TestHotToolDefsPerAgent(t *testing.T) {
+	// Main agent should have hot tools.
+	mainHot := agentHotTools["main"]
+	if len(mainHot) == 0 {
+		t.Fatal("main agent has no hot tools")
+	}
+
+	// think should be hot for main.
+	hasThink := false
+	for _, name := range mainHot {
+		if name == "think" {
+			hasThink = true
+		}
+	}
+	if !hasThink {
+		t.Error("think should be hot for main agent")
+	}
+
+	// skip should NOT be hot for any agent (hot: false in YAML).
+	for agent, hots := range agentHotTools {
+		for _, name := range hots {
+			if name == "skip" {
+				t.Errorf("skip should not be hot for agent %q", agent)
+			}
+		}
+	}
+
+	// Memory agent should have no hot tools that don't belong to it.
+	for _, name := range agentHotTools["memory"] {
+		found := false
+		for _, memTool := range agentTools["memory"] {
+			if memTool == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("memory hot tool %q is not in memory's tool set", name)
+		}
+	}
+}
+
+func TestAgentListUnmarshal(t *testing.T) {
+	// Array syntax should work.
+	t.Run("array", func(t *testing.T) {
+		var a agentList
+		node := &yaml.Node{}
+		if err := yaml.Unmarshal([]byte("[main, memory]"), node); err != nil {
+			t.Fatal(err)
+		}
+		if err := a.UnmarshalYAML(node.Content[0]); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if len(a) != 2 || a[0] != "main" || a[1] != "memory" {
+			t.Errorf("expected [main memory], got %v", a)
+		}
+	})
+
+	// Bare string should error.
+	t.Run("bare_string", func(t *testing.T) {
+		var a agentList
+		node := &yaml.Node{}
+		if err := yaml.Unmarshal([]byte("main"), node); err != nil {
+			t.Fatal(err)
+		}
+		if err := a.UnmarshalYAML(node.Content[0]); err == nil {
+			t.Error("expected error for bare string, got nil")
+		}
+	})
+}
+
+func TestCategoryMembersForAgent(t *testing.T) {
+	// Search category tools should all belong to main.
+	members := CategoryMembersForAgent("search", "main")
+	if len(members) == 0 {
+		t.Fatal("expected search tools for main agent")
+	}
+	for _, name := range members {
+		if _, ok := toolDefs[name]; !ok {
+			t.Errorf("CategoryMembersForAgent returned unknown tool %q", name)
+		}
+	}
+
+	// Memory agent should get zero search tools (no search tools have agent: memory).
+	memMembers := CategoryMembersForAgent("search", "memory")
+	if len(memMembers) != 0 {
+		t.Errorf("memory agent should not have search tools, got %v", memMembers)
+	}
+
+	// Unknown category returns empty.
+	empty := CategoryMembersForAgent("nonexistent", "main")
+	if len(empty) != 0 {
+		t.Errorf("expected empty for unknown category, got %v", empty)
 	}
 }

--- a/tools/merge_memories/tool.yaml
+++ b/tools/merge_memories/tool.yaml
@@ -1,5 +1,5 @@
 name: merge_memories
-agent: dream
+agent: [dream]
 description: >-
   Merge multiple redundant memories into one consolidated memory. Provide
   the IDs of memories to merge and the new combined text. All source memories

--- a/tools/nearby_search/tool.yaml
+++ b/tools/nearby_search/tool.yaml
@@ -1,5 +1,5 @@
 name: nearby_search
-agent: main
+agent: [main]
 description: >-
   Search for nearby places — restaurants, coffee shops, pharmacies, parks, etc.
   Uses Foursquare Places API for structured results with distance and categories.

--- a/tools/notify_agent/tool.yaml
+++ b/tools/notify_agent/tool.yaml
@@ -1,5 +1,5 @@
 name: notify_agent
-agent: memory
+agent: [memory]
 description: >-
   Send results back to the driver agent and trigger a follow-up message to the
   user. Call this instead of done when you completed inbox tasks and the user

--- a/tools/read_card/tool.yaml
+++ b/tools/read_card/tool.yaml
@@ -1,5 +1,5 @@
 name: read_card
-agent: memory
+agent: [memory, introspection, dream]
 hint: "read a memory card's full content"
 description: >-
   Read the full content of a specific memory card by topic slug.

--- a/tools/remove_memory/tool.yaml
+++ b/tools/remove_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: remove_memory
-agent: memory
+agent: [memory, dream]
 description: >-
   Remove one or more memories that are no longer true, incorrect, or redundant.
   Memories are soft-deleted (kept for audit but excluded from retrieval).

--- a/tools/render_test.go
+++ b/tools/render_test.go
@@ -10,23 +10,23 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestRenderHotToolsList(t *testing.T) {
-	result := RenderHotToolsList()
+	result := RenderHotToolsList("main")
 
-	// Every hot tool should appear as a bolded markdown bullet.
-	for _, name := range hotTools {
+	// Every main-agent hot tool should appear as a bolded markdown bullet.
+	for _, name := range agentHotTools["main"] {
 		target := "- **" + name + "** — "
 		if !strings.Contains(result, target) {
 			t.Errorf("hot tool %q missing from rendered list", name)
 		}
 	}
 
-	// Output should have the same number of lines as hot tools.
+	// Output should have the same number of lines as main's hot tools.
 	lines := strings.Split(result, "\n")
-	if len(lines) != len(hotTools) {
-		t.Errorf("expected %d lines, got %d", len(hotTools), len(lines))
+	if len(lines) != len(agentHotTools["main"]) {
+		t.Errorf("expected %d lines, got %d", len(agentHotTools["main"]), len(lines))
 	}
 
-	// Lines should be sorted (hotTools is sorted at init).
+	// Lines should be sorted.
 	for i := 1; i < len(lines); i++ {
 		if lines[i] < lines[i-1] {
 			t.Errorf("lines not sorted: %q comes after %q", lines[i], lines[i-1])
@@ -77,7 +77,13 @@ func TestHotToolHintsComplete(t *testing.T) {
 	// Every hot tool should have a hint (from YAML or fallback).
 	// This catches the case where someone adds a new hot tool YAML
 	// but forgets the hint field.
-	for _, name := range hotTools {
+	seen := map[string]bool{}
+	for _, names := range agentHotTools {
+		for _, n := range names {
+			seen[n] = true
+		}
+	}
+	for name := range seen {
 		hint := hotToolHints[name]
 		if hint == "" {
 			// Check if there's a description to fall back on.

--- a/tools/reply/tool.yaml
+++ b/tools/reply/tool.yaml
@@ -1,5 +1,5 @@
 name: reply
-agent: main
+agent: [main]
 hint: "generate and send a response (REQUIRED every turn)"
 description: >-
   Generate and send a response to the user. REQUIRED — you MUST call this at

--- a/tools/save_memory/tool.yaml
+++ b/tools/save_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: save_memory
-agent: memory
+agent: [memory]
 hint: "save a new memory about the user"
 description: >-
   Save a new memory learned from the conversation. Only for information worth

--- a/tools/search_books/tool.yaml
+++ b/tools/search_books/tool.yaml
@@ -1,5 +1,5 @@
 name: search_books
-agent: main
+agent: [main]
 description: >-
   Search Open Library for books by title, author, topic, or any mix.
   Returns up to 10 hits with title, author(s), first-published year,

--- a/tools/send_task/tool.yaml
+++ b/tools/send_task/tool.yaml
@@ -1,5 +1,5 @@
 name: send_task
-agent: main
+agent: [main]
 description: >-
   Delegate a memory task to the background memory agent. Do your research first
   (recall_memories to find duplicates or compound memories), then send a task

--- a/tools/set_location/tool.yaml
+++ b/tools/set_location/tool.yaml
@@ -1,5 +1,5 @@
 name: set_location
-agent: main
+agent: [main]
 description: >-
   Set {{user}}'s HOME location so get_weather knows where to fetch weather
   for. Geocodes a city, address, landmark, or raw "lat,lon" coordinates

--- a/tools/shift_hours/tool.yaml
+++ b/tools/shift_hours/tool.yaml
@@ -1,5 +1,5 @@
 name: shift_hours
-agent: main
+agent: [main]
 description: >-
   Compute total hours worked over a time period. Parses time chit values
   from shift events and returns per-job and overall totals. Use when the

--- a/tools/skip/tool.yaml
+++ b/tools/skip/tool.yaml
@@ -1,5 +1,5 @@
 name: skip
-agent: introspection
+agent: [introspection]
 description: >-
   Skip this turn when there's nothing worth reflecting on. This is the
   expected outcome for most turns — self-discovery is rare, not constant.

--- a/tools/split_memory/tool.yaml
+++ b/tools/split_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: split_memory
-agent: memory
+agent: [memory]
 description: >-
   Split a compound memory into multiple individual memories. Deactivates the
   original and creates new memories from the provided facts. Use this when a

--- a/tools/think/tool.yaml
+++ b/tools/think/tool.yaml
@@ -1,5 +1,5 @@
 name: think
-agent: [main, introspection]
+agent: [main, introspection, dream]
 hint: "pause and reason before acting (free, use often)"
 description: >-
   Pause and reason before acting. Use this to evaluate search results,

--- a/tools/update_card/tool.yaml
+++ b/tools/update_card/tool.yaml
@@ -1,5 +1,5 @@
 name: update_card
-agent: dream
+agent: [dream]
 hint: "rewrite a memory card's dreamer-maintained summary"
 description: >-
   Rewrite a memory card's summary based on its current child memories.

--- a/tools/update_memory/tool.yaml
+++ b/tools/update_memory/tool.yaml
@@ -1,5 +1,5 @@
 name: update_memory
-agent: [memory, introspection]
+agent: [memory, introspection, dream]
 description: >-
   Update an existing memory when new information changes or refines what we
   knew. Use this instead of save_memory when a memory already exists but needs

--- a/tools/update_persona/tool.yaml
+++ b/tools/update_persona/tool.yaml
@@ -1,5 +1,5 @@
 name: update_persona
-agent: main
+agent: [dream]
 description: >-
   Rewrite {{her}}'s persona description. Use RARELY — only when accumulated
   self-memories suggest a meaningful evolution in how {{her}} sees herself. The

--- a/tools/use_tools/handler.go
+++ b/tools/use_tools/handler.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"strings"
 
+	"her/llm"
 	"her/logger"
 	"her/tools"
 )
@@ -52,7 +53,16 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		return "no matching categories found. Available categories: " + tools.CategoryDescription()
 	}
 
-	newTools := tools.LookupToolDefs(catNames, ctx.Cfg)
+	// Expand categories into tool defs, scoped to this agent's tool set.
+	var newTools []llm.ToolDef
+	for _, cat := range catNames {
+		members := tools.CategoryMembersForAgent(cat, ctx.AgentName)
+		for _, name := range members {
+			if def, ok := tools.LookupDef(name); ok {
+				newTools = append(newTools, tools.ExpandToolIdentity(def, ctx.Cfg))
+			}
+		}
+	}
 	if len(newTools) == 0 {
 		return "no matching tools found. Available categories: " + tools.CategoryDescription()
 	}

--- a/tools/view_image/tool.yaml
+++ b/tools/view_image/tool.yaml
@@ -1,5 +1,5 @@
 name: view_image
-agent: main
+agent: [main]
 description: >-
   Analyze an image the user sent. Returns a detailed description of what's
   in it. Call this BEFORE reply when the user sends a photo.

--- a/tools/web_read/tool.yaml
+++ b/tools/web_read/tool.yaml
@@ -1,5 +1,5 @@
 name: web_read
-agent: main
+agent: [main]
 description: >-
   Extract clean text content from a URL using Tavily. Use when the user
   shares a link and wants you to read it, or when a web_search result

--- a/tools/web_search/tool.yaml
+++ b/tools/web_search/tool.yaml
@@ -1,5 +1,5 @@
 name: web_search
-agent: main
+agent: [main]
 description: >-
   Search the web using Tavily. Returns relevant snippets and a synthesized
   summary. Use when the user asks about current events, facts you don't know,


### PR DESCRIPTION
## Summary

- Makes the `agent:` field in `tool.yaml` the **single source of truth** for which tools each agent can use
- Eliminates all hardcoded `LookupToolDefs` lists — adding a tool to an agent is now a one-line YAML change
- Adds agent-scoped filtering to `use_tools` and `HotToolDefs` so agents can only access their declared tools
- Removes dead code: `LookupToolDefs`, `RegisterDef`, `HotToolNames`, `hotTools` global
- Fixes `update_persona` ownership (was `main`, should be `dream` — persona evolution is a dream-cycle responsibility)

## Changes

- `tools/loader.go` — `agentList` YAML type, `agentTools`/`agentHotTools` indexes, `ToolDefsForAgent()`, `CategoryMembersForAgent()`
- `tools/use_tools/handler.go` — scopes deferred loading by agent via `CategoryMembersForAgent`
- `tools/context.go` — adds `AgentName string` field
- 4 agent files — switched from hardcoded lists to `ToolDefsForAgent("name", cfg)`
- 32 tool.yaml files — standardized to array syntax, corrected agent assignments
- 7 new tests covering agent index, mapping, scoping, YAML format enforcement

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./...` — all tests pass
- [x] `go test -race ./...` — zero races
- [x] `grep -r LookupToolDefs *.go` — zero results
- [ ] Run existing sims (card-lifecycle, introspection-test) — behavior unchanged