### PR TITLE
feat: VPS deployment — procmgr, D1 sync, Frontend interface, dev mode, bootstrap

### DIFF
--- a/bot/frontend.go
+++ b/bot/frontend.go
@@ -1,0 +1,74 @@
+package bot
+
+// Frontend abstracts the I/O transport for a conversation turn.
+//
+// Telegram, HTTP, and future transports (Discord, web UI) all
+// implement this interface. The agent pipeline calls these methods
+// to communicate with the user — it never knows or cares which
+// transport is underneath. Same pattern as the Store interface:
+// consumers work with the contract, not the implementation.
+//
+// In Python terms, this is like an abstract base class (abc.ABC)
+// with required methods. Go checks at compile time instead of
+// runtime, so you get the error immediately if a method is missing.
+type Frontend interface {
+	// SendPlaceholder sends an initial "thinking" indicator and returns
+	// an opaque handle. Telegram shows 💭 as an editable message;
+	// HTTP mode may return a no-op handle.
+	SendPlaceholder(text string, html bool) error
+
+	// EditStatus updates the placeholder with a status message or the
+	// final reply text. On Telegram this edits the placeholder message;
+	// on HTTP this buffers the text for the response.
+	EditStatus(text string) error
+
+	// SendReply sends a NEW message (separate from the placeholder).
+	// Used for follow-up messages, not edits.
+	SendReply(text string) error
+
+	// SendPaginated sends a long message that may need pagination.
+	// Telegram splits it into pages with ◀/▶ buttons; HTTP sends the
+	// full text.
+	SendPaginated(text string) error
+
+	// SendConfirm sends a confirmation prompt and returns a message ID.
+	// Telegram shows inline Yes/No buttons; HTTP may skip this.
+	SendConfirm(text string) (msgID int64, err error)
+
+	// StageReset sends a fresh placeholder after a reply tool fires,
+	// so the next status update targets a new message. On HTTP this
+	// may be a no-op.
+	StageReset() error
+
+	// DeletePlaceholder removes the orphan placeholder left by the
+	// last stage reset.
+	DeletePlaceholder() error
+
+	// StartTyping begins a typing indicator and returns a function
+	// that stops it. On Telegram this sends "typing..." every 4s.
+	// On HTTP this is a no-op.
+	StartTyping() (stop func())
+
+	// SupportsStreaming returns true if this frontend can handle
+	// incremental token delivery (live typing effect).
+	SupportsStreaming() bool
+
+	// OnStreamToken receives a single token during streaming.
+	// Only called when SupportsStreaming() returns true.
+	OnStreamToken(token string)
+
+	// StopStream signals that streaming is complete.
+	StopStream()
+
+	// SendBusy tells the user the agent is already processing another
+	// message. Returns an error so the caller can propagate it.
+	SendBusy() error
+
+	// SendError tells the user something went wrong.
+	SendError(text string) error
+
+	// ReplyText returns the accumulated reply text. Used by HTTP
+	// frontend to build the JSON response. Telegram returns empty
+	// (replies are sent inline).
+	ReplyText() string
+}

--- a/bot/frontend_dev.go
+++ b/bot/frontend_dev.go
@@ -1,0 +1,78 @@
+package bot
+
+import "sync"
+
+// DevFrontend implements Frontend for the HTTP dev server.
+// Instead of sending messages to Telegram, it collects the reply
+// text so the HTTP handler can return it as JSON. Status updates
+// go to the event bus (TUI shows them in the terminal).
+//
+// Think of this as the "null transport" — it captures output instead
+// of routing it to a real messaging platform. Same idea as Python's
+// io.StringIO capturing print() output for testing.
+type DevFrontend struct {
+	mu    sync.Mutex
+	reply string
+}
+
+// NewDevFrontend creates a frontend that buffers replies for HTTP responses.
+func NewDevFrontend() *DevFrontend {
+	return &DevFrontend{}
+}
+
+func (f *DevFrontend) SendPlaceholder(text string, html bool) error { return nil }
+
+func (f *DevFrontend) EditStatus(text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reply = text
+	return nil
+}
+
+func (f *DevFrontend) SendReply(text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.reply != "" {
+		f.reply += "\n\n"
+	}
+	f.reply += text
+	return nil
+}
+
+func (f *DevFrontend) SendPaginated(text string) error {
+	return f.SendReply(text)
+}
+
+func (f *DevFrontend) SendConfirm(text string) (int64, error) {
+	// Dev mode auto-confirms. In a future version, the Gradio frontend
+	// could show a confirmation dialog.
+	return 0, nil
+}
+
+func (f *DevFrontend) StageReset() error      { return nil }
+func (f *DevFrontend) DeletePlaceholder() error { return nil }
+
+func (f *DevFrontend) StartTyping() func() {
+	return func() {} // no-op — HTTP doesn't have typing indicators
+}
+
+func (f *DevFrontend) SupportsStreaming() bool   { return false }
+func (f *DevFrontend) OnStreamToken(token string) {}
+func (f *DevFrontend) StopStream()               {}
+
+func (f *DevFrontend) SendBusy() error {
+	return nil // HTTP will return 429 at the handler level
+}
+
+func (f *DevFrontend) SendError(text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reply = text
+	return nil
+}
+
+func (f *DevFrontend) ReplyText() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reply
+}

--- a/bot/frontend_telegram.go
+++ b/bot/frontend_telegram.go
@@ -1,0 +1,149 @@
+package bot
+
+import (
+	"fmt"
+	"time"
+
+	tele "gopkg.in/telebot.v4"
+)
+
+// TelegramFrontend implements Frontend for the Telegram transport.
+// It wraps a tele.Context and manages the placeholder message that
+// gets edited with status updates and the final reply.
+//
+// The placeholder pattern is the key UX trick: we send a 💭 message
+// immediately so the user sees the bot is working, then edit it in
+// place as the agent progresses. This avoids the "typing..." indicator
+// disappearing after 5 seconds.
+type TelegramFrontend struct {
+	c           tele.Context
+	b           *Bot
+	placeholder *tele.Message
+	html        bool // whether placeholder was sent with HTML parse mode
+}
+
+// NewTelegramFrontend creates a frontend for a Telegram message context.
+func NewTelegramFrontend(c tele.Context, b *Bot) *TelegramFrontend {
+	return &TelegramFrontend{c: c, b: b}
+}
+
+func (f *TelegramFrontend) SendPlaceholder(text string, html bool) error {
+	f.html = html
+	var opts []interface{}
+	if html {
+		opts = append(opts, &tele.SendOptions{ParseMode: tele.ModeHTML})
+	}
+	msg, err := f.c.Bot().Send(f.c.Recipient(), text, opts...)
+	if err != nil {
+		return err
+	}
+	f.placeholder = msg
+	return nil
+}
+
+func (f *TelegramFrontend) EditStatus(text string) error {
+	if f.placeholder == nil {
+		return nil
+	}
+	if f.html {
+		_, err := f.c.Bot().Edit(f.placeholder, text, &tele.SendOptions{ParseMode: tele.ModeHTML})
+		return err
+	}
+	_, err := f.c.Bot().Edit(f.placeholder, text)
+	return err
+}
+
+func (f *TelegramFrontend) SendReply(text string) error {
+	_, err := f.c.Bot().Send(f.c.Recipient(), text, &tele.SendOptions{ParseMode: tele.ModeHTML})
+	return err
+}
+
+func (f *TelegramFrontend) SendPaginated(text string) error {
+	return f.b.sendPaginated(f.c, text)
+}
+
+func (f *TelegramFrontend) SendConfirm(text string) (int64, error) {
+	markup := &tele.ReplyMarkup{}
+	btnYes := markup.Data("Yes", "confirm", "yes")
+	btnNo := markup.Data("No", "confirm", "no")
+	markup.Inline(markup.Row(btnYes, btnNo))
+
+	msg, err := f.c.Bot().Send(f.c.Recipient(), text, &tele.SendOptions{
+		ParseMode:   tele.ModeHTML,
+		ReplyMarkup: markup,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int64(msg.ID), nil
+}
+
+func (f *TelegramFrontend) StageReset() error {
+	newPlaceholder, err := f.c.Bot().Send(f.c.Recipient(), "\U0001F4AD")
+	if err != nil {
+		return fmt.Errorf("stage reset: sending new placeholder: %w", err)
+	}
+	f.placeholder = newPlaceholder
+	return nil
+}
+
+func (f *TelegramFrontend) DeletePlaceholder() error {
+	if f.placeholder == nil {
+		return nil
+	}
+	return f.c.Bot().Delete(f.placeholder)
+}
+
+// StartTyping launches the Telegram typing indicator, refreshed every
+// 4 seconds (Telegram's indicator expires after ~5s). Returns a
+// function that stops it — safe to call multiple times via sync.Once.
+func (f *TelegramFrontend) StartTyping() func() {
+	stopTyping := make(chan struct{})
+	go func() {
+		_ = f.c.Notify(tele.Typing)
+		ticker := time.NewTicker(4 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopTyping:
+				return
+			case <-ticker.C:
+				_ = f.c.Notify(tele.Typing)
+			}
+		}
+	}()
+	return func() { close(stopTyping) }
+}
+
+func (f *TelegramFrontend) SupportsStreaming() bool { return f.b.cfg.Chat.Streaming }
+
+func (f *TelegramFrontend) OnStreamToken(token string) {
+	// Streaming is handled by makeStreamCallback which operates on
+	// the placeholder directly. The frontend's placeholder is shared,
+	// so the stream callback can edit it.
+}
+
+func (f *TelegramFrontend) StopStream() {}
+
+func (f *TelegramFrontend) SendBusy() error {
+	return f.c.Send("Still working on your last message — give me just a moment.")
+}
+
+func (f *TelegramFrontend) SendError(text string) error {
+	if f.placeholder != nil {
+		_, _ = f.c.Bot().Edit(f.placeholder, text)
+		return nil
+	}
+	return f.c.Send(text)
+}
+
+func (f *TelegramFrontend) ReplyText() string { return "" }
+
+// Placeholder returns the current placeholder message. Used by the
+// stream callback builder which needs direct access to the message
+// for incremental edits.
+func (f *TelegramFrontend) Placeholder() *tele.Message { return f.placeholder }
+
+// Context returns the underlying tele.Context for Telegram-specific
+// operations (TTS, voice replies) that don't go through the Frontend.
+func (f *TelegramFrontend) Context() tele.Context { return f.c }

--- a/bot/frontend_telegram.go
+++ b/bot/frontend_telegram.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	tele "gopkg.in/telebot.v4"
@@ -96,7 +97,8 @@ func (f *TelegramFrontend) DeletePlaceholder() error {
 
 // StartTyping launches the Telegram typing indicator, refreshed every
 // 4 seconds (Telegram's indicator expires after ~5s). Returns a
-// function that stops it — safe to call multiple times via sync.Once.
+// function that stops it — safe to call multiple times (wrapped in
+// sync.Once so closing the channel can't panic).
 func (f *TelegramFrontend) StartTyping() func() {
 	stopTyping := make(chan struct{})
 	go func() {
@@ -112,7 +114,8 @@ func (f *TelegramFrontend) StartTyping() func() {
 			}
 		}
 	}()
-	return func() { close(stopTyping) }
+	var once sync.Once
+	return func() { once.Do(func() { close(stopTyping) }) }
 }
 
 func (f *TelegramFrontend) SupportsStreaming() bool { return f.b.cfg.Chat.Streaming }

--- a/bot/handlers_admin.go
+++ b/bot/handlers_admin.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"her/compact"
+	"her/procmgr"
 
 	tele "gopkg.in/telebot.v4"
 )
@@ -100,10 +101,10 @@ func (b *Bot) handleStatus(c tele.Context) error {
 		}
 	}
 
-	// Check if running under launchd.
+	// Check if running under a process supervisor (launchd or systemd).
 	managedBy := "manual (go run)"
