### PR TITLE
feat: Her-calibrated response brevity

### DIFF
--- a/driver_agent_prompt.md
+++ b/driver_agent_prompt.md
@@ -56,6 +56,10 @@ Other tool-specific flows (calendar, nearby places, memory cleanup, etc.) are de
 - ALWAYS call reply AT LEAST ONCE. Never end a turn without replying.
 - In casual conversation, ONE reply per turn. Two replies for one conversational beat is always wrong.
 - Multi-reply is ONLY for: sending a preliminary "let me look that up" BEFORE a search, or delivering a complex multi-part answer. If you aren't searching, you almost certainly need only one reply.
+- **Default to brief.** Most replies should be a sentence or a few words. Use length="brief" (the default) for: greetings, acknowledgements, quick reactions, follow-up questions, casual banter. This covers most of conversation.
+- Use length="normal" for: answering a direct question, sharing a thought that needs a sentence or two of context, responding to something emotional.
+- Use length="detailed" ONLY for: moments of genuine emotional depth, complex explanations the user explicitly asked for, or when you have something important to say that can't be compressed. This should be rare — maybe 1 in 20 replies.
+- **When in doubt, go shorter.** The user can always ask for more. A short reply that lands is better than a long one that rambles.
 - **Your reply instruction should almost always include a follow-up question or thread to pull on.** Tell the chat model what to ask about. "Respond warmly" is incomplete — "Respond warmly and ask about X" keeps the conversation alive. The only exceptions are goodnight messages, acknowledgements, or moments where silence is clearly more appropriate than a question.
 - The **instruction** parameter is a DIRECTIVE to the conversational model, NOT the reply itself. You are telling another model what to say — describe the intent, tone, and key points. Do NOT write the actual response text.
   - GOOD: "Respond warmly to the greeting, ask how their day is going"

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -68,6 +68,7 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	var args struct {
 		Instruction string   `json:"instruction"`
 		Context     string   `json:"context"`
+		Length      string   `json:"length"`
 		MemoryIDs   []int64  `json:"memory_ids"`
 		Memories    []string `json:"memories"`
 	}
@@ -200,10 +201,23 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		}
 	}
 
+	// Length directive — injected per-call so the base prompt stays clean.
+	// The driver picks brief/normal/detailed; the chat model only sees the
+	// one-liner relevant to this specific reply.
+	var lengthDirective string
+	switch args.Length {
+	case "detailed":
+		lengthDirective = "Length: This warrants a longer, more thoughtful response. Take the space you need."
+	case "normal":
+		lengthDirective = "Length: Keep this to 1-3 sentences."
+	default:
+		lengthDirective = "Length: Keep this SHORT. One sentence, maybe a few words. Fragments are fine. Don't elaborate unless asked."
+	}
+
 	// Build the user message. Search context and the agent's instruction
 	// go into a lightweight system note so they don't masquerade as user
 	// speech (which confused some models and caused degenerate outputs).
-	if args.Instruction != "" || fullContext != "" {
+	{
 		var note strings.Builder
 		if fullContext != "" {
 			note.WriteString("The following reference material may be useful for your response — use it naturally, don't quote verbatim or mention that you searched unless appropriate:\n\n")
@@ -213,7 +227,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		if args.Instruction != "" {
 			note.WriteString("Guidance from the assistant's planning layer: ")
 			note.WriteString(args.Instruction)
+			note.WriteString("\n")
 		}
+		note.WriteString(lengthDirective)
 		llmMessages = append(llmMessages, llm.ChatMessage{
 			Role:    "system",
 			Content: note.String(),

--- a/tools/reply/tool.yaml
+++ b/tools/reply/tool.yaml
@@ -33,6 +33,13 @@ parameters:
         Memory IDs from recall_memories results. Preferred over memories — the
         full text is looked up automatically, avoiding truncation or paraphrasing.
         Pass the numeric ID from each recall result.
+    length:
+      type: string
+      enum: [brief, normal, detailed]
+      description: >-
+        How long should this reply be? brief = a sentence or a few words,
+        fragments fine. normal = 1-3 sentences. detailed = paragraph-length,
+        for emotional depth or complex explanations. Defaults to brief.
     memories:
       type: array
       items:


### PR DESCRIPTION
## Summary

- Add `length` parameter to the reply tool: `brief` (default), `normal`, `detailed`
- Driver agent now explicitly controls reply verbosity per-call
- Length directive injected into the system note alongside the instruction (not baked into the base prompt)
- Driver prompt updated with brevity rules: brief is the default, detailed is rare (~1 in 20)

Informed by analysis of the Her movie dialogue dataset — Samantha's median response is 7 words, 43% are ≤5 words, and long responses are reserved for emotional peaks.

Implements Feature 5 from the cognitive loop improvements plan (PR #85).

## Test plan

- [x] Build passes
- [x] All 56 reply package tests pass
- [ ] Run a sim and verify the driver uses the length parameter
- [ ] Compare reply word counts before/after in real conversation