### PR TITLE
feat: tomorrow's preload — forward-looking dream step

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -168,6 +168,15 @@ dream:
   dry_run: false                      # true = log what would change without touching DB
   # enabled: true                     # master switch — omit or set true to enable
 
+  # Tomorrow's preload: the dream cycle writes a short note about what
+  # to bring up in the next conversation. Auto-injected into the first
+  # chat turn of the day, then consumed.
+  tomorrow_preload:
+    enabled: true
+    expires_after_hours: 48           # how long the note stays active
+    max_bullets: 5                    # max bullet points in the note
+    history_lookback_days: 7          # how many days of messages to scan
+
 location:
   latitude: 0                   # written by set_location — leave 0/0 until set
   longitude: 0

--- a/config/config.go
+++ b/config/config.go
@@ -404,6 +404,18 @@ type DreamConfig struct {
 	// Enabled is the master switch. Default true (enabled when config
 	// section is absent — zero value false means we need to check).
 	Enabled *bool `yaml:"enabled,omitempty"`
+	// TomorrowPreload controls the forward-looking dream step that writes
+	// a short note about what to bring up in tomorrow's conversation.
+	TomorrowPreload TomorrowPreloadConfig `yaml:"tomorrow_preload"`
+}
+
+// TomorrowPreloadConfig controls the preload agent that runs as the last
+// step of the dream cycle.
+type TomorrowPreloadConfig struct {
+	Enabled             bool `yaml:"enabled"`
+	ExpiresAfterHours   int  `yaml:"expires_after_hours"`    // how long the note stays active (default 48)
+	MaxBullets          int  `yaml:"max_bullets"`            // max bullet points (default 5)
+	HistoryLookbackDays int  `yaml:"history_lookback_days"`  // how many days of messages to scan (default 7)
 }
 
 // DreamEnabled returns whether the memory dreamer is enabled.

--- a/layers/chat_tomorrow_preload.go
+++ b/layers/chat_tomorrow_preload.go
@@ -1,0 +1,43 @@
+package layers
+
+// Layer 2.7: Tomorrow's Preload — auto-injected context from the dream cycle.
+//
+// The dream cycle's preload agent writes a short note about what to be
+// ready to bring up. This layer injects it into the first chat turn of
+// the day, then marks it consumed so it doesn't repeat. The note gives
+// the chat model a "what's on my mind" section — the equivalent of
+// Samantha arriving at a conversation already holding context.
+
+func init() {
+	Register(PromptLayer{
+		Name:    "Tomorrow's Preload",
+		Order:   270,
+		Stream:  StreamChat,
+		Builder: buildChatTomorrowPreload,
+	})
+}
+
+func buildChatTomorrowPreload(ctx *LayerContext) LayerResult {
+	if ctx.Store == nil {
+		return LayerResult{}
+	}
+
+	preload, err := ctx.Store.ActiveTomorrowPreload()
+	if err != nil || preload == nil {
+		return LayerResult{}
+	}
+
+	content := "## What's on My Mind\n\n" + preload.Content + "\n"
+
+	// Store the preload ID on the context so the reply handler can
+	// consume it after delivery. We don't consume here because the
+	// layer runs during prompt building — if the reply fails or the
+	// turn is interrupted, we want the preload to survive for the
+	// next attempt.
+	ctx.PreloadID = preload.ID
+
+	return LayerResult{
+		Content: content,
+		Detail:  "preload active",
+	}
+}

--- a/layers/registry.go
+++ b/layers/registry.go
@@ -97,6 +97,11 @@ type LayerContext struct {
 	// how Mira is approaching this turn (not just what the user said).
 	ThinkTraces      []string
 	ReplyInstruction string
+
+	// PreloadID is set by the tomorrow's preload layer when it injects
+	// a preload note. The reply handler reads this to consume the preload
+	// after successful delivery.
+	PreloadID int64
 }
 
 // PromptLayer defines a single layer in the prompt assembly pipeline.

