### PR TITLE
feat: importance rewire — blended retrieval + usage tracking

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -145,6 +145,14 @@ func runBot(cmd *cobra.Command, args []string) error {
 	store.AutoLinkCount = cfg.Memory.AutoLinkCount
 	store.AutoLinkThreshold = cfg.Memory.AutoLinkThreshold
 
+	// Blended retrieval weights — see config.RecallConfig for the formula.
+	rc := cfg.Memory.Recall.WithDefaults()
+	store.RecallSimilarityWeight = rc.SimilarityWeight
+	store.RecallImportanceWeight = rc.ImportanceWeight
+	store.RecallRecencyWeight = rc.RecencyWeight
+	store.RecallRecencyHalfLifeDays = rc.RecencyHalfLifeDays
+	store.RecallUsageBoostFactor = rc.UsageBoostFactor
+
 	// If D1 sync is configured, wrap SQLiteStore in SyncedStore for
 	// bidirectional sync with Cloudflare D1. Writes push to D1 in the
 	// background; Pull() on startup hydrates local her.db with any

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -687,6 +687,12 @@ func runSim(cmd *cobra.Command, args []string) error {
 	defer store.Close()
 	store.AutoLinkCount = cfg.Memory.AutoLinkCount
 	store.AutoLinkThreshold = cfg.Memory.AutoLinkThreshold
+	rc := cfg.Memory.Recall.WithDefaults()
+	store.RecallSimilarityWeight = rc.SimilarityWeight
+	store.RecallImportanceWeight = rc.ImportanceWeight
+	store.RecallRecencyWeight = rc.RecencyWeight
+	store.RecallRecencyHalfLifeDays = rc.RecencyHalfLifeDays
+	store.RecallUsageBoostFactor = rc.UsageBoostFactor
 
 	// ------------------------------------------------------------------
 	// 5. Create LLM + embed + search clients (same pattern as run.go)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -135,6 +135,17 @@ memory:
   auto_link_threshold: 0.7       # min cosine similarity to create a link (0.0-1.0). Higher = stricter, fewer links.
   max_memory_length: 1000        # hard character limit per memory. Raised from 300 to support dream consolidation merges. The SPLIT classifier catches packed memories before this fires.
 
+  # Blended retrieval scoring — weights for the formula that ranks memories
+  # by a blend of similarity, importance, recency, and usage frequency.
+  # Similarity still dominates; importance + recency + usage act as tiebreakers
+  # that promote well-used, recent, high-importance memories over raw distance.
+  recall:
+    similarity_weight: 0.60       # cosine similarity contribution
+    importance_weight: 0.25       # importance score (1-10, normalized to 0-1)
+    recency_weight: 0.15          # exponential decay on memory age
+    recency_half_life_days: 30    # half-life for recency decay (days)
+    usage_boost_factor: 0.10      # boost from recall_count (log-scaled, diminishing returns)
+
 scrub:
   enabled: true
   # tier 1 (hard redact) and tier 2 (tokenize) are always on

--- a/config/config.go
+++ b/config/config.go
@@ -507,15 +507,44 @@ type ProviderConfig struct {
 
 // MemoryConfig controls the SQLite-backed memory system.
 type MemoryConfig struct {
-	DBPath              string  `yaml:"db_path"`
-	RecentMessages      int     `yaml:"recent_messages"`
-	MaxFactsInContext   int     `yaml:"max_facts_in_context"`
-	ExtractionInterval  int     `yaml:"extraction_interval"`
-	MaxHistoryTokens    int     `yaml:"max_history_tokens"`    // history token budget for compaction — both triggers fire at 75% of this
-	DriverContextBudget int     `yaml:"driver_context_budget"` // driver model total prompt budget for action history compaction; 0 = use 6000 default
-	AutoLinkCount       int     `yaml:"auto_link_count"`       // max links per new fact (0 = disabled)
-	AutoLinkThreshold   float64 `yaml:"auto_link_threshold"`   // min cosine similarity to create a link (0.0-1.0)
-	MaxMemoryLength     int     `yaml:"max_memory_length"`     // hard character limit for a single memory (0 = use default 300)
+	DBPath              string       `yaml:"db_path"`
+	RecentMessages      int          `yaml:"recent_messages"`
+	MaxFactsInContext   int          `yaml:"max_facts_in_context"`
+	ExtractionInterval  int          `yaml:"extraction_interval"`
+	MaxHistoryTokens    int          `yaml:"max_history_tokens"`    // history token budget for compaction — both triggers fire at 75% of this
+	DriverContextBudget int          `yaml:"driver_context_budget"` // driver model total prompt budget for action history compaction; 0 = use 6000 default
+	AutoLinkCount       int          `yaml:"auto_link_count"`       // max links per new fact (0 = disabled)
+	AutoLinkThreshold   float64      `yaml:"auto_link_threshold"`   // min cosine similarity to create a link (0.0-1.0)
+	MaxMemoryLength     int          `yaml:"max_memory_length"`     // hard character limit for a single memory (0 = use default 300)
+	Recall              RecallConfig `yaml:"recall"`
+}
+
+// RecallConfig controls the blended retrieval scoring formula.
+// Instead of ranking memories purely by cosine distance, retrieval uses a
+// weighted blend of similarity, importance, recency, and usage frequency.
+// Weights should sum to ~1.0 for interpretability but this isn't enforced.
+type RecallConfig struct {
+	SimilarityWeight    float64 `yaml:"similarity_weight"`     // cosine similarity contribution (default 0.60)
+	ImportanceWeight    float64 `yaml:"importance_weight"`     // importance score normalized 0-1 (default 0.25)
+	RecencyWeight       float64 `yaml:"recency_weight"`        // exponential decay on age (default 0.15)
+	RecencyHalfLifeDays int     `yaml:"recency_half_life_days"` // how fast recency decays (default 30)
+	UsageBoostFactor    float64 `yaml:"usage_boost_factor"`    // boost from recall_count with diminishing returns (default 0.10)
+}
+
+// RecallDefaults returns a RecallConfig with sensible defaults when the
+// config file doesn't specify recall settings.
+func (rc RecallConfig) WithDefaults() RecallConfig {
+	if rc.SimilarityWeight == 0 && rc.ImportanceWeight == 0 && rc.RecencyWeight == 0 {
+		// Nothing configured — use plan defaults (similarity-dominant).
+		rc.SimilarityWeight = 0.60
+		rc.ImportanceWeight = 0.25
+		rc.RecencyWeight = 0.15
+		rc.UsageBoostFactor = 0.10
+	}
+	if rc.RecencyHalfLifeDays == 0 {
+		rc.RecencyHalfLifeDays = 30
+	}
+	return rc
 }
 
 // ScrubConfig controls PII scrubbing behavior.

--- a/memory/store.go
+++ b/memory/store.go
@@ -59,6 +59,7 @@ type Store interface {
 	GetMemoryContent(memoryID int64) (string, error)
 	UpdateMemory(memoryID int64, content, category string, importance int, tags string) error
 	UpdateMemoryTags(memoryID int64, tags string) error
+	MarkMemoriesRecalled(ids []int64) error
 	DeactivateMemory(memoryID int64) error
 	LinkMemories(id1, id2 int64, similarity float64) error
 	LinkedMemories(memoryID int64, limit int) ([]Memory, error)
@@ -192,6 +193,15 @@ type SQLiteStore struct {
 	// stored in SQLite so it persists across restarts.
 	AutoLinkCount     int     // max links per new memory (0 = disabled)
 	AutoLinkThreshold float64 // min cosine similarity to create a link (0.0-1.0)
+
+	// Blended retrieval weights — used by SemanticSearch to rank results
+	// by a weighted blend of similarity, importance, recency, and usage.
+	// Set from config.RecallConfig at store creation time.
+	RecallSimilarityWeight    float64
+	RecallImportanceWeight    float64
+	RecallRecencyWeight       float64
+	RecallRecencyHalfLifeDays int
+	RecallUsageBoostFactor    float64
 }
 
 // NewStore opens (or creates) the SQLite database at the given path

--- a/memory/store_facts.go
+++ b/memory/store_facts.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 
 	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
@@ -45,6 +46,11 @@ type Memory struct {
 	Embedding       []float32 // cached tag embedding vector (nil if not yet computed)
 	EmbeddingText   []float32 // cached text embedding vector (nil if not yet computed)
 	Distance        float64   // populated by SemanticSearch — cosine distance from query (0 = identical)
+
+	// Usage tracking — how often this memory is actually pulled into chat.
+	// Populated by MarkMemoriesRecalled; used by blended retrieval scoring.
+	RecallCount    int       // number of times this memory entered the chat prompt
+	LastRecalledAt time.Time // most recent time it was pulled into the chat prompt
 
 	// Zettelkasten fields — knowledge graph edges and supersession tracking.
 	SupersededBy    int64  // ID of the memory that replaced this one (0 = not superseded)
@@ -300,6 +306,38 @@ func (s *SQLiteStore) UpdateMemory(memoryID int64, content, category string, imp
 // Used by `her retag` to backfill tags for existing memories.
 func (s *SQLiteStore) UpdateMemoryTags(memoryID int64, tags string) error {
 	_, err := s.db.Exec(`UPDATE memories SET tags = ? WHERE id = ?`, tags, memoryID)
+	return err
+}
+
+// MarkMemoriesRecalled bumps the usage signal for memories that were just
+// pulled into the chat prompt — either via the reply tool's memory_ids or
+// via auto-injection from the memory layers. This is the write side of the
+// blended retrieval scoring: memories that are actually used in conversation
+// accumulate recall_count and a fresh last_recalled_at, which the retrieval
+// formula rewards.
+func (s *SQLiteStore) MarkMemoriesRecalled(ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	// Build a placeholder string for the IN clause. Go's database/sql
+	// doesn't support slice parameters directly — you have to expand
+	// the placeholders yourself. Same pattern as Python's ", ".join().
+	placeholders := make([]byte, 0, len(ids)*2)
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		if i > 0 {
+			placeholders = append(placeholders, ',')
+		}
+		placeholders = append(placeholders, '?')
+		args[i] = id
+	}
+	_, err := s.db.Exec(
+		`UPDATE memories
+		 SET last_recalled_at = CURRENT_TIMESTAMP,
+		     recall_count = recall_count + 1
+		 WHERE id IN (`+string(placeholders)+`) AND active = 1`,
+		args...,
+	)
 	return err
 }
 
@@ -649,17 +687,23 @@ func (s *SQLiteStore) AllActiveMemories() ([]Memory, error) {
 	return memories, nil
 }
 
-// SemanticSearch finds the top-K memories most similar to a query vector
-// using sqlite-vec's KNN search. Returns memories with their cosine distance
-// (0 = identical, up to 2 = opposite). Only returns active memories.
+// SemanticSearch finds the top-K memories most relevant to a query vector
+// using a blended scoring formula. Instead of returning results purely by
+// cosine distance, it oversamples from the KNN index (4x topK) and reranks
+// using a weighted blend of:
 //
-// This is the core of v0.4's "She Understands" — instead of just grabbing
-// the most important memories, we find the memories most RELEVANT to what the
-// user is talking about right now.
+//   - Similarity (1 - cosine distance)
+//   - Importance (the 1-10 score, normalized to 0-1)
+//   - Recency (exponential decay on age)
+//   - Usage (log-scaled recall_count — memories that are actually used often
+//     get a boost, with diminishing returns)
 //
-// Under the hood, sqlite-vec uses the MATCH operator on the vec0 virtual
-// table. The query plan: KNN on vec_memories → get rowids → JOIN memories for
-// metadata → filter out inactive memories.
+// The weights come from config via the store's Recall* fields. When all
+// weights are zero (unconfigured), defaults to similarity-only (the old
+// behavior).
+//
+// Under the hood: sqlite-vec KNN on vec_memories → oversample candidates →
+// JOIN memories for metadata + usage columns → rerank in Go → take top-K.
 func (s *SQLiteStore) SemanticSearch(queryVec []float32, topK int) ([]Memory, error) {
 	if s.EmbedDimension == 0 {
 		return nil, fmt.Errorf("semantic search not available: embed dimension is 0")
@@ -670,47 +714,112 @@ func (s *SQLiteStore) SemanticSearch(queryVec []float32, topK int) ([]Memory, er
 		return nil, fmt.Errorf("serializing query vector: %w", err)
 	}
 
-	// We request more than topK from vec_memories because some results may
-	// be inactive memories (soft-deleted). We filter those out after the JOIN.
-	// Requesting 2x is a reasonable buffer.
+	// Oversample 4x so we have enough candidates for reranking after
+	// filtering inactive memories. The old 2x buffer was for pure-KNN;
+	// blended scoring needs a wider candidate pool to let importance and
+	// recency promote results that aren't in the top-K by distance alone.
+	oversample := topK * 4
+	if oversample < 20 {
+		oversample = 20
+	}
+
 	rows, err := s.db.Query(
 		`SELECT m.id, m.timestamp, m.memory, m.category, COALESCE(m.subject, 'user'),
-		        m.importance, COALESCE(m.tags, ''), m.embedding_text, v.distance
+		        m.importance, COALESCE(m.tags, ''), m.embedding_text, v.distance,
+		        COALESCE(m.recall_count, 0), m.last_recalled_at
 		 FROM vec_memories v
 		 JOIN memories m ON m.id = v.rowid
 		 WHERE v.embedding MATCH ?
 		   AND k = ?
 		   AND m.active = 1
 		 ORDER BY v.distance ASC`,
-		queryBytes, topK*2,
+		queryBytes, oversample,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("semantic search query: %w", err)
 	}
 	defer rows.Close()
 
-	var memories []Memory
+	var candidates []Memory
 	for rows.Next() {
 		var m Memory
 		var ts string
 		var embTextData []byte
-		if err := rows.Scan(&m.ID, &ts, &m.Content, &m.Category, &m.Subject, &m.Importance, &m.Tags, &embTextData, &m.Distance); err != nil {
+		var lastRecalled sql.NullString
+		if err := rows.Scan(&m.ID, &ts, &m.Content, &m.Category, &m.Subject,
+			&m.Importance, &m.Tags, &embTextData, &m.Distance,
+			&m.RecallCount, &lastRecalled); err != nil {
 			return nil, fmt.Errorf("scanning semantic search result: %w", err)
 		}
 		m.Timestamp = parseTimestamp(ts)
-		m.Active = true
-		m.Source = "semantic"
-		m.EmbeddingText = deserializeEmbedding(embTextData)
-		memories = append(memories, m)
-
-		// Stop once we have enough active results.
-		if len(memories) >= topK {
-			break
+		if lastRecalled.Valid {
+			m.LastRecalledAt = parseTimestamp(lastRecalled.String)
 		}
+		m.Active = true
+		m.EmbeddingText = deserializeEmbedding(embTextData)
+		candidates = append(candidates, m)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating rows: %w", err)
 	}
+
+	// Blended reranking. If no weights are configured, similarity dominates
+	// (same behavior as before, just with the oversample buffer).
+	wSim := s.RecallSimilarityWeight
+	wImp := s.RecallImportanceWeight
+	wRec := s.RecallRecencyWeight
+	wUse := s.RecallUsageBoostFactor
+	halfLife := float64(s.RecallRecencyHalfLifeDays)
+	if halfLife <= 0 {
+		halfLife = 30
+	}
+	// If nothing configured, fall back to pure similarity ranking.
+	if wSim == 0 && wImp == 0 && wRec == 0 && wUse == 0 {
+		wSim = 1.0
+	}
+
+	now := time.Now()
+	type scored struct {
+		mem   Memory
+		score float64
+	}
+	ranked := make([]scored, len(candidates))
+	for i, m := range candidates {
+		similarity := 1 - m.Distance
+		importanceNorm := float64(m.Importance) / 10.0
+		ageDays := now.Sub(m.Timestamp).Hours() / 24.0
+		recency := math.Exp(-ageDays * math.Ln2 / halfLife)
+		usage := math.Min(1.0, math.Log1p(float64(m.RecallCount))/4.0)
+
+		score := similarity*wSim + importanceNorm*wImp + recency*wRec + usage*wUse
+
+		// Tag the source based on what dominated the score. This makes the
+		// Source field meaningful again — "importance" means the memory
+		// surfaced because of its importance/recency/usage, not just distance.
+		source := "semantic"
+		if wImp+wRec+wUse > 0 {
+			nonSimContribution := importanceNorm*wImp + recency*wRec + usage*wUse
+			simContribution := similarity * wSim
+			if nonSimContribution > simContribution {
+				source = "importance"
+			}
+		}
+		m.Source = source
+		ranked[i] = scored{mem: m, score: score}
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].score > ranked[j].score
+	})
+
+	memories := make([]Memory, 0, topK)
+	for _, r := range ranked {
+		if len(memories) >= topK {
+			break
+		}
+		memories = append(memories, r.mem)
+	}
+
 
 	// Zettelkasten 1-hop traversal: for each primary KNN result, pull in
 	// linked neighbors that didn't directly match the query. This is the

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -635,6 +635,12 @@ func (s *SyncedStore) UpdateMemoryTags(memoryID int64, tags string) error {
 	return nil
 }
 
+// MarkMemoriesRecalled bumps usage counters locally. No outbox write — recall
+// tracking is local-only (each machine tracks its own usage patterns).
+func (s *SyncedStore) MarkMemoriesRecalled(ids []int64) error {
+	return s.SQLiteStore.MarkMemoriesRecalled(ids)
+}
+
 // DeactivateMemory soft-deletes a memory locally and records in outbox.
 // The vec_memories DELETE only happens locally — D1 has no vector tables.
 func (s *SyncedStore) DeactivateMemory(memoryID int64) error {

--- a/memory_agent_prompt.md
+++ b/memory_agent_prompt.md
@@ -46,6 +46,19 @@ Think of each card as a folder. One well-organized folder per topic beats scatte
 - **Passes the 30-day test.** Would this matter in a conversation a month from now?
 - **One fact per memory.** If you're packing two unrelated ideas, save them separately.
 
+## How to score importance (1-10)
+
+Be calibrated. The default for an ordinary memory is 5. Don't bunch at extremes.
+
+- **10** — Identity-level. Name, pronouns, fundamental facts that almost never change. "{{user}} uses she/her pronouns" is a 10.
+- **8-9** — Major life context. Current job, where she lives, primary relationships, health conditions on active treatment, sobriety status.
+- **6-7** — Stable preferences and patterns. "Prefers functional-OOP hybrid code." "Watches mood when off Prozac." "Drinks tea, not coffee."
+- **4-5** — DEFAULT. Useful context but replaceable. "Working on the Raindrop Link Detector spec." "Has a Cava close shift tomorrow."
+- **2-3** — Episode-specific. Something that mattered today but is unlikely to matter in 30 days.
+- **1** — Borderline. Save only because you weren't sure.
+
+If you can't tell between two scores, pick the lower one. The system adjusts importance over time based on how often a memory is actually used in conversation — over-scoring at write time just creates noise.
+
 ## What NOT to save
 
 - **Transient moods:** "feeling nothing today", "stressed about work this afternoon" — momentary states, not durable facts

--- a/migrations/000017_add_memory_usage_tracking.up.sql
+++ b/migrations/000017_add_memory_usage_tracking.up.sql
@@ -1,0 +1,13 @@
+-- Track how often and how recently memories are recalled into the chat
+-- prompt. This powers the blended retrieval scoring (Feature 1: Importance
+-- Rewire) — memories that are actually used in conversation get a usage
+-- boost, replacing the one-shot LLM importance judgment as the long-term
+-- signal.
+
+ALTER TABLE memories ADD COLUMN last_recalled_at TIMESTAMP;
+ALTER TABLE memories ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0;
+
+-- Index for the dreamer's recalibration pass and for the forgetting
+-- policy (Feature 3) which needs to find memories unused for 60+ days.
+CREATE INDEX IF NOT EXISTS idx_memories_recall
+    ON memories (active, recall_count, last_recalled_at);

--- a/tools/memory_helpers.go
+++ b/tools/memory_helpers.go
@@ -96,11 +96,12 @@ func MaxMemoryLength() int {
 // gates, same embedding strategy, same classifier check.
 func ExecSaveMemory(argsJSON, subject string, ctx *Context) string {
 	var args struct {
-		CardSlug string `json:"card_slug"`
-		Memory   string `json:"memory"`
-		Category string `json:"category"`
-		Tags     string `json:"tags"`
-		Context  string `json:"context"` // optional: why this memory matters
+		CardSlug   string `json:"card_slug"`
+		Memory     string `json:"memory"`
+		Category   string `json:"category"`
+		Tags       string `json:"tags"`
+		Importance int    `json:"importance"` // 1-10, defaults to 5 if omitted or out of range
+		Context    string `json:"context"`    // optional: why this memory matters
 	}
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
 		return fmt.Sprintf("error parsing arguments: %v", err)
@@ -266,7 +267,13 @@ func ExecSaveMemory(argsJSON, subject string, ctx *Context) string {
 		return "error: no store configured"
 	}
 
-	id, err := ctx.Store.SaveMemory(args.Memory, args.Category, subject, 0, 5, newVec, textVec, args.Tags, args.Context, cardID)
+	// Clamp importance to 1-10, defaulting to 5 if omitted or out of range.
+	importance := args.Importance
+	if importance < 1 || importance > 10 {
+		importance = 5
+	}
+
+	id, err := ctx.Store.SaveMemory(args.Memory, args.Category, subject, 0, importance, newVec, textVec, args.Tags, args.Context, cardID)
 	if err != nil {
 		return fmt.Sprintf("error saving memory: %v", err)
 	}

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -84,6 +84,10 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 				args.Memories = append(args.Memories, mem.Content)
 			}
 		}
+		// Track that these memories were used in the chat prompt.
+		if err := ctx.Store.MarkMemoriesRecalled(args.MemoryIDs); err != nil {
+			log.Warn("reply: failed to mark memories recalled", "err", err)
+		}
 	}
 
 	// If the agent passed memories (by ID or text), store them on ctx so the
@@ -109,8 +113,10 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	}
 	systemPrompt, chatLayerResults := layers.BuildAll(layers.StreamChat, chatLayerCtx)
 
-	// Log chat prompt shape for observability.
+	// Log chat prompt shape for observability and collect injected memory
+	// IDs for usage tracking (blended retrieval scoring).
 	var chatTotalTokens int
+	var layerInjectedIDs []int64
 	for _, lr := range chatLayerResults {
 		chatTotalTokens += lr.Tokens
 		if lr.Detail != "" {
@@ -120,6 +126,7 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		}
 		// Pass injected memories observability to the TUI.
 		for _, m := range lr.InjectedMemories {
+			layerInjectedIDs = append(layerInjectedIDs, m.ID)
 			memArgs := fmt.Sprintf("#%d %s", m.ID, m.Source)
 			if m.Distance > 0 {
 				memArgs = fmt.Sprintf("#%d %s dist=%.2f", m.ID, m.Source, m.Distance)
@@ -138,6 +145,13 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		}
 	}
 	log.Infof("  chat system prompt total: ~%d tokens", chatTotalTokens)
+
+	// Mark layer-injected memories as recalled for usage tracking.
+	if len(layerInjectedIDs) > 0 && ctx.Store != nil {
+		if err := ctx.Store.MarkMemoriesRecalled(layerInjectedIDs); err != nil {
+			log.Warn("reply: failed to mark layer-injected memories recalled", "err", err)
+		}
+	}
 
 	// Combine any accumulated search context with the explicit context parameter.
 	fullContext := ctx.SearchContext

--- a/tools/save_memory/tool.yaml
+++ b/tools/save_memory/tool.yaml
@@ -44,6 +44,11 @@ parameters:
         memory is about so it surfaces in the right conversations. Example:
         'mental health, burnout, coping, energy' or 'programming, go,
         backend, projects'. Be specific to the memory's topic.
+    importance:
+      type: integer
+      description: >-
+        How important is this memory? 1-10. Default 5. See the scoring
+        anchors in your system prompt. When unsure, pick the lower score.
     context:
       type: string
       description: >-

--- a/tools/save_self_memory/tool.yaml
+++ b/tools/save_self_memory/tool.yaml
@@ -37,6 +37,11 @@ parameters:
         Comma-separated topic tags for semantic search — describes WHAT this
         self-memory is about. Example: 'identity, communication style,
         authenticity' or 'relationship, boundaries, user dynamic'.
+    importance:
+      type: integer
+      description: >-
+        How important is this memory? 1-10. Default 5. See the scoring
+        anchors in your system prompt. When unsure, pick the lower score.
     context:
       type: string
       description: >-


### PR DESCRIPTION
## Summary

- **Blended retrieval**: `SemanticSearch()` oversamples 4x from the KNN index and reranks using a weighted formula (similarity 60%, importance 25%, recency 15%, usage 10%)
- **Usage tracking**: new `MarkMemoriesRecalled()` method bumps `recall_count` and `last_recalled_at` whenever memories enter the chat prompt (via reply tool or layer auto-injection)
- **Calibrated importance scoring**: memory agent can now set importance 1-10 per memory with concrete anchors (10=identity, 5=default, 1=borderline)
- **Migration 000017**: adds `recall_count`, `last_recalled_at` columns and index to `memories`

Over time, memories that are actually used in conversation accumulate a usage signal that promotes them in future retrieval — replacing the one-shot LLM importance judgment as the long-term ranking signal.

Implements Feature 2 from the cognitive loop improvements plan (PR #85).

## Test plan

- [x] Build passes
- [x] All memory, reply, save_memory, save_self_memory, gateway tests pass
- [ ] Run a sim and verify recall_count increments on recalled memories
- [ ] After a week of real use: `SELECT id, content, importance, recall_count FROM memories ORDER BY recall_count DESC LIMIT 20` shows intuitively correct results