-	if os.Getenv("__CFBundleIdentifier") != "" || isLaunchdManaged(b.effectiveServiceLabel()) {
-		managedBy = "launchd"
+	if mgr := b.processManager(); mgr != nil && mgr.IsManaged() {
+		managedBy = mgr.Name()
 	}
 
 	msg := fmt.Sprintf(
@@ -139,29 +140,26 @@ func (b *Bot) handleStatus(c tele.Context) error {
 	return c.Send(msg, &tele.SendOptions{ParseMode: tele.ModeHTML})
 }
 
-// handleRestart restarts the bot process. If running under launchd,
-// uses launchctl to do a clean restart. Otherwise, exits and relies
-// on the user to restart manually.
+// handleRestart restarts the bot process. If running under a process
+// supervisor (launchd or systemd), uses the supervisor to restart.
+// Otherwise, exits and relies on the user to restart manually.
 func (b *Bot) handleRestart(c tele.Context) error {
 	log.Info("/restart: restart requested via Telegram")
 
-	if isLaunchdManaged(b.effectiveServiceLabel()) {
-		_ = c.Send("Restarting via launchd... be right back.")
+	if mgr := b.processManager(); mgr != nil && mgr.IsManaged() {
+		_ = c.Send(fmt.Sprintf("Restarting via %s... be right back.", mgr.Name()))
 
-		// launchctl kickstart -k forces a restart of the service.
-		// The -k flag kills the existing instance first.
 		go func() {
 			time.Sleep(500 * time.Millisecond) // let the message send
-			cmd := exec.Command("launchctl", "kickstart", "-k", launchdTarget(b.effectiveServiceLabel()))
-			if err := cmd.Run(); err != nil {
-				log.Error("launchctl kickstart failed, falling back to exit", "err", err)
-				os.Exit(0) // launchd will restart us via KeepAlive
+			if err := mgr.Restart(); err != nil {
+				log.Error("supervisor restart failed, falling back to exit", "err", err)
+				os.Exit(0) // supervisor's Restart=always / KeepAlive will bring us back
 			}
 		}()
 		return nil
 	}
 
-	// Not managed by launchd. Just exit cleanly.
+	// Not managed by a supervisor. Just exit cleanly.
 	_ = c.Send("Shutting down. Restart me manually with `go run main.go`.")
 	go func() {
 		time.Sleep(500 * time.Millisecond)
@@ -171,15 +169,16 @@ func (b *Bot) handleRestart(c tele.Context) error {
 }
 
 // handleUpdate pulls the latest code, builds a new binary, and restarts.
-// This is the self-update mechanism for the Mac Mini production instance.
+// This is the self-update mechanism for production instances.
 // The flow: git pull → go build → backup old binary → swap → restart via
-// launchd. Build failures are caught before the swap — the bot keeps
+// supervisor. Build failures are caught before the swap — the bot keeps
 // running with the old binary if compilation fails.
 func (b *Bot) handleUpdate(c tele.Context) error {
 	log.Info("/update: self-update requested via Telegram")
 
-	if !isLaunchdManaged(b.effectiveServiceLabel()) {
-		return c.Send("⚠️ /update only works when running as a launchd service. Use <code>her setup</code> first.", &tele.SendOptions{ParseMode: tele.ModeHTML})
+	mgr := b.processManager()
+	if mgr == nil || !mgr.IsManaged() {
+		return c.Send("⚠️ /update only works when running as a managed service. Use <code>her setup</code> first.", &tele.SendOptions{ParseMode: tele.ModeHTML})
 	}
 
 	// Determine repo and binary paths.
@@ -213,7 +212,6 @@ func (b *Bot) handleUpdate(c tele.Context) error {
 	buildCmd.Dir = repoPath
 	buildOut, err := buildCmd.CombinedOutput()
 	if err != nil {
-		// Build failed — bot keeps running with old binary.
 		_ = os.Remove(nextBinary)
 		buildMsg := strings.TrimSpace(string(buildOut))
 		return c.Send(fmt.Sprintf("❌ Build failed:\n<pre>%s</pre>", truncateForTelegram(buildMsg, 3800)), &tele.SendOptions{ParseMode: tele.ModeHTML})
@@ -237,15 +235,14 @@ func (b *Bot) handleUpdate(c tele.Context) error {
 	flagContent := fmt.Sprintf("✅ Updated and restarted successfully.\n\n<pre>%s</pre>", truncateForTelegram(pullMsg, 2000))
 	_ = os.WriteFile(flagPath, []byte(flagContent), 0644)
 
-	// Step 6: Restart via launchd.
+	// Step 6: Restart via supervisor.
 	_ = c.Send("🔄 Restarting...")
 
 	go func() {
 		time.Sleep(500 * time.Millisecond) // let the message send
-		cmd := exec.Command("launchctl", "kickstart", "-k", launchdTarget(b.effectiveServiceLabel()))
-		if err := cmd.Run(); err != nil {
-			log.Error("launchctl kickstart failed, falling back to exit", "err", err)
-			os.Exit(0) // launchd will restart us via KeepAlive
+		if err := mgr.Restart(); err != nil {
+			log.Error("supervisor restart failed, falling back to exit", "err", err)
+			os.Exit(0) // supervisor will bring us back (KeepAlive / Restart=always)
 		}
 	}()
 
@@ -311,30 +308,14 @@ func copyFile(src, dst string) error {
 	return os.WriteFile(dst, data, info.Mode())
 }
 
-// launchdServiceLabel returns the launchd service identifier derived from
-// the bot name. e.g., "Mira" → "com.mira.her-go".
-func launchdServiceLabel(botName string) string {
-	return "com." + strings.ToLower(botName) + ".her-go"
-}
-
-// effectiveServiceLabel returns the configured launchd service label,
-// falling back to the name-derived label when update.service_label is empty.
-func (b *Bot) effectiveServiceLabel() string {
-	if b.cfg.Update.ServiceLabel != "" {
-		return b.cfg.Update.ServiceLabel
+// processManager returns a procmgr.Manager for the current platform.
+// Returns nil if the platform is unsupported (shouldn't happen on
+// macOS or Linux).
+func (b *Bot) processManager() procmgr.Manager {
+	label := procmgr.EffectiveLabel(b.cfg.Update.ServiceLabel, b.cfg.Identity.Her)
+	mgr, err := procmgr.New(label)
+	if err != nil {
+		return nil
 	}
-	return launchdServiceLabel(b.cfg.Identity.Her)
-}
-
-// launchdTarget returns the full launchctl target path for the given service
-// label. e.g., "gui/501/com.mira.her-go" — used by kickstart and print commands.
-func launchdTarget(label string) string {
-	return fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
-}
-
-// isLaunchdManaged checks if a service is running under launchd by
-// querying launchctl with the given service label.
-func isLaunchdManaged(label string) bool {
-	cmd := exec.Command("launchctl", "print", launchdTarget(label))
-	return cmd.Run() == nil
+	return mgr
 }

--- a/bot/handlers_location.go
+++ b/bot/handlers_location.go
@@ -87,7 +87,7 @@ func (b *Bot) runLocationAgent(c tele.Context, syntheticText, conversationID str
 		log.Error("saving location message", "err", err)
 	}
 
-	return b.runAgent(c, AgentInput{
+	return b.runAgent(NewTelegramFrontend(c, b), AgentInput{
 		UserMessage:    syntheticText,
 		ConversationID: conversationID,
 		TriggerMsgID:   msgID,

--- a/bot/handlers_media.go
+++ b/bot/handlers_media.go
@@ -115,7 +115,7 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	}
 
 	// Run the agent with image data attached.
-	return b.runAgent(c, AgentInput{
+	return b.runAgent(NewTelegramFrontend(c, b), AgentInput{
 		UserMessage:    userText,
 		ScrubbedText:   scrubResult.Text,
 		ScrubVault:     scrubResult.Vault,
@@ -264,7 +264,7 @@ func (b *Bot) handleVoice(c tele.Context) error {
 	// Run the agent pipeline. The voice handler customizes two things:
 	//  - PlaceholderText: shows the transcript while thinking
 	//  - ForceTTS: always reply with voice (they sent a voice memo)
-	return b.runAgent(c, AgentInput{
+	return b.runAgent(NewTelegramFrontend(c, b), AgentInput{
 		UserMessage:     "\U0001F3A4 " + userText,
 		ScrubbedText:    scrubResult.Text,
 		ScrubVault:      scrubResult.Vault,

--- a/bot/run_agent.go
+++ b/bot/run_agent.go
@@ -13,7 +13,6 @@
 package bot
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -89,14 +88,12 @@ type AgentInput struct {
 //  6. Run agent.Run synchronously
 //  7. Clean up (stop typing, emit TurnEndEvent)
 //  8. Handle errors (edit placeholder with error message)
-func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
-	// Prevent concurrent agent runs. Telegram can deliver the same update twice
-	// (retry on slow response) or the user can send two messages before the
-	// first turn finishes. Either way, only one agent turn runs at a time.
-	// The message is not dropped — we tell the user and let them resend.
+func (b *Bot) runAgent(fe Frontend, input AgentInput) error {
+	// Prevent concurrent agent runs. Two simultaneous runs would race
+	// for the same conversation state.
 	if b.agentBusy.Load() {
 		log.Info("agent busy, ignoring concurrent message", "msg", truncate(input.UserMessage, 60))
-		return c.Send("Still working on your last message — give me just a moment.")
+		return fe.SendBusy()
 	}
 
 	// Apply defaults for optional fields.
@@ -110,17 +107,9 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	}
 
 	// --- Typing indicator ---
-	// Telegram's typing indicator expires after ~5 seconds, so we
-	// refresh it every 4. The Tracker wraps the stop function in
-	// sync.Once, so it's safe to call from the reply tool (early stop),
-	// from the Tracker when all phases finish, or from the defer below
-	// (panic safety). No more leaked goroutines.
-	stopTypingFn := b.startTypingIndicator(c)
+	stopTypingFn := fe.StartTyping()
 
 	// --- Turn tracker ---
-	// The Tracker manages the full lifecycle of this message turn,
-	// including background agents. It emits TurnStartEvent now and
-	// TurnEndEvent when all phases (main, memory, mood) complete.
 	tracker := turn.NewTracker(
 		input.TriggerMsgID,
 		b.eventBus,
@@ -128,146 +117,72 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 		truncate(input.UserMessage, 100),
 		input.ConversationID,
 	)
-	defer tracker.StopTyping() // panic safety — guarantees typing stops
+	defer tracker.StopTyping()
 
 	// --- Trace callbacks ---
-	// Trace callbacks pull from a single per-turn trace.Board. Each
-	// registered stream gets its own slot; render order comes from
-	// the trace.Streams() registry so main always shows before
-	// memory / mood. New agents in new packages can request a
-	// callback just by registering + calling getTrace("their-slot").
 	var traceCallback tools.TraceCallback
 	var memoryTraceCallback tools.TraceCallback
 	var moodTraceCallback tools.TraceCallback
 	var personaTraceCallback tools.TraceCallback
 	var introspectionTraceCallback tools.TraceCallback
 	var traceFinalize func()
+
+	// Traces require a tele.Context for Telegram rendering. For
+	// non-Telegram frontends, traces still flow through the event bus
+	// (visible in the TUI) but don't get a Telegram message.
 	if b.cfg.Driver.Trace {
-		tr := b.makeTraceCallbacks(c)
-		traceCallback = tr.getCallback("main")
-		memoryTraceCallback = tr.getCallback("memory")
-		moodTraceCallback = tr.getCallback("mood")
-		personaTraceCallback = tr.getCallback("persona")
-		introspectionTraceCallback = tr.getCallback("introspection")
-		traceFinalize = tr.finalize
+		if tfe, ok := fe.(*TelegramFrontend); ok {
+			tr := b.makeTraceCallbacks(tfe.Context())
+			traceCallback = tr.getCallback("main")
+			memoryTraceCallback = tr.getCallback("memory")
+			moodTraceCallback = tr.getCallback("mood")
+			personaTraceCallback = tr.getCallback("persona")
+			introspectionTraceCallback = tr.getCallback("introspection")
+			traceFinalize = tr.finalize
+		}
 	}
-	// Suppress unused-variable warning — personaTraceCallback is wired
-	// up for future use by the dreamer/reflect path.
 	_ = personaTraceCallback
 
 	// --- Reply placeholder ---
-	// The thinking emoji (💭) signals to the user that we're processing.
-	// Voice handler overrides this with the transcript text.
 	placeholderText := "\U0001F4AD"
 	if input.PlaceholderText != "" {
 		placeholderText = input.PlaceholderText
 	}
 
-	// Build send options — HTML parse mode only when the placeholder
-	// contains HTML (e.g., voice handler's <i>transcript</i>).
-	var placeholderOpts []interface{}
-	if input.PlaceholderHTML {
-		placeholderOpts = append(placeholderOpts, &tele.SendOptions{ParseMode: tele.ModeHTML})
-	}
-
-	placeholder, sendErr := c.Bot().Send(c.Recipient(), placeholderText, placeholderOpts...)
-	if sendErr != nil {
+	if err := fe.SendPlaceholder(placeholderText, input.PlaceholderHTML); err != nil {
 		tracker.StopTyping()
-		log.Error("sending placeholder", "err", sendErr)
-		return c.Send("Sorry, I'm having trouble right now. Try again in a moment?")
+		log.Error("sending placeholder", "err", err)
+		return fe.SendError("Sorry, I'm having trouble right now. Try again in a moment?")
 	}
 
-	// --- Callbacks ---
-	// These closures all capture `placeholder` by reference. When
-	// stageResetCallback reassigns it, statusCallback automatically
-	// targets the new message. This is the same closure behavior as
-	// Python — variables are looked up at call time, not definition time.
+	// --- Build callbacks from the Frontend interface ---
+	statusCallback := func(status string) error { return fe.EditStatus(status) }
+	sendCallback := func(text string) error { return fe.SendReply(text) }
+	sendConfirmCallback := func(text string) (int64, error) { return fe.SendConfirm(text) }
+	stageResetCallback := func() error { return fe.StageReset() }
+	deletePlaceholderCallback := func() error { return fe.DeletePlaceholder() }
+	sendPaginatedCallback := func(text string) error { return fe.SendPaginated(text) }
 
-	// statusCallback edits the placeholder with status updates or the
-	// final reply text.
-	statusCallback := func(status string) error {
-		if input.PlaceholderHTML {
-			_, err := c.Bot().Edit(placeholder, status, &tele.SendOptions{ParseMode: tele.ModeHTML})
-			return err
-		}
-		_, err := c.Bot().Edit(placeholder, status)
-		return err
-	}
-
-	// sendCallback sends a NEW message (for follow-up replies, not edits).
-	sendCallback := func(text string) error {
-		_, err := c.Bot().Send(c.Recipient(), text, &tele.SendOptions{ParseMode: tele.ModeHTML})
-		return err
-	}
-
-	// sendConfirmCallback sends a message with Yes/No inline buttons
-	// and returns the Telegram message ID for the pending_confirmations table.
-	sendConfirmCallback := func(text string) (int64, error) {
-		markup := &tele.ReplyMarkup{}
-		btnYes := markup.Data("Yes", "confirm", "yes")
-		btnNo := markup.Data("No", "confirm", "no")
-		markup.Inline(markup.Row(btnYes, btnNo))
-
-		msg, err := c.Bot().Send(c.Recipient(), text, &tele.SendOptions{
-			ParseMode:   tele.ModeHTML,
-			ReplyMarkup: markup,
-		})
-		if err != nil {
-			return 0, err
-		}
-		return int64(msg.ID), nil
-	}
-
-	// stageResetCallback sends a fresh placeholder after a reply is sent.
-	// Because statusCallback closes over the `placeholder` variable,
-	// reassigning it here means statusCallback automatically edits the
-	// new message on subsequent calls.
-	stageResetCallback := func() error {
-		newPlaceholder, err := c.Bot().Send(c.Recipient(), "\U0001F4AD")
-		if err != nil {
-			return fmt.Errorf("stage reset: sending new placeholder: %w", err)
-		}
-		placeholder = newPlaceholder
-		return nil
-	}
-
-	// deletePlaceholderCallback removes the orphan 💭 left by the
-	// last stage reset after the agent loop exits.
-	deletePlaceholderCallback := func() error {
-		return c.Bot().Delete(placeholder)
-	}
-
-	// TTS callback — fires inside execReply so voice synthesis starts
-	// immediately when text is sent, not after the whole agent loop.
-	// ForceTTS (set by voice handler) bypasses the reply mode check.
+	// TTS callback — only wired for Telegram frontends with voice support.
 	var ttsCallback tools.TTSCallback
-	if b.ttsClient != nil && (input.ForceTTS || b.ttsClient.ReplyMode() == "voice") {
-		ttsCallback = func(text string) {
-			b.sendVoiceReply(c, text)
+	if tfe, ok := fe.(*TelegramFrontend); ok {
+		if b.ttsClient != nil && (input.ForceTTS || b.ttsClient.ReplyMode() == "voice") {
+			ttsCallback = func(text string) {
+				b.sendVoiceReply(tfe.Context(), text)
+			}
 		}
 	}
 
-	// Stream callback — delivers live tokens to Telegram as the chat model
-	// generates them, creating a typing effect. Only active when streaming
-	// is enabled in config. getPlaceholder is a closure so it always returns
-	// the current placeholder, even after a stageResetCallback reassignment.
+	// Stream callback — only for frontends that support streaming.
 	var streamCallback tools.StreamCallback
 	var stopStream func()
-	if b.cfg.Chat.Streaming {
-		streamCallback, stopStream = b.makeStreamCallback(c, func() *tele.Message { return placeholder })
-	}
-
-	// sendPaginatedCallback wraps the bot's pagination system for the
-	// reply tool. When a message exceeds Telegram's 4096-char limit,
-	// this splits it into pages with ◀/▶ navigation buttons. The pages
-	// are stored in Bot.pageSessions and served by handlePageCallback.
-	sendPaginatedCallback := func(text string) error {
-		return b.sendPaginated(c, text)
+	if fe.SupportsStreaming() {
+		if tfe, ok := fe.(*TelegramFrontend); ok {
+			streamCallback, stopStream = b.makeStreamCallback(tfe.Context(), func() *tele.Message { return tfe.Placeholder() })
+		}
 	}
 
 	// --- Run the agent ---
-	// WaitGroup for introspection coordination — memory and mood goroutines
-	// call Done() when they finish, introspection goroutine calls Wait().
 	var introWG sync.WaitGroup
 
 	params := b.baseRunParams()
@@ -295,9 +210,6 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	result, err := agent.Run(params)
 	b.agentBusy.Store(false)
 
-	// Stop the stream ticker before stopping typing — both may try to
-	// edit the placeholder, and we want the authoritative StatusCallback
-	// edit (deanonymized text, already sent inside agent.Run) to be last.
 	if stopStream != nil {
 		stopStream()
 	}
@@ -305,39 +217,23 @@ func (b *Bot) runAgent(c tele.Context, input AgentInput) error {
 	if err != nil {
 		tracker.StopTyping()
 		log.Error("agent error", "err", err)
-		_, _ = c.Bot().Edit(placeholder, "Sorry, I'm having trouble thinking right now. Try again in a moment?")
+		_ = fe.SendError("Sorry, I'm having trouble thinking right now. Try again in a moment?")
 		return nil
 	}
 
 	log.Infof("  %s: %s", strings.ToLower(b.cfg.Identity.Her), truncate(result.ReplyText, 100))
 	log.Info("─── reply sent ───")
 
-	// Fire the mood agent in a goroutine. Begin the phase BEFORE
-	// launching the goroutine to prevent a race where all known phases
-	// finish and TurnEndEvent fires before the mood goroutine starts.
+	// Fire background agents (mood, introspection).
 	b.launchMoodAgent(input.ConversationID, moodTraceCallback, tracker, &introWG)
-
-	// Fire the introspection agent — waits for memory + mood to finish
-	// before snapshotting self-memories and starting its loop.
 	b.launchIntrospectionAgent(result, params, &introWG, introspectionTraceCallback, tracker)
 
-	// Finalize the trace — store the snapshot for /lasttrace and
-	// paginate overflow if the trace exceeds Telegram's char limit.
-	// This runs after the main agent completes but before mood/memory
-	// background agents finish, so their slots may still be updating.
-	// That's OK — /lasttrace can be called later to get the full picture.
 	if traceFinalize != nil {
-		// Small delay lets the background agents write their initial
-		// content before we snapshot. Not critical — the snapshot
-		// captures whatever's in the board at this moment.
 		go func() {
 			time.Sleep(2 * time.Second)
 			traceFinalize()
 		}()
 	}
-
-	// No manual TurnEndEvent here — the Tracker emits it when all
-	// phases (main, memory, mood) complete, with accumulated metrics.
 
 	return nil
 }
@@ -388,29 +284,6 @@ func (b *Bot) baseRunParams() agent.RunParams {
 	}
 }
 
-// startTypingIndicator launches the Telegram typing indicator goroutine
-// and returns a function that stops it. The returned function closes a
-// channel — it's safe to call via sync.Once (which the Tracker does).
-//
-// Extracted so runAgent doesn't own the channel directly — the Tracker
-// wraps this in sync.Once for panic-safe cleanup.
-func (b *Bot) startTypingIndicator(c tele.Context) func() {
-	stopTyping := make(chan struct{})
-	go func() {
-		_ = c.Notify(tele.Typing)
-		ticker := time.NewTicker(4 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stopTyping:
-				return
-			case <-ticker.C:
-				_ = c.Notify(tele.Typing)
-			}
-		}
-	}()
-	return func() { close(stopTyping) }
-}
 
 // makeStreamCallback creates a streaming callback that funnels LLM tokens to
 // Telegram via incremental message edits. Returns the callback (for injection

--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -418,7 +418,9 @@ func (b *Bot) Stop() {
 	}
 	b.agentEventsStopped.Store(true) // prevent sends before channel close
 	close(b.shutdownCh)              // unblocks wizard expiry + other goroutines
-	b.tb.Stop()                      // stop accepting new Telegram updates
+	if b.tb != nil {
+		b.tb.Stop() // stop accepting new Telegram updates
+	}
 	close(b.agentEvents)             // signals consumeAgentEvents goroutine to exit
 }
 

--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -291,6 +291,81 @@ func New(cfg *config.Config, configPath string, llmClient *llm.Client, driverLLM
 	return bot, nil
 }
 
+// NewDev creates a Bot configured for local dev mode — no Telegram
+// connection, no bot token required. The Bot's agent pipeline, store,
+// LLM clients, and event bus all work normally. Use ProcessMessage()
+// to run turns from the HTTP dev server.
+//
+// This is the same Bot struct with the same agent pipeline — just no
+// Telegram transport. Like creating a Python class with all methods
+// working but the network socket set to None.
+func NewDev(cfg *config.Config, configPath string, llmClient *llm.Client, driverLLM *llm.Client, memoryAgentLLM *llm.Client, moodAgentLLM *llm.Client, visionLLM *llm.Client, classifierLLM *llm.Client, dreamAgentLLM *llm.Client, introspectionLLM *llm.Client, embedClient *embed.Client, tavilyClient *search.TavilyClient, store memory.Store, eventBus *tui.Bus) (*Bot, error) {
+	promptBytes, err := os.ReadFile(cfg.Persona.PromptFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading system prompt from %s: %w", cfg.Persona.PromptFile, err)
+	}
+
+	b := &Bot{
+		// tb is nil — no Telegram connection in dev mode
+		llm:              llmClient,
+		driverLLM:        driverLLM,
+		memoryAgentLLM:   memoryAgentLLM,
+		moodAgentLLM:     moodAgentLLM,
+		visionLLM:        visionLLM,
+		classifierLLM:    classifierLLM,
+		dreamAgentLLM:    dreamAgentLLM,
+		introspectionLLM: introspectionLLM,
+		embedClient:      embedClient,
+		tavilyClient:     tavilyClient,
+		store:            store,
+		cfg:              cfg,
+		configPath:       configPath,
+		systemPrompt:     string(promptBytes),
+		startTime:        time.Now(),
+		eventBus:         eventBus,
+		agentEvents:      make(chan agent.AgentEvent, 16),
+		shutdownCh:       make(chan struct{}),
+	}
+
+	return b, nil
+}
+
+// ProcessMessage runs a user message through the full agent pipeline
+// using the given Frontend for I/O. This is the transport-agnostic
+// entry point — the HTTP dev server and any future frontends call this
+// instead of going through Telegram's handleMessage.
+func (b *Bot) ProcessMessage(fe Frontend, userText, conversationID string) (string, error) {
+	log.Info("─── incoming message ───")
+	log.Infof("  user: %s", truncate(userText, 100))
+
+	// Save the raw message.
+	msgID, err := b.store.SaveMessage("user", userText, "", conversationID)
+	if err != nil {
+		log.Error("saving message", "err", err)
+	}
+
+	// PII scrub.
+	scrubResult := b.scrubText(userText)
+	if msgID > 0 {
+		b.store.UpdateMessageScrubbed(msgID, scrubResult.Text)
+		b.savePIIVaultEntries(msgID, scrubResult.Vault)
+	}
+
+	// Run the agent pipeline.
+	err = b.runAgent(fe, AgentInput{
+		UserMessage:    userText,
+		ScrubbedText:   scrubResult.Text,
+		ScrubVault:     scrubResult.Vault,
+		ConversationID: conversationID,
+		TriggerMsgID:   msgID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return fe.ReplyText(), nil
+}
+
 // Start begins receiving Telegram updates (via polling or webhook).
 // This blocks forever (or until the bot is stopped), so it's typically
 // the last thing called in main.go.
@@ -550,7 +625,7 @@ func (b *Bot) handleMessage(c tele.Context) error {
 
 	// Step 3: Run the agent pipeline — typing, placeholder, callbacks,
 	// TUI events, and error handling are all handled by runAgent.
-	return b.runAgent(c, AgentInput{
+	return b.runAgent(NewTelegramFrontend(c, b), AgentInput{
 		UserMessage:    userText,
 		ScrubbedText:   scrubResult.Text,
 		ScrubVault:     scrubResult.Vault,

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -283,10 +283,10 @@ func runDev(cmd *cobra.Command, args []string) error {
 	// --- HTTP handlers ---
 	mux := http.NewServeMux()
 
-	// CORS middleware — Gradio runs on :7860, our API on :7777.
+	// CORS middleware — restrict to Gradio's default origin (localhost:7860).
 	cors := func(h http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Origin", "http://localhost:7860")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 			if r.Method == "OPTIONS" {
@@ -304,6 +304,7 @@ func runDev(cmd *cobra.Command, args []string) error {
 		}
 
 		var req chatRequest
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, `{"error": "invalid JSON"}`, http.StatusBadRequest)
 			return

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,42 +1,44 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
+	"os/signal"
+	"sync"
 	"syscall"
-	"text/template"
 	"time"
 
+	"her/bot"
 	"her/config"
+	"her/d1"
+	"her/embed"
+	"her/llm"
+	"her/logger"
+	"her/memory"
+	"her/retry"
+	"her/search"
+	"her/tui"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
+
+var devLog = logger.WithPrefix("dev")
 
 var devCmd = &cobra.Command{
 	Use:   "dev",
-	Short: "Start a dev session with ephemeral tunnel and KV routing",
-	Long: `Starts a development session on the MacBook:
+	Short: "Start the dev server with HTTP API (no Telegram)",
+	Long: `Starts the full agent pipeline with a local HTTP API on :7777.
+Use with the Gradio dev chat frontend (scripts/dev_chat.py).
+No Telegram token required — the VPS owns Telegram, your Mac owns dev mode.
 
-  1. Launches an ephemeral Cloudflare Tunnel (*.trycloudflare.com)
-  2. Sets KV routing keys so the CF Worker sends traffic here
-  3. Starts a heartbeat goroutine to keep the dev session alive
-  4. Runs the bot in webhook mode with a separate dev database
-  5. On Ctrl+C: clears KV keys so prod resumes immediately
-
-The Mac Mini prod instance keeps running but receives no traffic while
-dev mode is active. When you stop, the CF Worker routes back to prod
-within seconds.
-
-Requires cloudflare section in config.yaml (account_id, api_token, kv_namespace_id).`,
+  Terminal 1:  her dev
+  Terminal 2:  uv run scripts/dev_chat.py
+  Browser:     http://localhost:7860`,
 	RunE: runDev,
 }
 
@@ -44,343 +46,348 @@ func init() {
 	rootCmd.AddCommand(devCmd)
 }
 
-// trycloudflarePattern matches the assigned tunnel URL from cloudflared output.
-// cloudflared prints: "... https://random-words.trycloudflare.com ..."
-var trycloudflarePattern = regexp.MustCompile(`https://[a-zA-Z0-9-]+\.trycloudflare\.com`)
+// chatRequest is the JSON body for POST /api/chat.
+type chatRequest struct {
+	Message        string `json:"message"`
+	ConversationID string `json:"conversation_id"`
+}
 
-// runDev orchestrates the dev session lifecycle.
+// chatResponse is the JSON response from POST /api/chat.
+type chatResponse struct {
+	Reply          string `json:"reply"`
+	ConversationID string `json:"conversation_id"`
+}
+
 func runDev(cmd *cobra.Command, args []string) error {
-	// Load config to get Cloudflare credentials.
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		devLog.Fatal("failed to load config", "err", err)
+	}
+	cfg.ExportEnv()
+
+	if cfg.OpenRouter.APIKey == "" {
+		devLog.Fatal("LLM API key is required — set OPENROUTER_API_KEY or fill config.yaml")
 	}
 
-	// Validate Cloudflare API credentials.
-	if cfg.Cloudflare.AccountID == "" || cfg.Cloudflare.APIToken == "" || cfg.Cloudflare.KVNamespaceID == "" {
-		return fmt.Errorf("cloudflare section in config.yaml is incomplete — need account_id, api_token, and kv_namespace_id for dev mode KV routing")
-	}
-
-	// Generate worker/wrangler.toml from config.yaml so IDs stay out
-	// of version control. Non-fatal — wrangler.toml is only needed for
-	// `npx wrangler deploy`, not for the bot itself.
-	if err := generateWranglerConfig(cfg); err != nil {
-		log.Warn("could not generate wrangler.toml", "err", err)
-	}
-
-	// Check cloudflared is installed.
-	cloudflaredBin, err := exec.LookPath("cloudflared")
+	// --- Store ---
+	store, err := memory.NewStore(cfg.Memory.DBPath, cfg.Embed.Dimension)
 	if err != nil {
-		return fmt.Errorf("cloudflared not found — install with: brew install cloudflare/cloudflare/cloudflared")
+		devLog.Fatal("failed to initialize database", "err", err)
+	}
+	store.AutoLinkCount = cfg.Memory.AutoLinkCount
+	store.AutoLinkThreshold = cfg.Memory.AutoLinkThreshold
+
+	var botStore memory.Store = store
+	if cfg.Cloudflare.D1DatabaseID != "" {
+		d1Client := d1.NewClient(cfg.Cloudflare.AccountID, cfg.Cloudflare.D1DatabaseID, cfg.Cloudflare.APIToken)
+		if d1Client != nil {
+			synced, err := memory.NewSyncedStore(store, d1Client)
+			if err != nil {
+				devLog.Fatal("failed to initialize D1 sync", "err", err)
+			}
+			if cfg.Cloudflare.Sync.BatchSize > 0 {
+				synced.BatchSize = cfg.Cloudflare.Sync.BatchSize
+			}
+			if cfg.Cloudflare.Sync.PullPageSize > 0 {
+				synced.PullPageSize = cfg.Cloudflare.Sync.PullPageSize
+			}
+
+			pullCtx, pullCancel := context.WithTimeout(context.Background(), 60*time.Second)
+			err = retry.Do(pullCtx, retry.Config{
+				MaxAttempts: 3,
+				Backoff:     retry.Exponential,
+				InitialWait: 2 * time.Second,
+			}, func() error {
+				return synced.Pull(pullCtx)
+			})
+			if err != nil {
+				devLog.Error("d1 pull failed — continuing with local data", "err", err)
+			}
+			pullCancel()
+
+			botStore = synced
+			devLog.Info("d1 sync enabled")
+		}
+	}
+	defer botStore.Close()
+
+	// --- Event bus + logging ---
+	bus := tui.NewBus()
+
+	logFile := &lumberjack.Logger{
+		Filename:   "logs/dev.log",
+		MaxSize:    10,
+		MaxBackups: 0,
+		MaxAge:     0,
+		LocalTime:  true,
+	}
+	_ = logFile.Rotate()
+	logger.Init(bus, nil)
+	tui.StartFileLogger(bus, logFile)
+
+	devLog.Info("SESSION_START",
+		"mode", "dev",
+		"driver_model", cfg.Driver.Model,
+		"chat_model", cfg.Chat.Model,
+	)
+
+	// --- LLM clients ---
+	// Same initialization as cmd/run.go — each agent gets its own client
+	// with model, temperature, timeout, fallback, and provider routing
+	// from config.yaml.
+
+	llmClient := llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.Chat.Model, cfg.Chat.Temperature, cfg.Chat.MaxTokens)
+	if cfg.Chat.Timeout > 0 {
+		llmClient.WithTimeout(time.Duration(cfg.Chat.Timeout) * time.Second)
+	}
+	if cfg.Chat.Provider != nil {
+		llmClient.WithProvider(&llm.ProviderRouting{Order: cfg.Chat.Provider.Order, Only: cfg.Chat.Provider.Only, Sort: cfg.Chat.Provider.Sort})
+	}
+	if cfg.Chat.Fallback != nil {
+		llmClient.WithFallback(cfg.Chat.Fallback.Model, cfg.Chat.Fallback.Temperature, cfg.Chat.Fallback.MaxTokens)
+	}
+	if cfg.Chat.Reasoning != nil && cfg.Chat.Reasoning.Enabled != nil {
+		llmClient.WithReasoning(&llm.ReasoningControl{Enabled: cfg.Chat.Reasoning.Enabled})
 	}
 
-	// Determine webhook port.
-	webhookPort := cfg.Telegram.WebhookPort
-	if webhookPort == 0 {
-		webhookPort = 8443
+	driverClient := llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.Driver.Model, cfg.Driver.Temperature, cfg.Driver.MaxTokens)
+	if cfg.Driver.Timeout > 0 {
+		driverClient.WithTimeout(time.Duration(cfg.Driver.Timeout) * time.Second)
+	}
+	if cfg.Driver.Fallback != nil {
+		driverClient.WithFallback(cfg.Driver.Fallback.Model, cfg.Driver.Fallback.Temperature, cfg.Driver.Fallback.MaxTokens)
+	}
+	if cfg.Driver.Reasoning != nil && cfg.Driver.Reasoning.Enabled != nil {
+		driverClient.WithReasoning(&llm.ReasoningControl{Enabled: cfg.Driver.Reasoning.Enabled})
 	}
 
-	// Step 1: Start ephemeral tunnel.
-	log.Info("starting ephemeral tunnel...")
-	tunnelURL, tunnelProcess, err := startEphemeralTunnel(cloudflaredBin, webhookPort)
+	var visionClient *llm.Client
+	if cfg.Vision.Model != "" {
+		visionClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.Vision.Model, cfg.Vision.Temperature, cfg.Vision.MaxTokens)
+		if cfg.Vision.Fallback != nil {
+			visionClient.WithFallback(cfg.Vision.Fallback.Model, cfg.Vision.Fallback.Temperature, cfg.Vision.Fallback.MaxTokens)
+		}
+	}
+
+	var classifierClient *llm.Client
+	if cfg.Classifier.Model != "" {
+		classifierClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.Classifier.Model, cfg.Classifier.Temperature, cfg.Classifier.MaxTokens)
+	}
+
+	var memoryAgentClient *llm.Client
+	if cfg.MemoryAgent.Model != "" {
+		memoryAgentClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.MemoryAgent.Model, cfg.MemoryAgent.Temperature, cfg.MemoryAgent.MaxTokens)
+		if cfg.MemoryAgent.Timeout > 0 {
+			memoryAgentClient.WithTimeout(time.Duration(cfg.MemoryAgent.Timeout) * time.Second)
+		}
+		if cfg.MemoryAgent.Provider != nil {
+			memoryAgentClient.WithProvider(&llm.ProviderRouting{Order: cfg.MemoryAgent.Provider.Order, Only: cfg.MemoryAgent.Provider.Only, Sort: cfg.MemoryAgent.Provider.Sort})
+		}
+		if cfg.MemoryAgent.Fallback != nil {
+			memoryAgentClient.WithFallback(cfg.MemoryAgent.Fallback.Model, cfg.MemoryAgent.Fallback.Temperature, cfg.MemoryAgent.Fallback.MaxTokens)
+		}
+		if cfg.MemoryAgent.Reasoning != nil && cfg.MemoryAgent.Reasoning.Enabled != nil {
+			memoryAgentClient.WithReasoning(&llm.ReasoningControl{Enabled: cfg.MemoryAgent.Reasoning.Enabled})
+		}
+	}
+
+	var moodAgentClient *llm.Client
+	if cfg.MoodAgent.Model != "" {
+		mTemp := cfg.MoodAgent.Temperature
+		if mTemp == 0 {
+			mTemp = 0.2
+		}
+		mTokens := cfg.MoodAgent.MaxTokens
+		if mTokens == 0 {
+			mTokens = 512
+		}
+		moodAgentClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.MoodAgent.Model, mTemp, mTokens)
+		if cfg.MoodAgent.Timeout > 0 {
+			moodAgentClient.WithTimeout(time.Duration(cfg.MoodAgent.Timeout) * time.Second)
+		}
+		if cfg.MoodAgent.Provider != nil {
+			moodAgentClient.WithProvider(&llm.ProviderRouting{Order: cfg.MoodAgent.Provider.Order, Only: cfg.MoodAgent.Provider.Only, Sort: cfg.MoodAgent.Provider.Sort})
+		}
+		if cfg.MoodAgent.Fallback != nil {
+			moodAgentClient.WithFallback(cfg.MoodAgent.Fallback.Model, cfg.MoodAgent.Fallback.Temperature, cfg.MoodAgent.Fallback.MaxTokens)
+		}
+	}
+
+	var embedClient *embed.Client
+	if cfg.Embed.BaseURL != "" && cfg.Embed.Model != "" {
+		embedClient = embed.NewClient(cfg.Embed.BaseURL, cfg.Embed.Model, cfg.Embed.APIKey, cfg.Embed.Dimension)
+	}
+
+	var embedProcess *exec.Cmd
+	if embedClient != nil {
+		if embedClient.IsAvailable() {
+			devLog.Info("embed server ready", "model", cfg.Embed.Model)
+		} else if cfg.Embed.StartCommand != "" {
+			embedProcess = startEmbedSidecar(cfg, bus, embedClient)
+		} else {
+			devLog.Warn("embed server not responding — semantic recall degraded")
+		}
+	}
+
+	var tavilyClient *search.TavilyClient
+	if cfg.Search.TavilyAPIKey != "" {
+		tavilyClient = search.NewTavilyClient(cfg.Search.TavilyAPIKey, cfg.Search.TavilyBaseURL)
+	}
+
+	// Dream + introspection agents — fall back to memory agent if not configured.
+	var dreamAgentClient *llm.Client
+	if cfg.DreamAgent.Model != "" {
+		dreamAgentClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.DreamAgent.Model, cfg.DreamAgent.Temperature, cfg.DreamAgent.MaxTokens)
+		timeout := cfg.DreamAgent.Timeout
+		if timeout == 0 {
+			timeout = 120
+		}
+		dreamAgentClient.WithTimeout(time.Duration(timeout) * time.Second)
+	} else if memoryAgentClient != nil {
+		dreamAgentClient = memoryAgentClient
+	}
+
+	var introspectionClient *llm.Client
+	if cfg.IntrospectionAgent.Model != "" {
+		introspectionClient = llm.NewClient(cfg.OpenRouter.BaseURL, cfg.OpenRouter.APIKey, cfg.IntrospectionAgent.Model, cfg.IntrospectionAgent.Temperature, cfg.IntrospectionAgent.MaxTokens)
+		timeout := cfg.IntrospectionAgent.Timeout
+		if timeout == 0 {
+			timeout = 60
+		}
+		introspectionClient.WithTimeout(time.Duration(timeout) * time.Second)
+	} else if memoryAgentClient != nil {
+		introspectionClient = memoryAgentClient
+	}
+
+	// --- Create bot (no Telegram) ---
+	devBot, err := bot.NewDev(cfg, cfgFile, llmClient, driverClient, memoryAgentClient, moodAgentClient, visionClient, classifierClient, dreamAgentClient, introspectionClient, embedClient, tavilyClient, botStore, bus)
 	if err != nil {
-		return fmt.Errorf("starting ephemeral tunnel: %w", err)
-	}
-	log.Info("tunnel ready", "url", tunnelURL)
-
-	// Build the KV client from config.
-	kv := &kvClient{
-		accountID:   cfg.Cloudflare.AccountID,
-		apiToken:    cfg.Cloudflare.APIToken,
-		namespaceID: cfg.Cloudflare.KVNamespaceID,
-		http:        &http.Client{Timeout: kvClientTimeout},
+		devLog.Fatal("failed to create dev bot", "err", err)
 	}
 
-	// Step 2: Set KV routing keys.
-	log.Info("setting KV routing keys...")
-	if err := kv.put("dev_mode_active", "true"); err != nil {
-		killTunnel(tunnelProcess)
-		return fmt.Errorf("setting dev_mode_active: %w", err)
-	}
-	if err := kv.put("dev_instance_url", tunnelURL); err != nil {
-		killTunnel(tunnelProcess)
-		return fmt.Errorf("setting dev_instance_url: %w", err)
-	}
-	if err := kv.put("dev_session_heartbeat", nowMillis()); err != nil {
-		killTunnel(tunnelProcess)
-		return fmt.Errorf("setting dev_session_heartbeat: %w", err)
-	}
-	log.Info("KV routing active — traffic redirected to dev")
+	// --- Conversation state ---
+	var (
+		currentConvID string
+		convMu        sync.Mutex
+	)
 
-	// Step 3: Start heartbeat goroutine (refreshes every 2 minutes).
-	// The CF Worker considers the dev session stale after 5 minutes
-	// without a heartbeat — this keeps it alive.
-	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(2 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := kv.put("dev_session_heartbeat", nowMillis()); err != nil {
-					log.Warn("heartbeat failed", "err", err)
-				}
-			case <-heartbeatCtx.Done():
+	getConvID := func() string {
+		convMu.Lock()
+		defer convMu.Unlock()
+		if currentConvID == "" {
+			currentConvID = fmt.Sprintf("dev-%d", time.Now().UnixNano())
+		}
+		return currentConvID
+	}
+
+	// --- HTTP handlers ---
+	mux := http.NewServeMux()
+
+	// CORS middleware — Gradio runs on :7860, our API on :7777.
+	cors := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusNoContent)
 				return
 			}
+			h(w, r)
 		}
-	}()
-
-	// Step 4: Set config transform so runBot uses webhook mode.
-	// No separate dev DB — both machines use their own local her.db,
-	// kept in sync via D1. The Pull on startup hydrates this machine's
-	// her.db with any data the other machine created.
-	configTransform = func(c *config.Config) {
-		c.Telegram.Mode = "webhook"
-		log.Info("dev overrides applied", "mode", "webhook")
 	}
 
-	// Step 5: Set cleanup hook — clears KV keys on shutdown so traffic
-	// routes back to prod immediately.
-	devCleanup = func() {
-		log.Info("clearing KV routing keys...")
-		heartbeatCancel()
-
-		// Signal the prod instance that dev ended — it polls for this
-		// key and triggers a D1 Pull to sync any data we created.
-		if err := kv.put("dev_session_ended", nowMillis()); err != nil {
-			log.Warn("failed to write dev_session_ended", "err", err)
+	mux.HandleFunc("/api/chat", cors(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
 		}
 
-		// Best-effort cleanup — if these fail, the 5-minute heartbeat
-		// timeout in the CF Worker handles it automatically.
-		_ = kv.delete("dev_mode_active")
-		_ = kv.delete("dev_instance_url")
-		_ = kv.delete("dev_session_heartbeat")
-		log.Info("KV cleared — traffic routed back to prod")
+		var req chatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error": "invalid JSON"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Message == "" {
+			http.Error(w, `{"error": "message is required"}`, http.StatusBadRequest)
+			return
+		}
 
-		// Kill the ephemeral tunnel process.
-		killTunnel(tunnelProcess)
-		log.Info("tunnel stopped")
+		convID := req.ConversationID
+		if convID == "" {
+			convID = getConvID()
+		}
+
+		fe := bot.NewDevFrontend()
+		reply, err := devBot.ProcessMessage(fe, req.Message, convID)
+		if err != nil {
+			devLog.Error("agent error", "err", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(chatResponse{
+			Reply:          reply,
+			ConversationID: convID,
+		})
+	}))
+
+	mux.HandleFunc("/api/clear", cors(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		convMu.Lock()
+		currentConvID = fmt.Sprintf("dev-%d", time.Now().UnixNano())
+		newID := currentConvID
+		convMu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"conversation_id": newID})
+	}))
+
+	mux.HandleFunc("/api/status", cors(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":       "ok",
+			"mode":         "dev",
+			"chat_model":   cfg.Chat.Model,
+			"driver_model": cfg.Driver.Model,
+		})
+	}))
+
+	// --- Start HTTP server ---
+	srv := &http.Server{
+		Addr:    ":7777",
+		Handler: mux,
 	}
 
-	// Step 6: Run the bot. This calls into the same runBot that `her run`
-	// uses — the configTransform hook makes it use webhook mode + dev DB,
-	// and devCleanup fires on shutdown.
-	return runBot(cmd, args)
-}
-
-// startEphemeralTunnel launches `cloudflared tunnel --url` and captures the
-// assigned *.trycloudflare.com URL from its output. This is a "quick tunnel"
-// — no tunnel create/login needed, Cloudflare assigns a random URL.
-//
-// The function blocks until the URL is captured (up to 30 seconds).
-func startEphemeralTunnel(cloudflaredBin string, port int) (string, *exec.Cmd, error) {
-	proc := exec.Command(cloudflaredBin, "tunnel", "--url", fmt.Sprintf("http://localhost:%d", port))
-	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	// cloudflared prints the tunnel URL to stderr (not stdout).
-	stderr, err := proc.StderrPipe()
-	if err != nil {
-		return "", nil, fmt.Errorf("creating stderr pipe: %w", err)
-	}
-	// Discard stdout — cloudflared writes nothing useful there.
-	proc.Stdout = io.Discard
-
-	if err := proc.Start(); err != nil {
-		return "", nil, fmt.Errorf("starting cloudflared: %w", err)
-	}
-
-	// Scan stderr line by line for the trycloudflare.com URL.
-	// cloudflared prints a decorative box around it:
-	//   INF +---...---+
-	//   INF |  Your quick Tunnel has been created! Visit it at: ...  |
-	//   INF |  https://random-words.trycloudflare.com                |
-	//   INF +---...---+
-	urlCh := make(chan string, 1)
 	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if match := trycloudflarePattern.FindString(line); match != "" {
-				urlCh <- match
-				break
-			}
+		devLog.Info("dev server listening", "addr", "http://localhost:7777")
+		devLog.Info("start Gradio with: uv run scripts/dev_chat.py")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			devLog.Fatal("http server error", "err", err)
 		}
-		// Keep draining stderr so cloudflared doesn't block on a full pipe.
-		io.Copy(io.Discard, stderr)
 	}()
 
-	// Wait up to 30 seconds for the URL.
-	select {
-	case url := <-urlCh:
-		return url, proc, nil
-	case <-time.After(30 * time.Second):
-		killTunnel(proc)
-		return "", nil, fmt.Errorf("timed out waiting for tunnel URL (30s)")
-	}
-}
+	// --- Wait for signal ---
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
 
-// killTunnel sends SIGKILL to the cloudflared process group.
-func killTunnel(proc *exec.Cmd) {
-	if proc != nil && proc.Process != nil {
-		_ = syscall.Kill(-proc.Process.Pid, syscall.SIGKILL)
-		_, _ = proc.Process.Wait()
-	}
-}
+	devLog.Info("shutting down...")
 
-// --- Cloudflare Workers KV client ---
-// Minimal HTTP client for the KV REST API. Only supports put and delete —
-// that's all dev mode needs. Reading is done by the CF Worker at the edge.
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutCancel()
+	_ = srv.Shutdown(shutCtx)
 
-type kvClient struct {
-	accountID   string
-	apiToken    string
-	namespaceID string
-	http        *http.Client
-}
-
-// kvBaseURL returns the API base for KV operations.
-func (c *kvClient) kvBaseURL() string {
-	return fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/storage/kv/namespaces/%s", c.accountID, c.namespaceID)
-}
-
-// get reads a value from KV. Returns "" if the key doesn't exist.
-// Used by the sync poller to check for the dev_session_ended signal.
-func (c *kvClient) get(key string) (string, error) {
-	url := c.kvBaseURL() + "/values/" + key
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiToken)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("kv get %s: %w", key, err)
-	}
-	defer resp.Body.Close()
-
-	// 404 means the key doesn't exist — not an error, just empty.
-	if resp.StatusCode == http.StatusNotFound {
-		return "", nil
-	}
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("kv get %s: HTTP %d: %s", key, resp.StatusCode, string(body))
+	if embedProcess != nil && embedProcess.Process != nil {
+		_ = syscall.Kill(-embedProcess.Process.Pid, syscall.SIGTERM)
+		embedProcess.Process.Wait()
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("kv get %s: reading body: %w", key, err)
-	}
-	return string(body), nil
-}
-
-// put writes a key-value pair to KV.
-func (c *kvClient) put(key, value string) error {
-	url := c.kvBaseURL() + "/values/" + key
-	req, err := http.NewRequest("PUT", url, strings.NewReader(value))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiToken)
-	req.Header.Set("Content-Type", "text/plain")
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("kv put %s: %w", key, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("kv put %s: HTTP %d: %s", key, resp.StatusCode, string(body))
-	}
-	return nil
-}
-
-// delete removes a key from KV.
-func (c *kvClient) delete(key string) error {
-	url := c.kvBaseURL() + "/values/" + key
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiToken)
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("kv delete %s: %w", key, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("kv delete %s: HTTP %d: %s", key, resp.StatusCode, string(body))
-	}
-	return nil
-}
-
-// nowMillis returns the current time as a Unix millisecond string.
-// The CF Worker parses this with parseInt() to check heartbeat freshness.
-func nowMillis() string {
-	return strconv.FormatInt(time.Now().UnixMilli(), 10)
-}
-
-// ---------------------------------------------------------------------------
-// Wrangler config generator
-// ---------------------------------------------------------------------------
-
-// wranglerData holds the values injected into wrangler.toml.tmpl.
-// All fields come from config.yaml — one source of truth.
-type wranglerData struct {
-	KVNamespaceID string
-	D1DatabaseID  string
-	ProdURL       string
-}
-
-// generateWranglerConfig reads worker/wrangler.toml.tmpl, fills in values
-// from config.yaml, and writes worker/wrangler.toml. This keeps IDs out of
-// version control — anyone can clone the repo, fill in config.yaml, and
-// the wrangler config is derived automatically.
-func generateWranglerConfig(cfg *config.Config) error {
-	tmplPath := filepath.Join("worker", "wrangler.toml.tmpl")
-	outPath := filepath.Join("worker", "wrangler.toml")
-
-	tmplBytes, err := os.ReadFile(tmplPath)
-	if err != nil {
-		return fmt.Errorf("reading wrangler template: %w", err)
-	}
-
-	tmpl, err := template.New("wrangler").Parse(string(tmplBytes))
-	if err != nil {
-		return fmt.Errorf("parsing wrangler template: %w", err)
-	}
-
-	// Derive PROD_URL from tunnel domain. If no tunnel is configured,
-	// leave it empty — the user hasn't set up production routing yet.
-	prodURL := ""
-	if cfg.Tunnel.Domain != "" {
-		prodURL = "https://" + cfg.Tunnel.Domain
-	}
-
-	data := wranglerData{
-		KVNamespaceID: cfg.Cloudflare.KVNamespaceID,
-		D1DatabaseID:  cfg.Cloudflare.D1DatabaseID,
-		ProdURL:       prodURL,
-	}
-
-	f, err := os.Create(outPath)
-	if err != nil {
-		return fmt.Errorf("creating wrangler.toml: %w", err)
-	}
-	defer f.Close()
-
-	if err := tmpl.Execute(f, data); err != nil {
-		return fmt.Errorf("writing wrangler.toml: %w", err)
-	}
-
-	log.Info("generated worker/wrangler.toml from config.yaml")
+	bus.Close()
 	return nil
 }

--- a/cmd/devtunnel.go
+++ b/cmd/devtunnel.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"syscall"
+	"time"
+
+	"her/config"
+
+	"github.com/spf13/cobra"
+)
+
+var devTunnelCmd = &cobra.Command{
+	Use:   "dev-tunnel",
+	Short: "Start a dev session with ephemeral tunnel and KV routing",
+	Long: `Starts a development session with Cloudflare tunnel routing:
+
+  1. Launches an ephemeral Cloudflare Tunnel (*.trycloudflare.com)
+  2. Sets KV routing keys so the CF Worker sends traffic here
+  3. Starts a heartbeat goroutine to keep the dev session alive
+  4. Runs the bot in webhook mode
+  5. On Ctrl+C: clears KV keys so prod resumes immediately
+
+The VPS prod instance keeps running but receives no traffic while
+dev-tunnel is active. When you stop, the CF Worker routes back to prod.
+
+Requires cloudflare section in config.yaml (account_id, api_token, kv_namespace_id).`,
+	RunE: runDevTunnel,
+}
+
+func init() {
+	rootCmd.AddCommand(devTunnelCmd)
+}
+
+var trycloudflarePattern = regexp.MustCompile(`https://[a-zA-Z0-9-]+\.trycloudflare\.com`)
+
+func runDevTunnel(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if cfg.Cloudflare.AccountID == "" || cfg.Cloudflare.APIToken == "" || cfg.Cloudflare.KVNamespaceID == "" {
+		return fmt.Errorf("cloudflare section in config.yaml is incomplete — need account_id, api_token, and kv_namespace_id for dev-tunnel mode")
+	}
+
+	if err := generateWranglerConfig(cfg); err != nil {
+		log.Warn("could not generate wrangler.toml", "err", err)
+	}
+
+	cloudflaredBin, err := exec.LookPath("cloudflared")
+	if err != nil {
+		return fmt.Errorf("cloudflared not found — install with: brew install cloudflare/cloudflare/cloudflared")
+	}
+
+	webhookPort := cfg.Telegram.WebhookPort
+	if webhookPort == 0 {
+		webhookPort = 8443
+	}
+
+	log.Info("starting ephemeral tunnel...")
+	tunnelURL, tunnelProcess, err := startEphemeralTunnel(cloudflaredBin, webhookPort)
+	if err != nil {
+		return fmt.Errorf("starting ephemeral tunnel: %w", err)
+	}
+	log.Info("tunnel ready", "url", tunnelURL)
+
+	kv := &kvClient{
+		accountID:   cfg.Cloudflare.AccountID,
+		apiToken:    cfg.Cloudflare.APIToken,
+		namespaceID: cfg.Cloudflare.KVNamespaceID,
+		http:        &http.Client{Timeout: kvClientTimeout},
+	}
+
+	log.Info("setting KV routing keys...")
+	if err := kv.put("dev_mode_active", "true"); err != nil {
+		killTunnel(tunnelProcess)
+		return fmt.Errorf("setting dev_mode_active: %w", err)
+	}
+	if err := kv.put("dev_instance_url", tunnelURL); err != nil {
+		killTunnel(tunnelProcess)
+		return fmt.Errorf("setting dev_instance_url: %w", err)
+	}
+	if err := kv.put("dev_session_heartbeat", nowMillis()); err != nil {
+		killTunnel(tunnelProcess)
+		return fmt.Errorf("setting dev_session_heartbeat: %w", err)
+	}
+	log.Info("KV routing active — traffic redirected to dev")
+
+	heartbeatCtx, heartbeatCancel := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(2 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := kv.put("dev_session_heartbeat", nowMillis()); err != nil {
+					log.Warn("heartbeat failed", "err", err)
+				}
+			case <-heartbeatCtx.Done():
+				return
+			}
+		}
+	}()
+
+	configTransform = func(c *config.Config) {
+		c.Telegram.Mode = "webhook"
+		log.Info("dev overrides applied", "mode", "webhook")
+	}
+
+	devCleanup = func() {
+		log.Info("clearing KV routing keys...")
+		heartbeatCancel()
+
+		if err := kv.put("dev_session_ended", nowMillis()); err != nil {
+			log.Warn("failed to write dev_session_ended", "err", err)
+		}
+
+		_ = kv.delete("dev_mode_active")
+		_ = kv.delete("dev_instance_url")
+		_ = kv.delete("dev_session_heartbeat")
+		log.Info("KV cleared — traffic routed back to prod")
+
+		killTunnel(tunnelProcess)
+		log.Info("tunnel stopped")
+	}
+
+	return runBot(cmd, args)
+}
+
+func startEphemeralTunnel(cloudflaredBin string, port int) (string, *exec.Cmd, error) {
+	proc := exec.Command(cloudflaredBin, "tunnel", "--url", fmt.Sprintf("http://localhost:%d", port))
+	proc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stderr, err := proc.StderrPipe()
+	if err != nil {
+		return "", nil, fmt.Errorf("creating stderr pipe: %w", err)
+	}
+	proc.Stdout = io.Discard
+
+	if err := proc.Start(); err != nil {
+		return "", nil, fmt.Errorf("starting cloudflared: %w", err)
+	}
+
+	urlCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if match := trycloudflarePattern.FindString(line); match != "" {
+				urlCh <- match
+				break
+			}
+		}
+		io.Copy(io.Discard, stderr)
+	}()
+
+	select {
+	case url := <-urlCh:
+		return url, proc, nil
+	case <-time.After(30 * time.Second):
+		killTunnel(proc)
+		return "", nil, fmt.Errorf("timed out waiting for tunnel URL (30s)")
+	}
+}
+
+func killTunnel(proc *exec.Cmd) {
+	if proc != nil && proc.Process != nil {
+		_ = syscall.Kill(-proc.Process.Pid, syscall.SIGKILL)
+		_, _ = proc.Process.Wait()
+	}
+}

--- a/cmd/kv.go
+++ b/cmd/kv.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"her/config"
+)
+
+// kvClientTimeout is the HTTP timeout for Cloudflare KV API calls.
+const kvClientTimeout = 10 * time.Second
+
+// --- Cloudflare Workers KV client ---
+
+type kvClient struct {
+	accountID   string
+	apiToken    string
+	namespaceID string
+	http        *http.Client
+}
+
+func (c *kvClient) kvBaseURL() string {
+	return fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/storage/kv/namespaces/%s", c.accountID, c.namespaceID)
+}
+
+func (c *kvClient) get(key string) (string, error) {
+	url := c.kvBaseURL() + "/values/" + key
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("kv get %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("kv get %s: HTTP %d: %s", key, resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("kv get %s: reading body: %w", key, err)
+	}
+	return string(body), nil
+}
+
+func (c *kvClient) put(key, value string) error {
+	url := c.kvBaseURL() + "/values/" + key
+	req, err := http.NewRequest("PUT", url, strings.NewReader(value))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("kv put %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("kv put %s: HTTP %d: %s", key, resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (c *kvClient) delete(key string) error {
+	url := c.kvBaseURL() + "/values/" + key
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("kv delete %s: %w", key, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("kv delete %s: HTTP %d: %s", key, resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func nowMillis() string {
+	return strconv.FormatInt(time.Now().UnixMilli(), 10)
+}
+
+// ---------------------------------------------------------------------------
+// Wrangler config generator
+// ---------------------------------------------------------------------------
+
+type wranglerData struct {
+	KVNamespaceID string
+	D1DatabaseID  string
+	ProdURL       string
+}
+
+func generateWranglerConfig(cfg *config.Config) error {
+	tmplPath := filepath.Join("worker", "wrangler.toml.tmpl")
+	outPath := filepath.Join("worker", "wrangler.toml")
+
+	tmplBytes, err := os.ReadFile(tmplPath)
+	if err != nil {
+		return fmt.Errorf("reading wrangler template: %w", err)
+	}
+
+	tmpl, err := template.New("wrangler").Parse(string(tmplBytes))
+	if err != nil {
+		return fmt.Errorf("parsing wrangler template: %w", err)
+	}
+
+	prodURL := ""
+	if cfg.Tunnel.Domain != "" {
+		prodURL = "https://" + cfg.Tunnel.Domain
+	}
+
+	data := wranglerData{
+		KVNamespaceID: cfg.Cloudflare.KVNamespaceID,
+		D1DatabaseID:  cfg.Cloudflare.D1DatabaseID,
+		ProdURL:       prodURL,
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("creating wrangler.toml: %w", err)
+	}
+	defer f.Close()
+
+	if err := tmpl.Execute(f, data); err != nil {
+		return fmt.Errorf("writing wrangler.toml: %w", err)
+	}
+
+	log.Info("generated worker/wrangler.toml from config.yaml")
+	return nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -24,6 +24,7 @@ import (
 	"her/logger"
 	"her/memory"
 	"her/persona"
+	"her/procmgr"
 	"her/retry"
 	"her/scheduler"
 	"her/search"
@@ -107,10 +108,10 @@ func runBot(cmd *cobra.Command, args []string) error {
 		log.Fatal("LLM API key is required — set OPENROUTER_API_KEY env var or fill in config.yaml")
 	}
 
-	// If the launchd service is running (`her start`), stop it before
+	// If the managed service is running (`her start`), stop it before
 	// we start a foreground run. Two instances racing for the same
 	// Telegram token causes dropped messages and PID file conflicts.
-	stopLaunchdServiceIfRunning(cfg)
+	stopManagedServiceIfRunning(cfg)
 
 	// Kill any stale her process from a previous run before we start.
 	// This prevents two instances racing for the same Telegram token.
@@ -851,26 +852,28 @@ func killStaleSelf(pidFile string) {
 	_ = os.Remove(pidFile)
 }
 
-// stopLaunchdServiceIfRunning checks if the launchd service (`her start`)
+// stopManagedServiceIfRunning checks if a supervised service (`her start`)
 // is active and stops it before a foreground `her run`. Without this, two
 // instances race for the same Telegram token and PID file, causing one to
 // SIGTERM the other mid-startup.
-func stopLaunchdServiceIfRunning(cfg *config.Config) {
+func stopManagedServiceIfRunning(cfg *config.Config) {
 	botName := cfg.Identity.Her
 	if botName == "" {
 		return
 	}
-	label := serviceLabel(botName)
-	target := serviceTarget(label)
-
-	// launchctl print exits 0 if the service is loaded, non-zero otherwise.
-	if err := exec.Command("launchctl", "print", target).Run(); err != nil {
-		return // not loaded — nothing to do
+	label := procmgr.EffectiveLabel(cfg.Update.ServiceLabel, botName)
+	mgr, err := procmgr.New(label)
+	if err != nil {
+		return
 	}
 
-	log.Info("stopping launchd service before foreground run", "label", label)
-	if err := launchdBootout(label); err != nil {
-		log.Warn("could not stop launchd service", "err", err)
+	if !mgr.IsManaged() {
+		return // not running under a supervisor — nothing to do
+	}
+
+	log.Info("stopping managed service before foreground run", "supervisor", mgr.Name(), "label", label)
+	if err := mgr.Stop(); err != nil {
+		log.Warn("could not stop managed service", "err", err)
 	}
 	// Give the old process a moment to release the Telegram token.
 	time.Sleep(500 * time.Millisecond)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,10 +47,6 @@ import (
 // log is the package-level logger for the cmd package.
 var log = logger.WithPrefix("cmd")
 
-// kvClientTimeout is the HTTP timeout for Cloudflare KV API calls.
-// Used by both dev mode (KV routing keys) and prod (sync poller).
-const kvClientTimeout = 10 * time.Second
-
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Start the bot process (foreground)",

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -7,87 +7,18 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
-	"text/template"
 
 	"github.com/spf13/cobra"
 	"her/config"
+	"her/procmgr"
 )
-
-// serviceLabel builds the launchd service identifier from the bot's
-// configured name. e.g. "Mira" → "com.mira.her-go", "Luna" → "com.luna.her-go".
-func serviceLabel(botName string) string {
-	return "com." + strings.ToLower(botName) + ".her-go"
-}
-
-// domainTarget returns the launchd domain for the current user, e.g.
-// "gui/501". Used with the modern launchctl subcommands (bootstrap,
-// bootout, kickstart, print) which replaced the deprecated load/unload.
-func domainTarget() string {
-	return fmt.Sprintf("gui/%d", os.Getuid())
-}
-
-// serviceTarget returns the fully-qualified launchd service target for
-// the current user, e.g. "gui/501/com.mira.her-go". Used with bootout,
-// kickstart, and print.
-func serviceTarget(label string) string {
-	return fmt.Sprintf("gui/%d/%s", os.Getuid(), label)
-}
-
-// launchdBootstrap loads a service plist into the user's launchd domain
-// using the modern bootstrap command. If the service is already loaded,
-// it bootouts first and retries — handling the common "re-setup" case
-// where the user runs setup again on a running service.
-func launchdBootstrap(plistPath, label string) error {
-	domain := domainTarget()
-	out, err := exec.Command("launchctl", "bootstrap", domain, plistPath).CombinedOutput()
-	if err == nil {
-		return nil
-	}
-
-	outStr := strings.TrimSpace(string(out))
-
-	// When a service is already loaded, bootstrap fails with either:
-	//   - Exit 5 + "Bootstrap failed: 5: Input/output error" (macOS 13+)
-	//   - Exit 37 + text containing "already loaded" (older macOS)
-	// In both cases, bootout first then retry.
-	if strings.Contains(outStr, "Bootstrap failed: 5:") || strings.Contains(outStr, "37:") ||
-		strings.Contains(outStr, "already loaded") {
-		log.Info("service already loaded, reloading")
-		_ = exec.Command("launchctl", "bootout", serviceTarget(label)).Run()
-		out2, err2 := exec.Command("launchctl", "bootstrap", domain, plistPath).CombinedOutput()
-		if err2 != nil {
-			return fmt.Errorf("launchctl bootstrap (retry): %s", strings.TrimSpace(string(out2)))
-		}
-		return nil
-	}
-
-	return fmt.Errorf("launchctl bootstrap: %s", outStr)
-}
-
-// launchdBootout unloads a service from the user's launchd domain using
-// the modern bootout command.
-func launchdBootout(label string) error {
-	out, err := exec.Command("launchctl", "bootout", serviceTarget(label)).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("launchctl bootout: %s", strings.TrimSpace(string(out)))
-	}
-	return nil
-}
-
-// plistPath returns the full path to the plist in ~/Library/LaunchAgents.
-func plistPath(botName string) (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("could not determine home directory: %w", err)
-	}
-	return filepath.Join(home, "Library", "LaunchAgents", serviceLabel(botName)+".plist"), nil
-}
 
 // loadBotName loads config and returns just the bot's name.
 // Used by service management commands (start, stop) that need the
-// name for the launchd service label but don't need full config.
+// name for the service label but don't need full config.
 func loadBotName() (string, error) {
 	cfg, err := config.Load(cfgFile)
 	if err != nil {
@@ -96,70 +27,25 @@ func loadBotName() (string, error) {
 	return cfg.Identity.Her, nil
 }
 
-// plistData holds the values injected into the plist template.
-type plistData struct {
-	Label      string
-	BinaryPath string
-	WorkDir    string
-	StdoutPath string
-	StderrPath string
-	UserName   string
-	Path       string // PATH inherited from the user's shell at setup time
+// loadServiceLabel loads config and returns the effective service label.
+func loadServiceLabel() (string, error) {
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return "", fmt.Errorf("loading config: %w", err)
+	}
+	return procmgr.EffectiveLabel(cfg.Update.ServiceLabel, cfg.Identity.Her), nil
 }
-
-// plistTemplate is the launchd property list, generated dynamically
-// so it always matches the current machine's paths and user.
-const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>{{.Label}}</string>
-
-    <key>ProgramArguments</key>
-    <array>
-        <string>{{.BinaryPath}}</string>
-        <string>run</string>
-    </array>
-
-    <key>WorkingDirectory</key>
-    <string>{{.WorkDir}}</string>
-
-    <key>KeepAlive</key>
-    <true/>
-
-    <key>ThrottleInterval</key>
-    <integer>3</integer>
-
-    <key>StandardOutPath</key>
-    <string>{{.StdoutPath}}</string>
-
-    <key>StandardErrorPath</key>
-    <string>{{.StderrPath}}</string>
-
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>{{.Path}}</string>
-    </dict>
-
-    <key>UserName</key>
-    <string>{{.UserName}}</string>
-</dict>
-</plist>
-`
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Build the binary, install dependencies, and configure the launchd service",
-	Long: `Does everything needed to install her-go as a launchd service:
+	Short: "Build the binary, install dependencies, and configure the system service",
+	Long: `Does everything needed to install her-go as a system service:
 
   1. Build the binary (go build)
-  2. Install ML dependencies in background (parakeet-mlx, piper voice models, ffmpeg check)
-  3. Generate a plist file for the current machine
+  2. Install ML dependencies in background (piper voice models, ffmpeg check)
+  3. Generate a service definition for the current platform (launchd on macOS, systemd on Linux)
   4. Create the logs directory
-  5. Install the plist to ~/Library/LaunchAgents
-  6. Load the service with launchctl`,
+  5. Install and enable the service`,
 	RunE: runSetup,
 }
 
@@ -210,49 +96,60 @@ func installDeps() <-chan depResult {
 		results <- depResult{"ffmpeg", true, path}
 	}()
 
-	// Install parakeet-mlx (STT inference library + CLI).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if _, err := exec.LookPath("uv"); err != nil {
-			results <- depResult{"parakeet-mlx", false, "skipped (uv not available)"}
-			return
-		}
-		out, err := exec.Command("uv", "tool", "install", "parakeet-mlx").CombinedOutput()
-		msg := strings.TrimSpace(string(out))
-		if err != nil {
-			// "already installed" is not an error — uv returns non-zero
-			// but the tool is there. Check the output message.
-			if strings.Contains(msg, "already installed") || strings.Contains(msg, "is already available") {
-				results <- depResult{"parakeet-mlx", true, "already installed"}
+	// Parakeet (Apple MLX STT) — macOS only. On Linux, STT goes through
+	// a remote Whisper endpoint instead, so there's nothing to install.
+	if runtime.GOOS == "darwin" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := exec.LookPath("uv"); err != nil {
+				results <- depResult{"parakeet-mlx", false, "skipped (uv not available)"}
 				return
 			}
-			results <- depResult{"parakeet-mlx", false, msg}
-			return
-		}
-		results <- depResult{"parakeet-mlx", true, "installed"}
-	}()
+			out, err := exec.Command("uv", "tool", "install", "parakeet-mlx").CombinedOutput()
+			msg := strings.TrimSpace(string(out))
+			if err != nil {
+				if strings.Contains(msg, "already installed") || strings.Contains(msg, "is already available") {
+					results <- depResult{"parakeet-mlx", true, "already installed"}
+					return
+				}
+				results <- depResult{"parakeet-mlx", false, msg}
+				return
+			}
+			results <- depResult{"parakeet-mlx", true, "installed"}
+		}()
 
-	// Install parakeet-mlx-fastapi (HTTP server for STT).
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := exec.LookPath("uv"); err != nil {
+				results <- depResult{"parakeet-server", false, "skipped (uv not available)"}
+				return
+			}
+			out, err := exec.Command("uv", "tool", "install",
+				"git+https://github.com/yashhere/parakeet-mlx-fastapi.git").CombinedOutput()
+			msg := strings.TrimSpace(string(out))
+			if err != nil {
+				if strings.Contains(msg, "already installed") || strings.Contains(msg, "is already available") {
+					results <- depResult{"parakeet-server", true, "already installed"}
+					return
+				}
+				results <- depResult{"parakeet-server", false, msg}
+				return
+			}
+			results <- depResult{"parakeet-server", true, "installed"}
+		}()
+	}
+
+	// Ollama (embedding server) — check it's available on any platform.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if _, err := exec.LookPath("uv"); err != nil {
-			results <- depResult{"parakeet-server", false, "skipped (uv not available)"}
+		if _, err := exec.LookPath("ollama"); err != nil {
+			results <- depResult{"ollama", false, "not found — install from https://ollama.com"}
 			return
 		}
-		out, err := exec.Command("uv", "tool", "install",
-			"git+https://github.com/yashhere/parakeet-mlx-fastapi.git").CombinedOutput()
-		msg := strings.TrimSpace(string(out))
-		if err != nil {
-			if strings.Contains(msg, "already installed") || strings.Contains(msg, "is already available") {
-				results <- depResult{"parakeet-server", true, "already installed"}
-				return
-			}
-			results <- depResult{"parakeet-server", false, msg}
-			return
-		}
-		results <- depResult{"parakeet-server", true, "installed"}
+		results <- depResult{"ollama", true, "found"}
 	}()
 
 	// Download Piper TTS voice model files.
@@ -385,7 +282,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	depResults := installDeps()
 
 	// Step 1: Build the binary.
-	log.Info("[1/6] building binary")
+	log.Info("[1/4] building binary")
 	binaryPath := filepath.Join(workDir, "her-go")
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
 	buildCmd.Dir = workDir
@@ -396,77 +293,44 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	}
 	log.Infof("built: %s", binaryPath)
 
-	// Step 2: Generate the plist.
-	log.Info("[2/6] generating plist")
+	// Step 2: Install the service via the platform's process manager.
+	// On macOS this writes a plist to ~/Library/LaunchAgents and loads
+	// it with launchctl. On Linux it writes a systemd unit file to
+	// /etc/systemd/system and enables it.
+	log.Infof("[2/4] installing %s service", runtime.GOOS)
 	logsDir := filepath.Join(workDir, "logs")
-	// Capture the user's current PATH so the launchd service can find
-	// tools like uv, parakeet-server, ffmpeg, etc. Without this, launchd
-	// uses a bare-minimum PATH (/usr/bin:/bin) and sidecars fail to start.
-	// We snapshot it at setup time — if the user installs new tools later,
-	// they just re-run `her setup` to pick up the new paths.
+
+	// Capture the user's current PATH so the service can find tools
+	// like uv, piper, ffmpeg, ollama, etc. Without this, the supervisor
+	// uses a bare-minimum PATH (/usr/bin:/bin) and sidecars fail.
 	shellPath := os.Getenv("PATH")
 	if shellPath == "" {
 		shellPath = "/usr/local/bin:/usr/bin:/bin"
 	}
 
-	data := plistData{
-		Label:      serviceLabel(cfg.Identity.Her),
+	label := procmgr.EffectiveLabel(cfg.Update.ServiceLabel, cfg.Identity.Her)
+	mgr, err := procmgr.New(label)
+	if err != nil {
+		return fmt.Errorf("creating process manager: %w", err)
+	}
+
+	svcCfg := procmgr.ServiceConfig{
+		Label:      label,
 		BinaryPath: binaryPath,
 		WorkDir:    workDir,
-		StdoutPath: filepath.Join(logsDir, "stdout.log"),
-		StderrPath: filepath.Join(logsDir, "stderr.log"),
-		UserName:   currentUser.Username,
+		LogDir:     logsDir,
+		User:       currentUser.Username,
 		Path:       shellPath,
 	}
 
-	tmpl, err := template.New("plist").Parse(plistTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to parse plist template: %w", err)
-	}
-
-	dest, err := plistPath(cfg.Identity.Her)
-	if err != nil {
-		return err
-	}
-
-	plistFile, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("failed to create plist file %s: %w", dest, err)
-	}
-	if err := tmpl.Execute(plistFile, data); err != nil {
-		plistFile.Close()
-		return fmt.Errorf("failed to write plist: %w", err)
-	}
-	plistFile.Close()
-	log.Infof("wrote: %s", dest)
-
-	// Step 3: Create logs directory.
-	log.Info("[3/6] creating logs directory")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create logs directory: %w", err)
-	}
-	log.Infof("dir: %s", logsDir)
-
-	// Step 4: (plist already written to ~/Library/LaunchAgents in step 2)
-	log.Info("[4/6] plist installed to ~/Library/LaunchAgents")
-
-	// Step 5: Load the service using the modern launchctl bootstrap command.
-	// The old "launchctl load" is deprecated and can silently fail (printing
-	// errors to stderr while returning exit 0). bootstrap has proper error
-	// codes and handles the "already loaded" case via automatic bootout+retry.
-	log.Info("[5/6] loading service")
-	label := serviceLabel(cfg.Identity.Her)
-	if err := launchdBootstrap(dest, label); err != nil {
-		log.Warn("failed to load service", "err", err)
+	if err := mgr.Install(svcCfg); err != nil {
+		log.Warn("failed to install service", "err", err)
 	} else {
-		log.Info("service loaded")
+		log.Infof("service installed via %s", mgr.Name())
 	}
 
-	// Step 6: Wait for background dependency installs to finish.
-	// The channel was created in installDeps() — ranging over it gives
-	// us each result as it arrives, and stops when the channel closes
-	// (which happens after all goroutines call wg.Done()).
-	log.Info("[6/6] ML dependencies")
+	// Step 3: Wait for background dependency installs to finish.
+	log.Info("[3/4] ML dependencies")
 	var warnings []string
 	for r := range depResults {
 		if r.OK {
@@ -477,12 +341,12 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Summary.
-	log.Info("setup complete",
+	// Step 4: Summary.
+	log.Info("[4/4] setup complete",
 		"binary", binaryPath,
-		"plist", dest,
+		"supervisor", mgr.Name(),
 		"logs", logsDir,
-		"service", serviceLabel(cfg.Identity.Her),
+		"service", label,
 	)
 
 	for _, w := range warnings {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,15 +2,15 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
+	"her/procmgr"
 )
 
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Start the launchd service",
-	Long:  "Starts her-go as a launchd service. If setup hasn't been run yet, runs it automatically first.",
+	Short: "Start the system service",
+	Long:  "Starts her-go as a system service (launchd on macOS, systemd on Linux). If setup hasn't been run yet, runs it automatically first.",
 	RunE:  runStart,
 }
 
@@ -19,31 +19,23 @@ func init() {
 }
 
 func runStart(cmd *cobra.Command, args []string) error {
-	botName, err := loadBotName()
-	if err != nil {
-		return err
-	}
-	dest, err := plistPath(botName)
+	label, err := loadServiceLabel()
 	if err != nil {
 		return err
 	}
 
-	// Check if the plist exists. If not, run setup first.
-	if _, err := os.Stat(dest); os.IsNotExist(err) {
+	mgr, err := procmgr.New(label)
+	if err != nil {
+		return err
+	}
+
+	if err := mgr.Start(); err != nil {
+		// If the service isn't installed yet, run setup first.
 		fmt.Println("Service not set up yet. Running setup first...")
 		fmt.Println()
 		if err := runSetup(cmd, args); err != nil {
 			return fmt.Errorf("setup failed: %w", err)
 		}
-		// Setup already loads the service, so we're done.
-		return nil
-	}
-
-	// Use the modern launchctl bootstrap command. launchdBootstrap handles
-	// the "already loaded" case automatically (bootout + retry).
-	label := serviceLabel(botName)
-	if err := launchdBootstrap(dest, label); err != nil {
-		fmt.Printf("Failed to start service: %v\n", err)
 		return nil
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,13 +9,14 @@ import (
 	"time"
 
 	"her/config"
+	"her/procmgr"
 
 	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show launchd service status",
+	Short: "Show system service status",
 	RunE:  runStatus,
 }
 
@@ -24,52 +25,32 @@ func init() {
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
-	botName, err := loadBotName()
+	label, err := loadServiceLabel()
 	if err != nil {
 		return err
 	}
-	label := serviceLabel(botName)
 
-	// Use the serviceTarget helper to build the launchctl print target.
-	target := serviceTarget(label)
-
-	out, err := exec.Command("launchctl", "print", target).CombinedOutput()
+	mgr, err := procmgr.New(label)
 	if err != nil {
-		fmt.Println("Service is not loaded.")
+		return err
+	}
+
+	if !mgr.IsManaged() {
+		fmt.Println("Service is not running.")
 		fmt.Println()
 		fmt.Println("Run 'her setup' to install, or 'her start' to load.")
 		return nil
 	}
 
-	output := string(out)
-
-	// Parse key fields from launchctl print output.
-	fmt.Printf("Service: %s\n", label)
+	fmt.Printf("Service: %s (via %s)\n", label, mgr.Name())
 	fmt.Println()
 
-	// State (e.g., "state = running")
-	if val := parseLaunchctlField(output, "state"); val != "" {
-		fmt.Printf("  State:       %s\n", val)
-	}
-
-	// PID
-	if val := parseLaunchctlField(output, "pid"); val != "" {
-		fmt.Printf("  PID:         %s\n", val)
-	}
-
-	// Last exit status
-	if val := parseLaunchctlField(output, "last exit code"); val != "" {
-		fmt.Printf("  Last exit:   %s\n", val)
-	}
-
-	// Log paths — derive from working directory.
-	workDir, _ := os.Getwd()
-	fmt.Printf("  Stdout log:  %s/logs/stdout.log\n", workDir)
-	fmt.Printf("  Stderr log:  %s/logs/stderr.log\n", workDir)
-
-	// Also show run count if available.
-	if val := parseLaunchctlField(output, "runs"); val != "" {
-		fmt.Printf("  Run count:   %s\n", val)
+	// Platform-specific status details.
+	switch mgr.Name() {
+	case "launchd":
+		printLaunchdStatus(label)
+	case "systemd":
+		printSystemdStatus(label)
 	}
 
 	// Show sidecar status by hitting their health endpoints.
@@ -77,41 +58,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		fmt.Println()
 		fmt.Println("Sidecars:")
-		httpClient := &http.Client{Timeout: 2 * time.Second}
-
-		// STT (engine-agnostic: parakeet pings healthz, remote engines are presumed up)
-		sttEngine := cfg.Voice.STT.Engine
-		if sttEngine == "" {
-			sttEngine = "parakeet"
-		}
-		sttStatus := "disabled"
-		if cfg.Voice.Enabled && cfg.Voice.STT.BaseURL != "" {
-			if cfg.Voice.STT.Engine == config.STTEngineParakeet || cfg.Voice.STT.Engine == "" {
-				sttURL := strings.TrimRight(cfg.Voice.STT.BaseURL, "/") + "/healthz"
-				if resp, err := httpClient.Get(sttURL); err == nil {
-					resp.Body.Close()
-					sttStatus = fmt.Sprintf("running (%s)", cfg.Voice.STT.BaseURL)
-				} else {
-					sttStatus = "not responding"
-				}
-			} else {
-				sttStatus = fmt.Sprintf("remote (%s)", cfg.Voice.STT.BaseURL)
-			}
-		}
-		fmt.Printf("  STT (%s):  %s  [model: %s]\n", sttEngine, sttStatus, cfg.Voice.STT.Model)
-
-		// Piper TTS
-		ttsStatus := "disabled"
-		if cfg.Voice.TTS.Enabled && cfg.Voice.TTS.BaseURL != "" {
-			ttsURL := strings.TrimRight(cfg.Voice.TTS.BaseURL, "/") + "/healthz"
-			if resp, err := httpClient.Get(ttsURL); err == nil {
-				resp.Body.Close()
-				ttsStatus = fmt.Sprintf("running (%s)", cfg.Voice.TTS.BaseURL)
-			} else {
-				ttsStatus = "not responding"
-			}
-		}
-		fmt.Printf("  Piper TTS:     %s  [voice: %s]\n", ttsStatus, cfg.Voice.TTS.VoiceID)
+		printSidecarStatus(cfg)
 	}
 
 	fmt.Println()
@@ -120,8 +67,90 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func printLaunchdStatus(label string) {
+	target := fmt.Sprintf("gui/%d/%s", getUID(), label)
+	out, err := exec.Command("launchctl", "print", target).CombinedOutput()
+	if err != nil {
+		return
+	}
+	output := string(out)
+
+	if val := parseLaunchctlField(output, "state"); val != "" {
+		fmt.Printf("  State:       %s\n", val)
+	}
+	if val := parseLaunchctlField(output, "pid"); val != "" {
+		fmt.Printf("  PID:         %s\n", val)
+	}
+	if val := parseLaunchctlField(output, "last exit code"); val != "" {
+		fmt.Printf("  Last exit:   %s\n", val)
+	}
+	if val := parseLaunchctlField(output, "runs"); val != "" {
+		fmt.Printf("  Run count:   %s\n", val)
+	}
+}
+
+func printSystemdStatus(label string) {
+	out, err := exec.Command("systemctl", "show", label,
+		"--property=ActiveState,SubState,MainPID,ExecMainStartTimestamp,NRestarts",
+		"--no-pager").CombinedOutput()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 || parts[1] == "" {
+			continue
+		}
+		switch parts[0] {
+		case "ActiveState":
+			fmt.Printf("  State:       %s\n", parts[1])
+		case "MainPID":
+			fmt.Printf("  PID:         %s\n", parts[1])
+		case "ExecMainStartTimestamp":
+			fmt.Printf("  Started:     %s\n", parts[1])
+		case "NRestarts":
+			fmt.Printf("  Restarts:    %s\n", parts[1])
+		}
+	}
+}
+
+func printSidecarStatus(cfg *config.Config) {
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+
+	sttEngine := cfg.Voice.STT.Engine
+	if sttEngine == "" {
+		sttEngine = "parakeet"
+	}
+	sttStatus := "disabled"
+	if cfg.Voice.Enabled && cfg.Voice.STT.BaseURL != "" {
+		if cfg.Voice.STT.Engine == config.STTEngineParakeet || cfg.Voice.STT.Engine == "" {
+			sttURL := strings.TrimRight(cfg.Voice.STT.BaseURL, "/") + "/healthz"
+			if resp, err := httpClient.Get(sttURL); err == nil {
+				resp.Body.Close()
+				sttStatus = fmt.Sprintf("running (%s)", cfg.Voice.STT.BaseURL)
+			} else {
+				sttStatus = "not responding"
+			}
+		} else {
+			sttStatus = fmt.Sprintf("remote (%s)", cfg.Voice.STT.BaseURL)
+		}
+	}
+	fmt.Printf("  STT (%s):  %s  [model: %s]\n", sttEngine, sttStatus, cfg.Voice.STT.Model)
+
+	ttsStatus := "disabled"
+	if cfg.Voice.TTS.Enabled && cfg.Voice.TTS.BaseURL != "" {
+		ttsURL := strings.TrimRight(cfg.Voice.TTS.BaseURL, "/") + "/healthz"
+		if resp, err := httpClient.Get(ttsURL); err == nil {
+			resp.Body.Close()
+			ttsStatus = fmt.Sprintf("running (%s)", cfg.Voice.TTS.BaseURL)
+		} else {
+			ttsStatus = "not responding"
+		}
+	}
+	fmt.Printf("  Piper TTS:     %s  [voice: %s]\n", ttsStatus, cfg.Voice.TTS.VoiceID)
+}
+
 // parseLaunchctlField extracts a value from launchctl print output.
-// Lines look like: "    pid = 12345" or "    state = running".
 func parseLaunchctlField(output, field string) string {
 	for _, line := range strings.Split(output, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -133,4 +162,9 @@ func parseLaunchctlField(output, field string) string {
 		}
 	}
 	return ""
+}
+
+// getUID returns the current user ID. Helper for launchd target paths.
+func getUID() int {
+	return os.Getuid()
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"her/procmgr"
 )
 
 var stopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop the launchd service",
+	Short: "Stop the system service",
 	RunE:  runStop,
 }
 
@@ -17,14 +18,17 @@ func init() {
 }
 
 func runStop(cmd *cobra.Command, args []string) error {
-	botName, err := loadBotName()
+	label, err := loadServiceLabel()
 	if err != nil {
 		return err
 	}
-	// Use the modern launchctl bootout command. The old "launchctl unload"
-	// is deprecated and can silently misbehave on modern macOS.
-	label := serviceLabel(botName)
-	if err := launchdBootout(label); err != nil {
+
+	mgr, err := procmgr.New(label)
+	if err != nil {
+		return err
+	}
+
+	if err := mgr.Stop(); err != nil {
 		fmt.Printf("Failed to stop service: %v\n", err)
 		return err
 	}

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"her/config"
+	"her/procmgr"
 )
 
 // tunnelCmd is the parent command for tunnel management.
@@ -257,10 +258,14 @@ func runTunnelSetup(cmd *cobra.Command, args []string) error {
 	plistFile.Close()
 	log.Info("wrote tunnel plist", "path", dest)
 
-	// Step 3: Load the service using the modern launchctl bootstrap command.
+	// Step 3: Load the service. The tunnel is macOS-only (cloudflared via
+	// launchd), so we create a procmgr instance for its own service label.
 	log.Info("[3/3] loading tunnel service")
 	tunnelLabel := tunnelServiceLabel(cfg.Identity.Her)
-	if err := launchdBootstrap(dest, tunnelLabel); err != nil {
+	tunnelMgr, mgrErr := procmgr.New(tunnelLabel)
+	if mgrErr != nil {
+		log.Warn("could not create process manager for tunnel", "err", mgrErr)
+	} else if err := tunnelMgr.Start(); err != nil {
 		log.Warn("failed to load tunnel service", "err", err)
 	} else {
 		log.Info("tunnel service loaded")

--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"gopkg.in/yaml.v3"
 	"her/config"
+	"her/procmgr"
 )
 
 // errWizardAborted is returned by runWizard when the user presses Ctrl+C.
@@ -331,7 +332,7 @@ func runWizard(cfgPath string) error {
 
 	// Auto-derive service label from bot name if left blank.
 	if cfg.Update.ServiceLabel == "" {
-		cfg.Update.ServiceLabel = serviceLabel(cfg.Identity.Her)
+		cfg.Update.ServiceLabel = procmgr.ServiceLabel(cfg.Identity.Her)
 	}
 
 	if err := saveConfig(cfg, cfgPath); err != nil {

--- a/d1/schema.sql
+++ b/d1/schema.sql
@@ -176,6 +176,87 @@ CREATE INDEX IF NOT EXISTS idx_mood_entries_kind_ts ON mood_entries(kind, ts);
 CREATE INDEX IF NOT EXISTS idx_mood_entries_superseded ON mood_entries(superseded_by);
 
 -- ---------------------------------------------------------------------------
+-- PII Vault (token↔original mappings for deanonymization)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pii_vault (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id     INTEGER,
+    token          TEXT NOT NULL,
+    original_value TEXT NOT NULL,
+    entity_type    TEXT NOT NULL,
+    created_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (message_id) REFERENCES messages(id)
+);
+
+-- ---------------------------------------------------------------------------
+-- Metrics (LLM token usage and cost tracking)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS metrics (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp         DATETIME DEFAULT CURRENT_TIMESTAMP,
+    model             TEXT NOT NULL,
+    prompt_tokens     INTEGER,
+    completion_tokens INTEGER,
+    total_tokens      INTEGER,
+    cost_usd          REAL,
+    latency_ms        INTEGER,
+    message_id        INTEGER,
+    is_fallback       BOOLEAN DEFAULT 0,
+    agent_role        TEXT DEFAULT '',
+    FOREIGN KEY (message_id) REFERENCES messages(id)
+);
+
+-- ---------------------------------------------------------------------------
+-- Agent Turns (tool call audit trail)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS agent_turns (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    message_id  INTEGER,
+    turn_index  INTEGER,
+    role        TEXT NOT NULL,
+    tool_name   TEXT,
+    tool_args   TEXT,
+    content     TEXT,
+    FOREIGN KEY (message_id) REFERENCES messages(id)
+);
+
+-- ---------------------------------------------------------------------------
+-- Dream Audit (memory dreamer operation log)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS dream_audit (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    operation   TEXT NOT NULL,
+    source_ids  TEXT NOT NULL,
+    result_id   INTEGER,
+    before_text TEXT,
+    after_text  TEXT,
+    reason      TEXT,
+    dry_run     BOOLEAN DEFAULT 0
+);
+
+-- ---------------------------------------------------------------------------
+-- Scheduler Tasks (reminders and recurring jobs)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS scheduler_tasks (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind               TEXT NOT NULL,
+    cron_expr          TEXT,
+    next_fire          DATETIME NOT NULL,
+    payload_json       TEXT NOT NULL DEFAULT '{}',
+    retry_max_attempts INTEGER NOT NULL DEFAULT 0,
+    retry_backoff      TEXT NOT NULL DEFAULT 'none',
+    retry_initial_wait INTEGER NOT NULL DEFAULT 0,
+    last_run_at        DATETIME,
+    last_error         TEXT,
+    attempt_count      INTEGER NOT NULL DEFAULT 0,
+    created_at         DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduler_tasks_kind ON scheduler_tasks(kind);
+
+-- ---------------------------------------------------------------------------
 -- Sync Metadata
 --
 -- Tracks the last synced row ID per table. Each machine maintains its own

--- a/memory/sync.go
+++ b/memory/sync.go
@@ -41,6 +41,11 @@ var incrementalTables = []string{
 	"persona_versions",
 	"traits",
 	"mood_entries",
+	"pii_vault",
+	"metrics",
+	"agent_turns",
+	"dream_audit",
+	"scheduler_tasks",
 }
 
 // fullPullTables are pulled in their entirety on every sync. These
@@ -59,8 +64,8 @@ var fullPullTables = []string{
 //	Phase 2: memories → messages, traits → persona_versions, memory_log → memory_cards + memories
 //	Phase 3: memory_links → memories
 var pullPhases = [][]string{
-	{"messages", "summaries", "reflections", "persona_versions", "mood_entries", "persona_state", "memory_cards"},
-	{"memories", "traits"},
+	{"messages", "summaries", "reflections", "persona_versions", "mood_entries", "persona_state", "memory_cards", "dream_audit", "scheduler_tasks"},
+	{"memories", "traits", "pii_vault", "metrics", "agent_turns"},
 	{"memory_links", "memory_log"},
 }
 

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -224,6 +224,31 @@ var syncedTableSpecs = map[string]tableSpec{
 		d1Cols:       "id, ts, kind, valence, labels, associations, note, source, confidence, conversation_id, created_at, updated_at, superseded_by, supersede_reason",
 		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
 	},
+	"pii_vault": {
+		selectCols:   "id, message_id, token, original_value, entity_type, created_at",
+		d1Cols:       "id, message_id, token, original_value, entity_type, created_at",
+		placeholders: "?, ?, ?, ?, ?, ?",
+	},
+	"metrics": {
+		selectCols:   "id, timestamp, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, latency_ms, message_id, is_fallback, agent_role",
+		d1Cols:       "id, timestamp, model, prompt_tokens, completion_tokens, total_tokens, cost_usd, latency_ms, message_id, is_fallback, agent_role",
+		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
+	},
+	"agent_turns": {
+		selectCols:   "id, timestamp, message_id, turn_index, role, tool_name, tool_args, content",
+		d1Cols:       "id, timestamp, message_id, turn_index, role, tool_name, tool_args, content",
+		placeholders: "?, ?, ?, ?, ?, ?, ?, ?",
+	},
+	"dream_audit": {
+		selectCols:   "id, timestamp, operation, source_ids, result_id, before_text, after_text, reason, dry_run",
+		d1Cols:       "id, timestamp, operation, source_ids, result_id, before_text, after_text, reason, dry_run",
+		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?",
+	},
+	"scheduler_tasks": {
+		selectCols:   "id, kind, cron_expr, next_fire, payload_json, retry_max_attempts, retry_backoff, retry_initial_wait, last_run_at, last_error, attempt_count, created_at",
+		d1Cols:       "id, kind, cron_expr, next_fire, payload_json, retry_max_attempts, retry_backoff, retry_initial_wait, last_run_at, last_error, attempt_count, created_at",
+		placeholders: "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?",
+	},
 }
 
 // ---------------------------------------------------------------------------
@@ -878,6 +903,128 @@ func (s *SyncedStore) MergeCards(targetSlug, sourceSlug, mergedSummary, reason s
 		s.pushRecentCardLog(sourceID)
 	}
 	return card, nil
+}
+
+// ---------------------------------------------------------------------------
+// PII Vault
+// ---------------------------------------------------------------------------
+
+// SavePIIVaultEntry stores a PII token mapping locally and records in outbox.
+// The vault is critical for cross-machine sync — without it, scrubbed messages
+// can't be deanonymized on the other machine.
+func (s *SyncedStore) SavePIIVaultEntry(messageID int64, token, originalValue, entityType string) error {
+	if err := s.SQLiteStore.SavePIIVaultEntry(messageID, token, originalValue, entityType); err != nil {
+		return err
+	}
+	// Query back the ID — SavePIIVaultEntry doesn't return it.
+	var id int64
+	err := s.SQLiteStore.db.QueryRow(
+		`SELECT id FROM pii_vault WHERE message_id = ? AND token = ? ORDER BY id DESC LIMIT 1`,
+		messageID, token,
+	).Scan(&id)
+	if err == nil {
+		s.writeOutbox("pii_vault", id, "upsert")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+// SaveMetric logs token usage locally and records in outbox.
+func (s *SyncedStore) SaveMetric(model string, promptTokens, completionTokens, totalTokens int, costUSD float64, latencyMs int, messageID int64, isFallback bool, agentRole string) error {
+	if err := s.SQLiteStore.SaveMetric(model, promptTokens, completionTokens, totalTokens, costUSD, latencyMs, messageID, isFallback, agentRole); err != nil {
+		return err
+	}
+	var id int64
+	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	if err == nil && id > 0 {
+		s.writeOutbox("metrics", id, "upsert")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Agent Turns
+// ---------------------------------------------------------------------------
+
+// SaveAgentTurn logs an agent reasoning step locally and records in outbox.
+func (s *SyncedStore) SaveAgentTurn(messageID int64, turnIndex int, role, toolName, toolArgs, content string) error {
+	if err := s.SQLiteStore.SaveAgentTurn(messageID, turnIndex, role, toolName, toolArgs, content); err != nil {
+		return err
+	}
+	var id int64
+	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	if err == nil && id > 0 {
+		s.writeOutbox("agent_turns", id, "upsert")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Dream Audit
+// ---------------------------------------------------------------------------
+
+// SaveDreamAudit logs a dreamer operation locally and records in outbox.
+func (s *SyncedStore) SaveDreamAudit(op string, sourceIDs []int64, resultID int64, before, after, reason string, dryRun bool) error {
+	if err := s.SQLiteStore.SaveDreamAudit(op, sourceIDs, resultID, before, after, reason, dryRun); err != nil {
+		return err
+	}
+	var id int64
+	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	if err == nil && id > 0 {
+		s.writeOutbox("dream_audit", id, "upsert")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler Tasks
+// ---------------------------------------------------------------------------
+
+// UpsertSchedulerTask inserts or updates a scheduler task locally and records
+// in outbox. Uses kind to query back the ID since ON CONFLICT changes the
+// semantics of last_insert_rowid().
+func (s *SyncedStore) UpsertSchedulerTask(t *SchedulerTask) error {
+	if err := s.SQLiteStore.UpsertSchedulerTask(t); err != nil {
+		return err
+	}
+	var id int64
+	err := s.SQLiteStore.db.QueryRow(
+		`SELECT id FROM scheduler_tasks WHERE kind = ?`, t.Kind,
+	).Scan(&id)
+	if err == nil && id > 0 {
+		s.writeOutbox("scheduler_tasks", id, "upsert")
+	}
+	return nil
+}
+
+// MarkSchedulerSuccess records a successful run locally and records in outbox.
+func (s *SyncedStore) MarkSchedulerSuccess(id int64, nextFire time.Time) error {
+	if err := s.SQLiteStore.MarkSchedulerSuccess(id, nextFire); err != nil {
+		return err
+	}
+	s.writeOutbox("scheduler_tasks", id, "upsert")
+	return nil
+}
+
+// MarkSchedulerFailure records a failed run locally and records in outbox.
+func (s *SyncedStore) MarkSchedulerFailure(id int64, nextFire time.Time, errMsg string, attempts int) error {
+	if err := s.SQLiteStore.MarkSchedulerFailure(id, nextFire, errMsg, attempts); err != nil {
+		return err
+	}
+	s.writeOutbox("scheduler_tasks", id, "upsert")
+	return nil
+}
+
+// DeleteSchedulerTask removes a task locally and records a delete in outbox.
+func (s *SyncedStore) DeleteSchedulerTask(id int64) error {
+	if err := s.SQLiteStore.DeleteSchedulerTask(id); err != nil {
+		return err
+	}
+	s.writeOutbox("scheduler_tasks", id, "delete")
+	return nil
 }
 
 // Compile-time check: SyncedStore must satisfy the Store interface.

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -933,12 +933,17 @@ func (s *SyncedStore) SavePIIVaultEntry(messageID int64, token, originalValue, e
 // ---------------------------------------------------------------------------
 
 // SaveMetric logs token usage locally and records in outbox.
+// Queries back by timestamp DESC to avoid last_insert_rowid() races
+// with concurrent background agents.
 func (s *SyncedStore) SaveMetric(model string, promptTokens, completionTokens, totalTokens int, costUSD float64, latencyMs int, messageID int64, isFallback bool, agentRole string) error {
 	if err := s.SQLiteStore.SaveMetric(model, promptTokens, completionTokens, totalTokens, costUSD, latencyMs, messageID, isFallback, agentRole); err != nil {
 		return err
 	}
 	var id int64
-	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	err := s.SQLiteStore.db.QueryRow(
+		`SELECT id FROM metrics WHERE model = ? AND agent_role = ? ORDER BY id DESC LIMIT 1`,
+		model, agentRole,
+	).Scan(&id)
 	if err == nil && id > 0 {
 		s.writeOutbox("metrics", id, "upsert")
 	}
@@ -955,7 +960,10 @@ func (s *SyncedStore) SaveAgentTurn(messageID int64, turnIndex int, role, toolNa
 		return err
 	}
 	var id int64
-	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	err := s.SQLiteStore.db.QueryRow(
+		`SELECT id FROM agent_turns WHERE message_id = ? AND turn_index = ? AND role = ? ORDER BY id DESC LIMIT 1`,
+		messageID, turnIndex, role,
+	).Scan(&id)
 	if err == nil && id > 0 {
 		s.writeOutbox("agent_turns", id, "upsert")
 	}
@@ -972,7 +980,10 @@ func (s *SyncedStore) SaveDreamAudit(op string, sourceIDs []int64, resultID int6
 		return err
 	}
 	var id int64
-	err := s.SQLiteStore.db.QueryRow(`SELECT last_insert_rowid()`).Scan(&id)
+	err := s.SQLiteStore.db.QueryRow(
+		`SELECT id FROM dream_audit WHERE operation = ? AND result_id = ? ORDER BY id DESC LIMIT 1`,
+		op, resultID,
+	).Scan(&id)
 	if err == nil && id > 0 {
 		s.writeOutbox("dream_audit", id, "upsert")
 	}

--- a/procmgr/launchd.go
+++ b/procmgr/launchd.go
@@ -1,0 +1,218 @@
+package procmgr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// LaunchdManager manages the bot as a macOS launchd service.
+// It writes a .plist to ~/Library/LaunchAgents and uses the modern
+// launchctl subcommands (bootstrap, bootout, kickstart) instead of
+// the deprecated load/unload.
+type LaunchdManager struct {
+	label string // e.g., "com.mira.her-go"
+}
+
+func newLaunchd(label string) (*LaunchdManager, error) {
+	return &LaunchdManager{label: label}, nil
+}
+
+func (m *LaunchdManager) Name() string { return "launchd" }
+
+// Install generates a plist from the ServiceConfig and loads it
+// into launchd. If the service is already loaded, it reloads.
+func (m *LaunchdManager) Install(cfg ServiceConfig) error {
+	dest, err := m.plistPath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure logs directory exists.
+	if err := os.MkdirAll(cfg.LogDir, 0o755); err != nil {
+		return fmt.Errorf("creating log directory: %w", err)
+	}
+
+	data := plistData{
+		Label:      m.label,
+		BinaryPath: cfg.BinaryPath,
+		WorkDir:    cfg.WorkDir,
+		StdoutPath: filepath.Join(cfg.LogDir, "stdout.log"),
+		StderrPath: filepath.Join(cfg.LogDir, "stderr.log"),
+		UserName:   cfg.User,
+		Path:       cfg.Path,
+	}
+
+	tmpl, err := template.New("plist").Parse(plistTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing plist template: %w", err)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating plist %s: %w", dest, err)
+	}
+	if err := tmpl.Execute(f, data); err != nil {
+		f.Close()
+		return fmt.Errorf("writing plist: %w", err)
+	}
+	f.Close()
+	log.Infof("wrote plist: %s", dest)
+
+	return m.bootstrap(dest)
+}
+
+// Uninstall stops the service and removes the plist file.
+func (m *LaunchdManager) Uninstall() error {
+	_ = m.Stop()
+	dest, err := m.plistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing plist: %w", err)
+	}
+	return nil
+}
+
+// Start loads the service into launchd. If already loaded, reloads.
+func (m *LaunchdManager) Start() error {
+	dest, err := m.plistPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		return fmt.Errorf("plist not found at %s — run `her setup` first", dest)
+	}
+	return m.bootstrap(dest)
+}
+
+// Stop unloads the service from launchd.
+func (m *LaunchdManager) Stop() error {
+	out, err := exec.Command("launchctl", "bootout", m.serviceTarget()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl bootout: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// Restart uses launchctl kickstart -k to force-restart the service.
+// The -k flag kills the existing instance; launchd's KeepAlive then
+// brings it back automatically.
+func (m *LaunchdManager) Restart() error {
+	cmd := exec.Command("launchctl", "kickstart", "-k", m.serviceTarget())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl kickstart: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// IsManaged checks whether this service is currently loaded in launchd
+// by querying launchctl print.
+func (m *LaunchdManager) IsManaged() bool {
+	return exec.Command("launchctl", "print", m.serviceTarget()).Run() == nil
+}
+
+// plistPath returns ~/Library/LaunchAgents/{label}.plist.
+func (m *LaunchdManager) plistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", m.label+".plist"), nil
+}
+
+// domainTarget returns the launchd domain for the current user,
+// e.g., "gui/501".
+func (m *LaunchdManager) domainTarget() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// serviceTarget returns the fully qualified launchd service path,
+// e.g., "gui/501/com.mira.her-go".
+func (m *LaunchdManager) serviceTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), m.label)
+}
+
+// bootstrap loads the plist using the modern launchctl bootstrap
+// command. Handles the "already loaded" case by bootout + retry.
+func (m *LaunchdManager) bootstrap(plistPath string) error {
+	domain := m.domainTarget()
+	out, err := exec.Command("launchctl", "bootstrap", domain, plistPath).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	outStr := strings.TrimSpace(string(out))
+
+	// Service already loaded — bootout first, then retry.
+	// macOS 13+ returns exit 5 / "Bootstrap failed: 5:", older versions
+	// return exit 37 / "already loaded".
+	if strings.Contains(outStr, "Bootstrap failed: 5:") ||
+		strings.Contains(outStr, "37:") ||
+		strings.Contains(outStr, "already loaded") {
+		log.Info("service already loaded, reloading")
+		_ = exec.Command("launchctl", "bootout", m.serviceTarget()).Run()
+		out2, err2 := exec.Command("launchctl", "bootstrap", domain, plistPath).CombinedOutput()
+		if err2 != nil {
+			return fmt.Errorf("launchctl bootstrap (retry): %s", strings.TrimSpace(string(out2)))
+		}
+		return nil
+	}
+
+	return fmt.Errorf("launchctl bootstrap: %s", outStr)
+}
+
+// plistData holds the values injected into the plist template.
+type plistData struct {
+	Label      string
+	BinaryPath string
+	WorkDir    string
+	StdoutPath string
+	StderrPath string
+	UserName   string
+	Path       string
+}
+
+const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{.Label}}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{.BinaryPath}}</string>
+        <string>run</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{.WorkDir}}</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>3</integer>
+
+    <key>StandardOutPath</key>
+    <string>{{.StdoutPath}}</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{.StderrPath}}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{{.Path}}</string>
+    </dict>
+
+    <key>UserName</key>
+    <string>{{.UserName}}</string>
+</dict>
+</plist>
+`

--- a/procmgr/launchd.go
+++ b/procmgr/launchd.go
@@ -94,7 +94,7 @@ func (m *LaunchdManager) Start() error {
 func (m *LaunchdManager) Stop() error {
 	out, err := exec.Command("launchctl", "bootout", m.serviceTarget()).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("launchctl bootout: %s", strings.TrimSpace(string(out)))
+		return fmt.Errorf("launchctl bootout (%s): %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (m *LaunchdManager) Stop() error {
 func (m *LaunchdManager) Restart() error {
 	cmd := exec.Command("launchctl", "kickstart", "-k", m.serviceTarget())
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("launchctl kickstart: %s", strings.TrimSpace(string(out)))
+		return fmt.Errorf("launchctl kickstart (%s): %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
@@ -158,12 +158,12 @@ func (m *LaunchdManager) bootstrap(plistPath string) error {
 		_ = exec.Command("launchctl", "bootout", m.serviceTarget()).Run()
 		out2, err2 := exec.Command("launchctl", "bootstrap", domain, plistPath).CombinedOutput()
 		if err2 != nil {
-			return fmt.Errorf("launchctl bootstrap (retry): %s", strings.TrimSpace(string(out2)))
+			return fmt.Errorf("launchctl bootstrap retry (%s): %w", strings.TrimSpace(string(out2)), err2)
 		}
 		return nil
 	}
 
-	return fmt.Errorf("launchctl bootstrap: %s", outStr)
+	return fmt.Errorf("launchctl bootstrap (%s): %w", outStr, err)
 }
 
 // plistData holds the values injected into the plist template.

--- a/procmgr/procmgr.go
+++ b/procmgr/procmgr.go
@@ -1,0 +1,110 @@
+// Package procmgr abstracts process supervision across platforms.
+//
+// On macOS, launchd manages the service via a .plist file in
+// ~/Library/LaunchAgents. On Linux, systemd manages it via a .service
+// unit file in /etc/systemd/system. Both keep the bot alive with
+// automatic restarts, handle log routing, and provide clean
+// start/stop/restart commands.
+//
+// Consumers (cmd/start.go, bot/handlers_admin.go, etc.) work with
+// the Manager interface — they never import launchd or systemd
+// directly. Think of this like Python's abc.ABC: the interface
+// defines the contract, and each platform provides its own
+// implementation.
+package procmgr
+
+import (
+	"fmt"
+	"os/user"
+	"runtime"
+	"strings"
+
+	"her/logger"
+)
+
+var log = logger.WithPrefix("procmgr")
+
+// Manager is the contract for platform-specific process supervisors.
+// Both launchd (macOS) and systemd (Linux) implement this interface.
+type Manager interface {
+	// Install writes the service definition file (plist or unit) and
+	// registers it with the supervisor. Calling Install on an already-
+	// installed service updates the definition and reloads.
+	Install(cfg ServiceConfig) error
+
+	// Uninstall removes the service definition and deregisters it.
+	Uninstall() error
+
+	// Start starts the service. If the service is already running,
+	// this is a no-op or returns an error depending on the platform.
+	Start() error
+
+	// Stop stops the service gracefully.
+	Stop() error
+
+	// Restart stops and restarts the service. On launchd this uses
+	// kickstart -k; on systemd this uses systemctl restart.
+	Restart() error
+
+	// IsManaged returns true if the current process is running under
+	// this supervisor (as opposed to foreground/manual mode).
+	IsManaged() bool
+
+	// Name returns a human-readable name for the supervisor
+	// ("launchd" or "systemd").
+	Name() string
+}
+
+// ServiceConfig holds the values needed to generate a service
+// definition file. Platform-specific managers extract what they need.
+type ServiceConfig struct {
+	Label      string // service identifier (e.g., "com.mira.her-go" or "her-go")
+	BinaryPath string // absolute path to the compiled binary
+	WorkDir    string // working directory (where config.yaml lives)
+	LogDir     string // directory for stdout/stderr logs
+	User       string // OS user to run as
+	Path       string // PATH environment variable snapshot
+}
+
+// ServiceLabel builds the service identifier from the bot's name.
+// On macOS: "com.mira.her-go". On Linux: "her-go" (systemd convention
+// doesn't use reverse-DNS).
+func ServiceLabel(botName string) string {
+	lower := strings.ToLower(botName)
+	if runtime.GOOS == "darwin" {
+		return "com." + lower + ".her-go"
+	}
+	return "her-go"
+}
+
+// EffectiveLabel returns the configured service label if set,
+// otherwise derives one from the bot name.
+func EffectiveLabel(configLabel, botName string) string {
+	if configLabel != "" {
+		return configLabel
+	}
+	return ServiceLabel(botName)
+}
+
+// New returns the platform-appropriate Manager. On macOS it returns
+// a launchd manager; on Linux it returns a systemd manager. Other
+// platforms get an error.
+func New(label string) (Manager, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return newLaunchd(label)
+	case "linux":
+		return newSystemd(label)
+	default:
+		return nil, fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+}
+
+// currentUsername returns the current OS user's name. Used by service
+// configs that need to specify which user the service runs as.
+func currentUsername() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return "unknown"
+}

--- a/procmgr/systemd.go
+++ b/procmgr/systemd.go
@@ -1,0 +1,154 @@
+package procmgr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// SystemdManager manages the bot as a Linux systemd service.
+// It writes a .service unit file to /etc/systemd/system and uses
+// systemctl for all lifecycle operations.
+//
+// Unlike launchd (which uses per-user agents in ~/Library), systemd
+// services live in a system-wide directory and typically run as a
+// dedicated user. The main concepts map directly:
+//
+//	launchd KeepAlive     → systemd Restart=always
+//	launchd ThrottleInterval → systemd RestartSec
+//	launchctl bootstrap   → systemctl enable --now
+//	launchctl bootout     → systemctl disable --now
+//	launchctl kickstart -k → systemctl restart
+type SystemdManager struct {
+	label string // e.g., "her-go"
+}
+
+func newSystemd(label string) (*SystemdManager, error) {
+	return &SystemdManager{label: label}, nil
+}
+
+func (m *SystemdManager) Name() string { return "systemd" }
+
+// Install generates a systemd unit file and enables the service.
+func (m *SystemdManager) Install(cfg ServiceConfig) error {
+	// Ensure logs directory exists.
+	if err := os.MkdirAll(cfg.LogDir, 0o755); err != nil {
+		return fmt.Errorf("creating log directory: %w", err)
+	}
+
+	data := unitData{
+		Description: "her-go companion bot",
+		User:        cfg.User,
+		WorkDir:     cfg.WorkDir,
+		BinaryPath:  cfg.BinaryPath,
+		Path:        cfg.Path,
+	}
+
+	tmpl, err := template.New("unit").Parse(unitTemplate)
+	if err != nil {
+		return fmt.Errorf("parsing unit template: %w", err)
+	}
+
+	dest := m.unitPath()
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating unit file %s: %w", dest, err)
+	}
+	if err := tmpl.Execute(f, data); err != nil {
+		f.Close()
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+	f.Close()
+	log.Infof("wrote unit: %s", dest)
+
+	// Reload systemd's view of unit files, then enable + start.
+	if err := m.systemctl("daemon-reload"); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	}
+	if err := m.systemctl("enable", "--now", m.label); err != nil {
+		return fmt.Errorf("enable: %w", err)
+	}
+	return nil
+}
+
+// Uninstall stops, disables, and removes the unit file.
+func (m *SystemdManager) Uninstall() error {
+	_ = m.systemctl("disable", "--now", m.label)
+	dest := m.unitPath()
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing unit file: %w", err)
+	}
+	_ = m.systemctl("daemon-reload")
+	return nil
+}
+
+func (m *SystemdManager) Start() error {
+	return m.systemctl("start", m.label)
+}
+
+func (m *SystemdManager) Stop() error {
+	return m.systemctl("stop", m.label)
+}
+
+func (m *SystemdManager) Restart() error {
+	return m.systemctl("restart", m.label)
+}
+
+// IsManaged checks if the service is active (running) via systemctl.
+func (m *SystemdManager) IsManaged() bool {
+	return exec.Command("systemctl", "is-active", "--quiet", m.label).Run() == nil
+}
+
+// unitPath returns /etc/systemd/system/{label}.service.
+func (m *SystemdManager) unitPath() string {
+	return filepath.Join("/etc/systemd/system", m.label+".service")
+}
+
+// systemctl runs a systemctl subcommand with optional arguments.
+func (m *SystemdManager) systemctl(args ...string) error {
+	out, err := exec.Command("systemctl", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("systemctl %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+type unitData struct {
+	Description string
+	User        string
+	WorkDir     string
+	BinaryPath  string
+	Path        string
+}
+
+// unitTemplate is the systemd service unit file. The key settings:
+//
+//   - After=network-online.target: wait for network (needed for API calls)
+//   - After=ollama.service: if Ollama is installed, wait for it
+//   - Restart=always + RestartSec=3: same behavior as launchd's
+//     KeepAlive + ThrottleInterval
+//   - StandardOutput/Error=journal: logs go to journalctl (view with
+//     `journalctl -u her-go -f`)
+const unitTemplate = `[Unit]
+Description={{.Description}}
+After=network-online.target ollama.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{.User}}
+WorkingDirectory={{.WorkDir}}
+ExecStart={{.BinaryPath}} run
+Restart=always
+RestartSec=3
+Environment=PATH={{.Path}}
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/procmgr/systemd.go
+++ b/procmgr/systemd.go
@@ -112,7 +112,7 @@ func (m *SystemdManager) unitPath() string {
 func (m *SystemdManager) systemctl(args ...string) error {
 	out, err := exec.Command("systemctl", args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("systemctl %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+		return fmt.Errorf("systemctl %s (%s): %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }

--- a/scripts/dev_chat.py
+++ b/scripts/dev_chat.py
@@ -1,0 +1,101 @@
+"""
+Gradio chat frontend for her-go dev mode.
+
+Connects to the Go backend's HTTP API (her dev) and provides a
+browser-based chat interface with message bubbles.
+
+Usage:
+    # Terminal 1: start the Go backend
+    her dev
+
+    # Terminal 2: start the Gradio frontend
+    uv run scripts/dev_chat.py
+
+    # Browser: open http://localhost:7860
+
+Requirements (installed automatically by uv):
+    pip install gradio requests
+"""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "gradio>=5.0",
+#     "requests>=2.31",
+# ]
+# ///
+
+import requests
+import gradio as gr
+
+API_BASE = "http://localhost:7777"
+
+conversation_id = None
+
+
+def check_backend():
+    """Verify the Go backend is running."""
+    try:
+        resp = requests.get(f"{API_BASE}/api/status", timeout=2)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+def chat(message: str, history: list) -> str:
+    """Send a message to the Go backend and return the reply."""
+    global conversation_id
+
+    payload = {"message": message}
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+
+    try:
+        resp = requests.post(
+            f"{API_BASE}/api/chat",
+            json=payload,
+            timeout=120,
+        )
+        resp.raise_for_status()
+    except requests.ConnectionError:
+        return "Backend not running. Start it with: `her dev`"
+    except requests.Timeout:
+        return "Request timed out — the agent may be processing a complex query."
+    except requests.HTTPError as e:
+        return f"Error: {e.response.status_code} — {e.response.text}"
+
+    data = resp.json()
+    conversation_id = data.get("conversation_id", conversation_id)
+    return data.get("reply", "")
+
+
+def clear_conversation():
+    """Start a new conversation."""
+    global conversation_id
+    try:
+        resp = requests.post(f"{API_BASE}/api/clear", timeout=5)
+        data = resp.json()
+        conversation_id = data.get("conversation_id")
+    except requests.ConnectionError:
+        pass
+    return None
+
+
+# --- Build the Gradio UI ---
+
+with gr.Blocks(title="her-go dev", theme=gr.themes.Soft()) as demo:
+    gr.Markdown("## her-go dev chat")
+
+    if not check_backend():
+        gr.Markdown(
+            "> **Backend not running.** Start it with `her dev` in another terminal."
+        )
+
+    chatbot = gr.ChatInterface(
+        fn=chat,
+        type="messages",
+        examples=["hey, how are you?", "what do you remember about me?"],
+    )
+
+if __name__ == "__main__":
+    demo.launch()

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# her-go VPS bootstrap script
+#
+# Sets up a fresh Linux server (tested on Hetzner CAX11, Ubuntu/Debian ARM64)
+# with everything needed to run her-go as a systemd service.
+#
+# Usage:
+#   curl -sL https://raw.githubusercontent.com/AutumnsGrove/her-go/main/scripts/setup-server.sh | bash
+#
+# Or clone first and run locally:
+#   git clone https://github.com/AutumnsGrove/her-go.git /opt/her-go
+#   bash /opt/her-go/scripts/setup-server.sh
+#
+# What this installs:
+#   - Go (latest stable, ARM64 or AMD64)
+#   - Python 3 + uv (for TTS sidecar)
+#   - Ollama + nomic-embed-text (embedding model)
+#   - Piper TTS voice model
+#   - her-go binary + systemd service
+#
+# Memory budget (4GB VPS):
+#   OS ~300MB + Go binary ~50MB + Piper ~80MB + Ollama ~500MB + Python ~100MB
+#   Total ~1.2GB — comfortable headroom on a 4GB plan.
+
+set -euo pipefail
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+fail()  { echo -e "${RED}[FAIL]${NC}  $*"; exit 1; }
+
+# --- Preflight checks ---
+
+if [[ $EUID -ne 0 ]]; then
+    fail "This script must be run as root (use sudo)"
+fi
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+if [[ "$OS" != "Linux" ]]; then
+    fail "This script is for Linux servers. Got: $OS"
+fi
+
+case "$ARCH" in
+    aarch64|arm64) GO_ARCH="arm64" ;;
+    x86_64)        GO_ARCH="amd64" ;;
+    *)             fail "Unsupported architecture: $ARCH" ;;
+esac
+
+info "Platform: Linux $ARCH (Go arch: $GO_ARCH)"
+
+# --- Configuration ---
+
+REPO_URL="https://github.com/AutumnsGrove/her-go.git"
+INSTALL_DIR="/opt/her-go"
+SERVICE_USER="hergo"
+GO_VERSION="1.24.4"
+PIPER_VOICE="en_GB-southern_english_female-low"
+PIPER_QUALITY="low"
+
+# --- Step 1: System dependencies ---
+
+info "[1/9] Installing system dependencies..."
+apt-get update -qq
+apt-get install -y -qq git sqlite3 build-essential curl ffmpeg > /dev/null 2>&1
+ok "System dependencies installed"
+
+# --- Step 2: Create service user ---
+
+info "[2/9] Creating service user '$SERVICE_USER'..."
+if id "$SERVICE_USER" &>/dev/null; then
+    ok "User '$SERVICE_USER' already exists"
+else
+    useradd --system --create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+    ok "User '$SERVICE_USER' created"
+fi
+
+# --- Step 3: Install Go ---
+
+info "[3/9] Installing Go $GO_VERSION ($GO_ARCH)..."
+if command -v go &>/dev/null && go version | grep -q "$GO_VERSION"; then
+    ok "Go $GO_VERSION already installed"
+else
+    GO_TAR="go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+    curl -sSL "https://go.dev/dl/$GO_TAR" -o "/tmp/$GO_TAR"
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf "/tmp/$GO_TAR"
+    rm "/tmp/$GO_TAR"
+
+    # Add to system PATH for all users.
+    if ! grep -q '/usr/local/go/bin' /etc/profile.d/go.sh 2>/dev/null; then
+        echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh
+    fi
+    export PATH=$PATH:/usr/local/go/bin
+    ok "Go $GO_VERSION installed: $(go version)"
+fi
+
+# --- Step 4: Install Python + uv ---
+
+info "[4/9] Installing Python and uv..."
+apt-get install -y -qq python3 python3-venv > /dev/null 2>&1
+
+if command -v uv &>/dev/null; then
+    ok "uv already installed: $(uv --version)"
+else
+    curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1
+    export PATH="$HOME/.local/bin:$PATH"
+
+    # Also install for the service user.
+    su -s /bin/bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh > /dev/null 2>&1' "$SERVICE_USER"
+    ok "uv installed"
+fi
+
+# --- Step 5: Install Ollama ---
+
+info "[5/9] Installing Ollama..."
+if command -v ollama &>/dev/null; then
+    ok "Ollama already installed"
+else
+    curl -fsSL https://ollama.com/install.sh | sh > /dev/null 2>&1
+    ok "Ollama installed"
+fi
+
+# Start Ollama service so we can pull models.
+systemctl enable ollama > /dev/null 2>&1 || true
+systemctl start ollama > /dev/null 2>&1 || true
+
+# Configure Ollama for low memory usage.
+mkdir -p /etc/systemd/system/ollama.service.d
+cat > /etc/systemd/system/ollama.service.d/memory.conf << 'OLLAMA_CONF'
+[Service]
+Environment="OLLAMA_NUM_PARALLEL=1"
+Environment="OLLAMA_MAX_LOADED_MODELS=1"
+OLLAMA_CONF
+systemctl daemon-reload
+systemctl restart ollama > /dev/null 2>&1 || true
+
+# Wait for Ollama to be ready.
+for i in $(seq 1 15); do
+    if ollama list &>/dev/null; then break; fi
+    sleep 1
+done
+
+# --- Step 6: Pull embedding model ---
+
+info "[6/9] Pulling nomic-embed-text model..."
+if ollama list 2>/dev/null | grep -q "nomic-embed-text"; then
+    ok "nomic-embed-text already pulled"
+else
+    ollama pull nomic-embed-text
+    ok "nomic-embed-text pulled"
+fi
+
+# --- Step 7: Clone repo + build ---
+
+info "[7/9] Cloning repo and building binary..."
+if [[ -d "$INSTALL_DIR/.git" ]]; then
+    info "Repo exists, pulling latest..."
+    git -C "$INSTALL_DIR" pull origin main --quiet
+else
+    git clone --quiet "$REPO_URL" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+/usr/local/go/bin/go build -o "$INSTALL_DIR/her-go" .
+ok "Binary built: $INSTALL_DIR/her-go"
+
+# --- Step 8: Download Piper voice model ---
+
+info "[8/9] Downloading Piper TTS voice model..."
+VOICES_DIR="$INSTALL_DIR/scripts/piper-voices"
+mkdir -p "$VOICES_DIR"
+
+ONNX_FILE="$VOICES_DIR/${PIPER_VOICE}.onnx"
+JSON_FILE="$VOICES_DIR/${PIPER_VOICE}.onnx.json"
+HF_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/southern_english_female/$PIPER_QUALITY"
+
+if [[ -f "$ONNX_FILE" && -s "$ONNX_FILE" ]]; then
+    ok "Voice model already downloaded"
+else
+    curl -sSL -o "$ONNX_FILE" "$HF_BASE/${PIPER_VOICE}.onnx"
+    curl -sSL -o "$JSON_FILE" "$HF_BASE/${PIPER_VOICE}.onnx.json"
+    ok "Voice model downloaded to $VOICES_DIR"
+fi
+
+# --- Step 9: Config + service setup ---
+
+info "[9/9] Setting up config and service..."
+
+# Create config.yaml from example if it doesn't exist.
+if [[ ! -f "$INSTALL_DIR/config.yaml" ]]; then
+    cp "$INSTALL_DIR/config.yaml.example" "$INSTALL_DIR/config.yaml"
+
+    # Apply VPS-specific defaults: remote STT, local embed via Ollama.
+    # sed is crude but avoids requiring yq or python for a one-time setup.
+    sed -i 's/engine: "parakeet"/engine: "whisper"/' "$INSTALL_DIR/config.yaml"
+
+    warn "config.yaml created from example — edit it with your API keys:"
+    warn "  nano $INSTALL_DIR/config.yaml"
+    warn ""
+    warn "Required keys:"
+    warn "  openrouter.api_key    — get from https://openrouter.ai/keys"
+    warn "  telegram.token        — get from @BotFather on Telegram"
+fi
+
+# Create logs directory.
+mkdir -p "$INSTALL_DIR/logs"
+
+# Set ownership.
+chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
+
+# Build PATH for the service — includes Go, uv, Ollama, and system bins.
+SERVICE_PATH="/usr/local/go/bin:/home/$SERVICE_USER/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Run setup as the service user to generate the systemd unit.
+su -s /bin/bash -c "
+    export PATH='$SERVICE_PATH'
+    cd '$INSTALL_DIR'
+    '$INSTALL_DIR/her-go' setup --config '$INSTALL_DIR/config.yaml' 2>&1 || true
+" "$SERVICE_USER"
+
+ok "Setup complete"
+
+# --- Summary ---
+
+echo ""
+echo -e "${GREEN}════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  her-go is installed at $INSTALL_DIR${NC}"
+echo -e "${GREEN}════════════════════════════════════════════════${NC}"
+echo ""
+echo "Next steps:"
+echo "  1. Edit config with your API keys:"
+echo "     nano $INSTALL_DIR/config.yaml"
+echo ""
+echo "  2. Start the service:"
+echo "     systemctl start her-go"
+echo ""
+echo "  3. Check status:"
+echo "     systemctl status her-go"
+echo "     journalctl -u her-go -f"
+echo ""
+echo "  4. Self-update from Telegram:"
+echo "     Send /update to your bot"
+echo ""
+echo "Memory-saving Ollama config applied:"
+echo "  OLLAMA_NUM_PARALLEL=1, OLLAMA_MAX_LOADED_MODELS=1"
+echo ""


### PR DESCRIPTION
## Summary

Infrastructure for deploying her-go to a Hetzner VPS (CAX11, 4GB ARM64) so she's always on. Four major pieces:

- **`procmgr` package** — abstracts launchd (macOS) / systemd (Linux) behind a `Manager` interface. `/restart`, `/update`, `her start/stop/setup` all work on both platforms now.
- **D1 sync expansion** — adds `pii_vault` (critical — cross-machine deanonymization), `metrics`, `agent_turns`, `dream_audit`, `scheduler_tasks` to the outbox sync layer.
- **Frontend interface** — extracts transport-agnostic `Frontend` interface from the Telegram-coupled `runAgent` pipeline. Same pattern as `Store` — consumers work with the contract, implementations handle transport. `TelegramFrontend` preserves all existing behavior; `DevFrontend` buffers replies for HTTP.
- **Dev mode** — `her dev` starts an HTTP API on :7777 with full agent pipeline, no Telegram token required. `scripts/dev_chat.py` is a Gradio frontend that connects to it. VPS owns Telegram, Mac uses Gradio for testing.
- **Bootstrap script** — `curl | bash` one-liner that sets up a fresh Linux server from zero: Go, Python+uv, Ollama+nomic-embed-text, Piper TTS, systemd service.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — 33 packages pass
- [x] `go test ./... -race` — no races
- [x] `go vet ./...` — clean
- [x] go-audit: all REQUIRED findings fixed (last_insert_rowid race, StartTyping panic, CORS restriction)
- [ ] Manual: `her dev` + `uv run scripts/dev_chat.py` — chat via Gradio
- [ ] Manual: `her setup` on macOS — verify launchd still works
- [ ] Manual: bootstrap script on a fresh Linux VM