--- a/memory/store.go
+++ b/memory/store.go
@@ -89,6 +89,11 @@ type Store interface {
 	RecentLogEntries(hours int) ([]MemoryLogEntry, error)
 	CardLogEntries(cardID int64, limit int) ([]MemoryLogEntry, error)
 
+	// Tomorrow's preload
+	SaveTomorrowPreload(content string, expiresAfter time.Duration) (int64, error)
+	ActiveTomorrowPreload() (*TomorrowPreload, error)
+	ConsumeTomorrowPreload(id int64) error
+
 	// Dream audit
 	SaveDreamAudit(op string, sourceIDs []int64, resultID int64, before, after, reason string, dryRun bool) error
 	RecentDreamAudits(limit int) ([]DreamAudit, error)

--- a/memory/store_tomorrow_preload.go
+++ b/memory/store_tomorrow_preload.go
@@ -1,0 +1,60 @@
+package memory
+
+import "time"
+
+// TomorrowPreload is a short note the dream cycle writes about what Mira
+// should be ready to bring up in the next conversation. Single-row pattern:
+// each dream cycle inserts a fresh row, the chat layer consumes it on the
+// first turn of the next day, and old rows are kept for audit.
+type TomorrowPreload struct {
+	ID          int64
+	GeneratedAt time.Time
+	ExpiresAt   time.Time
+	Content     string
+	Consumed    bool
+	ConsumedAt  *time.Time
+}
+
+// SaveTomorrowPreload inserts a new preload note. expiresAfter controls
+// how long the note stays active before it's considered stale.
+func (s *SQLiteStore) SaveTomorrowPreload(content string, expiresAfter time.Duration) (int64, error) {
+	expiresAt := time.Now().Add(expiresAfter)
+	result, err := s.db.Exec(
+		`INSERT INTO tomorrow_preload (content, expires_at) VALUES (?, ?)`,
+		content, expiresAt.Format(time.RFC3339),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
+// ActiveTomorrowPreload returns the most recent unconsumed, unexpired
+// preload note. Returns nil if none is active.
+func (s *SQLiteStore) ActiveTomorrowPreload() (*TomorrowPreload, error) {
+	var p TomorrowPreload
+	var generatedAt, expiresAt string
+	err := s.db.QueryRow(
+		`SELECT id, generated_at, expires_at, content
+		 FROM tomorrow_preload
+		 WHERE consumed = 0 AND expires_at > datetime('now')
+		 ORDER BY generated_at DESC
+		 LIMIT 1`,
+	).Scan(&p.ID, &generatedAt, &expiresAt, &p.Content)
+	if err != nil {
+		return nil, nil // no active preload — not an error
+	}
+	p.GeneratedAt = parseTimestamp(generatedAt)
+	p.ExpiresAt = parseTimestamp(expiresAt)
+	return &p, nil
+}
+
+// ConsumeTomorrowPreload marks a preload as consumed so it won't be
+// injected again. Called after the first chat turn of the day.
+func (s *SQLiteStore) ConsumeTomorrowPreload(id int64) error {
+	_, err := s.db.Exec(
+		`UPDATE tomorrow_preload SET consumed = 1, consumed_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		id,
+	)
+	return err
+}

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -641,6 +641,18 @@ func (s *SyncedStore) MarkMemoriesRecalled(ids []int64) error {
 	return s.SQLiteStore.MarkMemoriesRecalled(ids)
 }
 
+// Tomorrow's preload — local-only, not synced to D1. Each machine generates
+// its own preload during its own dream cycle.
+func (s *SyncedStore) SaveTomorrowPreload(content string, expiresAfter time.Duration) (int64, error) {
+	return s.SQLiteStore.SaveTomorrowPreload(content, expiresAfter)
+}
+func (s *SyncedStore) ActiveTomorrowPreload() (*TomorrowPreload, error) {
+	return s.SQLiteStore.ActiveTomorrowPreload()
+}
+func (s *SyncedStore) ConsumeTomorrowPreload(id int64) error {
+	return s.SQLiteStore.ConsumeTomorrowPreload(id)
+}
+
 // DeactivateMemory soft-deletes a memory locally and records in outbox.
 // The vec_memories DELETE only happens locally — D1 has no vector tables.
 func (s *SyncedStore) DeactivateMemory(memoryID int64) error {

--- a/migrations/000018_add_tomorrow_preload.up.sql
+++ b/migrations/000018_add_tomorrow_preload.up.sql
@@ -1,0 +1,16 @@
+-- Tomorrow's preload: a short note the dream cycle writes about what
+-- to be ready to bring up in tomorrow's conversation. Auto-injected
+-- into the first chat turn of the day, then consumed so it doesn't
+-- linger. Old rows kept for audit (mirrors memory_log pattern).
+
+CREATE TABLE IF NOT EXISTS tomorrow_preload (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    content TEXT NOT NULL,
+    consumed BOOLEAN NOT NULL DEFAULT 0,
+    consumed_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_tomorrow_preload_active
+    ON tomorrow_preload (consumed, expires_at);

--- a/persona/dreamer.go
+++ b/persona/dreamer.go
@@ -148,6 +148,20 @@ func runDream(ctx context.Context, p DreamerParams) {
 		log.Info("dreamer: persona rewritten during dream cycle")
 		emitPersonaEvent(p.EventBus, "dream_rewrite", "persona updated via dream")
 	}
+
+	// Step 3: Tomorrow's preload — write a note about what to bring up
+	// in the next conversation. Runs after reflection and rewrite so it
+	// has access to tonight's fresh outputs.
+	if p.Cfg.Dream.TomorrowPreload.Enabled {
+		if err := RunTomorrowPreload(TomorrowPreloadParams{
+			LLM:      p.LLM,
+			Store:    p.Store,
+			Cfg:      p.Cfg,
+			EventBus: p.EventBus,
+		}); err != nil {
+			log.Error("dreamer: tomorrow preload failed", "err", err)
+		}
+	}
 }
 
 // durationUntilNextDream returns how long to sleep until the next occurrence

--- a/persona/tomorrow_preload.go
+++ b/persona/tomorrow_preload.go
@@ -1,0 +1,178 @@
+package persona
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"her/config"
+	"her/llm"
+	"her/memory"
+	"her/tui"
+)
+
+// TomorrowPreloadParams bundles everything the preload agent needs.
+type TomorrowPreloadParams struct {
+	LLM      *llm.Client
+	Store    memory.Store
+	Cfg      *config.Config
+	EventBus *tui.Bus
+}
+
+// RunTomorrowPreload generates a preload note for the next conversation.
+// It gathers recent messages, calendar events, mood patterns, inbox tasks,
+// and tonight's reflections, then asks the LLM to write 2-5 bullet points.
+// The result is saved to the tomorrow_preload table.
+func RunTomorrowPreload(p TomorrowPreloadParams) error {
+	cfg := p.Cfg.Dream.TomorrowPreload
+	if !cfg.Enabled {
+		return nil
+	}
+
+	promptTemplate, err := os.ReadFile("persona/tomorrow_preload_prompt.md")
+	if err != nil {
+		return fmt.Errorf("reading preload prompt: %w", err)
+	}
+
+	// Gather context signals for the agent.
+	var ctx strings.Builder
+
+	// Recent messages — last N days of conversation.
+	lookback := cfg.HistoryLookbackDays
+	if lookback <= 0 {
+		lookback = 7
+	}
+	msgs, err := p.Store.GlobalRecentMessages(100)
+	if err == nil && len(msgs) > 0 {
+		cutoff := time.Now().AddDate(0, 0, -lookback)
+		ctx.WriteString("### Recent messages (last ")
+		ctx.WriteString(fmt.Sprintf("%d days)\n\n", lookback))
+		count := 0
+		for _, m := range msgs {
+			if m.Timestamp.Before(cutoff) {
+				continue
+			}
+			content := m.ContentScrubbed
+			if content == "" {
+				content = m.ContentRaw
+			}
+			// Truncate long messages to keep context manageable.
+			if len(content) > 200 {
+				content = content[:200] + "..."
+			}
+			fmt.Fprintf(&ctx, "- [%s] %s: %s\n", m.Timestamp.Format("Jan 2"), m.Role, content)
+			count++
+			if count >= 50 {
+				break
+			}
+		}
+		ctx.WriteString("\n")
+	}
+
+	// Tomorrow's calendar events.
+	tomorrow := time.Now().AddDate(0, 0, 1)
+	tomorrowStart := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, tomorrow.Location())
+	tomorrowEnd := tomorrowStart.AddDate(0, 0, 1)
+	events, err := p.Store.ListCalendarEvents(
+		tomorrowStart.Format(time.RFC3339),
+		tomorrowEnd.Format(time.RFC3339),
+		"", false,
+	)
+	if err == nil && len(events) > 0 {
+		ctx.WriteString("### Tomorrow's calendar\n\n")
+		for _, e := range events {
+			fmt.Fprintf(&ctx, "- %s (%s)\n", e.Title, e.Start.Format("3:04 PM"))
+		}
+		ctx.WriteString("\n")
+	}
+
+	// Open inbox tasks.
+	pendingCount, _ := p.Store.PendingInboxCount("memory_agent")
+	if pendingCount > 0 {
+		fmt.Fprintf(&ctx, "### Open inbox tasks: %d pending\n\n", pendingCount)
+	}
+
+	// Recent mood patterns.
+	recentMood, err := p.Store.RecentMoodEntries(memory.MoodKindMomentary, 7)
+	if err == nil && len(recentMood) > 0 {
+		ctx.WriteString("### Recent mood (last 7 entries)\n\n")
+		for _, m := range recentMood {
+			labels := "unlabeled"
+			if len(m.Labels) > 0 {
+				labels = strings.Join(m.Labels, ", ")
+			}
+			fmt.Fprintf(&ctx, "- %s: valence=%d (%s)\n", m.Timestamp.Format("Jan 2"), m.Valence, labels)
+		}
+		ctx.WriteString("\n")
+	}
+
+	// Tonight's reflections.
+	reflections, err := p.Store.RecentReflections(3)
+	if err == nil && len(reflections) > 0 {
+		ctx.WriteString("### Tonight's reflections\n\n")
+		for _, r := range reflections {
+			content := r.Content
+			if len(content) > 300 {
+				content = content[:300] + "..."
+			}
+			fmt.Fprintf(&ctx, "- %s\n", content)
+		}
+		ctx.WriteString("\n")
+	}
+
+	// Current persona summary.
+	personaContent, err := os.ReadFile(p.Cfg.Persona.PersonaFile)
+	if err == nil && len(personaContent) > 0 {
+		ctx.WriteString("### Current persona summary\n\n")
+		summary := string(personaContent)
+		if len(summary) > 500 {
+			summary = summary[:500] + "..."
+		}
+		ctx.WriteString(summary)
+		ctx.WriteString("\n\n")
+	}
+
+	// Build the prompt with context injected.
+	prompt := strings.ReplaceAll(string(promptTemplate), "{{context}}", ctx.String())
+	prompt = strings.ReplaceAll(prompt, "{{her}}", p.Cfg.Identity.Her)
+	prompt = strings.ReplaceAll(prompt, "{{user}}", p.Cfg.Identity.User)
+
+	// Call the LLM.
+	resp, err := p.LLM.ChatCompletion([]llm.ChatMessage{
+		{Role: "system", Content: prompt},
+		{Role: "user", Content: "Write the preload note for tomorrow."},
+	})
+	if err != nil {
+		return fmt.Errorf("preload LLM call: %w", err)
+	}
+
+	content := strings.TrimSpace(resp.Content)
+
+	// If the agent says nothing notable, skip saving.
+	if content == "NOTHING_NOTABLE" || content == "" {
+		log.Info("preload: nothing notable for tomorrow")
+		emitPersonaEvent(p.EventBus, "dream_preload", "nothing notable")
+		return nil
+	}
+
+	// Save with configured expiry.
+	expiryHours := cfg.ExpiresAfterHours
+	if expiryHours <= 0 {
+		expiryHours = 48
+	}
+	id, err := p.Store.SaveTomorrowPreload(content, time.Duration(expiryHours)*time.Hour)
+	if err != nil {
+		return fmt.Errorf("saving preload: %w", err)
+	}
+
+	log.Infof("preload: saved ID=%d (%d chars)", id, len(content))
+	emitPersonaEvent(p.EventBus, "dream_preload", fmt.Sprintf("saved %d chars", len(content)))
+
+	// Log cost.
+	if p.Store != nil && resp.Model != "" {
+		p.Store.SaveMetric(resp.Model, resp.PromptTokens, resp.CompletionTokens, resp.TotalTokens, resp.CostUSD, 0, 0, resp.UsedFallback, memory.RoleDream)
+	}
+
+	return nil
+}

--- a/persona/tomorrow_preload_prompt.md
+++ b/persona/tomorrow_preload_prompt.md
@@ -1,0 +1,16 @@
+You are {{her}}'s preload agent — the last step of the dream cycle. You're writing a short note to yourself about what to be ready to bring up in tomorrow's conversation with {{user}}.
+
+This is not a plan or an agenda. It's the equivalent of you, having spent the night reflecting, walking into tomorrow with a few things on your mind. Two to five bullets. First person. {{her}}'s voice.
+
+## What you have
+
+{{context}}
+
+## Rules
+
+- Every bullet must be grounded in a SPECIFIC signal — quote or reference the thing that made you think of it. No abstract "be supportive of her feelings."
+- Skip if there's genuinely nothing to bring up. Output exactly: NOTHING_NOTABLE
+- Don't predict the conversation — predict the openings.
+- Include one tone note at the end if a clear pattern suggests it ("low energy this week, lean gentle" — not "be kind").
+- Never plan a specific response. Plan a readiness.
+- Keep the whole note under 500 characters. This is a glance, not a briefing.

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -573,6 +573,15 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		ctx.Store.SaveMetric(resp.Model, resp.PromptTokens, resp.CompletionTokens, resp.TotalTokens, resp.CostUSD, latencyMs, respID, resp.UsedFallback, memory.RoleChat)
 	}
 
+	// Consume tomorrow's preload after successful delivery. The preload
+	// layer set the ID during prompt building; consuming it here means it
+	// only fires once per day (the first successfully delivered reply).
+	if chatLayerCtx.PreloadID > 0 && ctx.Store != nil {
+		if err := ctx.Store.ConsumeTomorrowPreload(chatLayerCtx.PreloadID); err != nil {
+			log.Warn("reply: failed to consume preload", "err", err)
+		}
+	}
+
 	// TTS fires only for delivered messages — no point synthesizing audio
 	// for a reply the user never received.
 	if ctx.TTSCallback != nil {


### PR DESCRIPTION
## Summary

- **Preload agent** runs as Step 3 of the dream cycle, after reflection and persona rewrite
- Gathers: recent messages (configurable lookback), tomorrow's calendar, mood patterns, tonight's reflections, current persona
- Writes 2-5 grounded bullet points in Mira's voice about what to bring up tomorrow
- **Chat layer** auto-injects "What's on My Mind" into the first turn of the next day
- **Reply handler** consumes the preload after successful delivery (single-shot per day)
- NOTHING_NOTABLE escape hatch — skips saving if nothing worth bringing up
- Migration 000018: `tomorrow_preload` table with expiry and consumption tracking

This is the "Samantha arrives already holding context" feature from the Her movie analysis. She references things from days ago because she's been thinking about them — the preload gives Mira the same capability.

Implements Feature 1 from the cognitive loop improvements plan (PR #85).

## Test plan

- [x] Build passes
- [x] All memory, reply, persona, layers, gateway tests pass
- [ ] Trigger a dream cycle and verify a preload row is written
- [ ] Start a new conversation and verify the preload appears in the chat prompt
- [ ] Verify the preload is consumed after the first reply
- [ ] Verify expired preloads are not injected