### PR TITLE
feat: conservative forgetting — code-enforced guard + policy

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -168,6 +168,16 @@ dream:
   dry_run: false                      # true = log what would change without touching DB
   # enabled: true                     # master switch — omit or set true to enable
 
+  # Conservative forgetting: hard rules in code prevent the dreamer from
+  # removing protected, important, recent, or actively-used memories.
+  # Even when all conditions are met, removals are capped per cycle.
+  forgetting:
+    enabled: true
+    max_removes_per_cycle: 5          # hard ceiling per nightly dream
+    require_low_importance: 3         # only memories with importance <= this
+    min_age_days: 60                  # eligible only after 60 days
+    min_unused_days: 60               # eligible only if unused for 60 days
+
   # Tomorrow's preload: the dream cycle writes a short note about what
   # to bring up in the next conversation. Auto-injected into the first
   # chat turn of the day, then consumed.

--- a/config/config.go
+++ b/config/config.go
@@ -407,6 +407,9 @@ type DreamConfig struct {
 	// TomorrowPreload controls the forward-looking dream step that writes
 	// a short note about what to bring up in tomorrow's conversation.
 	TomorrowPreload TomorrowPreloadConfig `yaml:"tomorrow_preload"`
+	// Forgetting controls the conservative forgetting policy. Hard rules
+	// are enforced in code; soft rules live in the dreamer prompt.
+	Forgetting ForgettingConfig `yaml:"forgetting"`
 }
 
 // TomorrowPreloadConfig controls the preload agent that runs as the last
@@ -416,6 +419,17 @@ type TomorrowPreloadConfig struct {
 	ExpiresAfterHours   int  `yaml:"expires_after_hours"`    // how long the note stays active (default 48)
 	MaxBullets          int  `yaml:"max_bullets"`            // max bullet points (default 5)
 	HistoryLookbackDays int  `yaml:"history_lookback_days"`  // how many days of messages to scan (default 7)
+}
+
+// ForgettingConfig controls the conservative forgetting policy enforced
+// during the dream cycle. Hard rules are in code (canForget guard);
+// soft rules are in the dreamer prompt.
+type ForgettingConfig struct {
+	Enabled            bool `yaml:"enabled"`
+	MaxRemovesPerCycle int  `yaml:"max_removes_per_cycle"` // hard ceiling per dream (default 5)
+	RequireLowImportance int `yaml:"require_low_importance"` // only memories ≤ this are eligible (default 3)
+	MinAgeDays         int  `yaml:"min_age_days"`           // eligible only after this many days (default 60)
+	MinUnusedDays      int  `yaml:"min_unused_days"`        // eligible only if unused for this many days (default 60)
 }
 
 // DreamEnabled returns whether the memory dreamer is enabled.

--- a/memory/store.go
+++ b/memory/store.go
@@ -85,6 +85,7 @@ type Store interface {
 	CreateCard(topicSlug, name, subject string, sourceMessageID int64) (*MemoryCard, error)
 	ExpireCard(topicSlug, reason string) error
 	MergeCards(targetSlug, sourceSlug, mergedSummary, reason string) (*MemoryCard, error)
+	MemoryCardForMemory(memoryID int64) (*MemoryCard, error)
 	MemoriesByCard(cardID int64) ([]Memory, error)
 	RecentLogEntries(hours int) ([]MemoryLogEntry, error)
 	CardLogEntries(cardID int64, limit int) ([]MemoryLogEntry, error)

--- a/memory/store_cards.go
+++ b/memory/store_cards.go
@@ -387,6 +387,30 @@ func (s *SQLiteStore) CardLogEntries(cardID int64, limit int) ([]MemoryLogEntry,
 	return entries, rows.Err()
 }
 
+// MemoryCardForMemory looks up which card a memory belongs to. Returns nil
+// if the memory has no card_id or the card doesn't exist. Used by the
+// forgetting guard to check whether a memory is in a protected card.
+func (s *SQLiteStore) MemoryCardForMemory(memoryID int64) (*MemoryCard, error) {
+	var c MemoryCard
+	var updatedAt, summary sql.NullString
+	err := s.db.QueryRow(`
+		SELECT c.id, c.topic_slug, c.name, c.subject, c.summary, c.version, c.protected, c.updated_at
+		FROM memory_cards c
+		JOIN memories m ON m.card_id = c.id
+		WHERE m.id = ?`, memoryID,
+	).Scan(&c.ID, &c.TopicSlug, &c.Name, &c.Subject, &summary, &c.Version, &c.Protected, &updatedAt)
+	if err != nil {
+		return nil, nil // no card — not an error
+	}
+	if summary.Valid {
+		c.Summary = summary.String
+	}
+	if updatedAt.Valid {
+		c.UpdatedAt = parseTimestamp(updatedAt.String)
+	}
+	return &c, nil
+}
+
 // MemoriesByCard returns all active memories belonging to a specific card,
 // ordered by most recent first. Used by the dream cycle to see a card's
 // children, and by recall_memories for card-scoped search.

--- a/persona/memory_dreamer_prompt.md
+++ b/persona/memory_dreamer_prompt.md
@@ -37,11 +37,28 @@ Your transcript contains:
 
 Write summaries as a dense, timeless overview. 2-4 sentences that capture the essence of what's in the folder. Don't list every memory — distill.
 
-### REMOVE MEMORY when:
-- An individual memory is stale (situation resolved, information outdated)
-- A memory is redundant with another memory in the same card
+### REMOVE MEMORY when ALL of these are true:
+1. The memory is in an unprotected card (or has no card)
+2. The memory's importance is 3 or lower
+3. The memory hasn't been recalled in 60+ days
+4. The memory describes a specific past situation that's resolved ("had a Cava close shift on May 14") rather than a durable pattern ("works at Cava")
+5. Removing it would not break a supersession chain
+6. You haven't already removed 5 memories this dream cycle
+
+If any of these fail, leave it alone. The system enforces rules 1-3, 5, and 6 in code — you'll get an error if you try to remove something protected. Rule 4 is on you.
+
+### NEVER REMOVE:
+- Anything from protected cards (identity, health, financial, family, relationships, work, interests, projects, routines, my-identity, my-emotions, my-communication, my-relationship, my-growth)
+- The head of a supersession chain (the current "active" version of an evolving fact)
+- Anything with importance 7 or higher
+- Anything saved or recalled in the last 30 days
+- Memories that describe relationship dynamics or recurring patterns — even if specific examples feel stale
+
+When in doubt: KEEP. Forgetting who someone is would be far worse than holding onto a few stale details.
+
+### ALSO REMOVE when (these bypass the age/importance rules):
 - A memory is a technique log ("I used X metaphor") that slipped past the classifier
-- A memory is a mood snapshot or ephemeral daily detail
+- A memory is clearly fictional or incorrect (the system will still enforce the protected card rule)
 
 ### MERGE MEMORIES when:
 - Two memories in the same card say essentially the same thing from different angles

--- a/tools/forget_guard.go
+++ b/tools/forget_guard.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"fmt"
+	"time"
+
+	"her/config"
+	"her/memory"
+)
+
+// CanForget checks whether a memory is eligible for removal by the dream
+// agent. Returns (true, "") if removal is allowed, or (false, reason) if
+// the memory is protected. These are hard rules enforced in code — the
+// dreamer prompt has matching soft rules, but even if the LLM ignores
+// the prompt, the code guard catches it.
+//
+// Only applies when the caller is the dream agent (ctx.AgentName == "dream").
+// The memory agent responding to user requests ("forget that") bypasses
+// these checks — users can always delete their own data.
+func CanForget(m *memory.Memory, store memory.Store, cfg config.ForgettingConfig) (bool, string) {
+	// Protected cards: never forget anything inside them.
+	if reason := isInProtectedCard(m.ID, store); reason != "" {
+		return false, reason
+	}
+
+	// Importance floor: anything above the threshold stays unless
+	// explicitly superseded (which goes through SupersedeMemory, not
+	// remove_memory).
+	maxImportance := cfg.RequireLowImportance
+	if maxImportance <= 0 {
+		maxImportance = 3
+	}
+	if m.Importance > maxImportance {
+		return false, fmt.Sprintf("importance %d > %d", m.Importance, maxImportance)
+	}
+
+	// Head of supersession chain: don't orphan predecessors.
+	if hasSupersessionPredecessors(m.ID, store) {
+		return false, "head of supersession chain"
+	}
+
+	// Age floor: anything saved recently stays.
+	minAge := cfg.MinAgeDays
+	if minAge <= 0 {
+		minAge = 60
+	}
+	if time.Since(m.Timestamp) < time.Duration(minAge)*24*time.Hour {
+		return false, fmt.Sprintf("saved %d days ago (min %d)", int(time.Since(m.Timestamp).Hours()/24), minAge)
+	}
+
+	// Usage recency: anything recalled recently stays.
+	minUnused := cfg.MinUnusedDays
+	if minUnused <= 0 {
+		minUnused = 60
+	}
+	if !m.LastRecalledAt.IsZero() && time.Since(m.LastRecalledAt) < time.Duration(minUnused)*24*time.Hour {
+		return false, fmt.Sprintf("recalled %d days ago (min unused %d)", int(time.Since(m.LastRecalledAt).Hours()/24), minUnused)
+	}
+
+	return true, ""
+}
+
+// isInProtectedCard checks whether a memory belongs to a protected card.
+// Uses a direct SQL join via MemoryCardForMemory — one query, no iteration.
+func isInProtectedCard(memoryID int64, store memory.Store) string {
+	card, err := store.MemoryCardForMemory(memoryID)
+	if err != nil || card == nil {
+		return "" // no card or error — not protected
+	}
+	if card.Protected {
+		return fmt.Sprintf("card %q is protected", card.TopicSlug)
+	}
+	return ""
+}
+
+// hasSupersessionPredecessors checks if any other memory points to this
+// one via superseded_by — meaning this memory is the "current" version
+// in a chain. Removing it would orphan the history.
+func hasSupersessionPredecessors(memoryID int64, store memory.Store) bool {
+	history, err := store.MemoryHistory(memoryID)
+	if err != nil {
+		return false
+	}
+	return len(history) > 1
+}

--- a/tools/remove_memory/handler.go
+++ b/tools/remove_memory/handler.go
@@ -36,11 +36,36 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		return fmt.Sprintf("error parsing arguments: %v", err)
 	}
 
+	// Conservative forgetting guard — only applies to the dream agent.
+	// The memory agent handling user requests can remove anything.
+	isDream := ctx.AgentName == "dream"
+	checkForget := func(id int64) string {
+		if !isDream || ctx.Cfg == nil {
+			return ""
+		}
+		if !ctx.Cfg.Dream.Forgetting.Enabled {
+			return ""
+		}
+		mem, err := ctx.Store.GetMemory(id)
+		if err != nil || mem == nil {
+			return ""
+		}
+		ok, reason := tools.CanForget(mem, ctx.Store, ctx.Cfg.Dream.Forgetting)
+		if !ok {
+			return fmt.Sprintf("refused: memory ID=%d cannot be forgotten (%s). Leave it alone.", id, reason)
+		}
+		return ""
+	}
+
 	// Batch mode: deactivate multiple memories at once.
 	if len(args.MemoryIDs) > 0 {
 		var removed int
 		var errors []string
 		for _, id := range args.MemoryIDs {
+			if refusal := checkForget(id); refusal != "" {
+				errors = append(errors, fmt.Sprintf("ID=%d: %s", id, refusal))
+				continue
+			}
 			if err := ctx.Store.DeactivateMemory(id); err != nil {
 				errors = append(errors, fmt.Sprintf("ID=%d: %v", id, err))
 				continue
@@ -60,8 +85,14 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		return "error: provide either memory_id (single) or memory_ids (batch)"
 	}
 
+	// Check forgetting guard for single mode.
+	if refusal := checkForget(args.MemoryID); refusal != "" {
+		return refusal
+	}
+
 	// If replaced_by is set, use SupersedeMemory to record the chain.
-	// Otherwise, plain DeactivateMemory (same behavior as before).
+	// Supersession bypasses the forgetting guard — replacing a memory
+	// with a newer version is not forgetting, it's updating.
 	if args.ReplacedBy > 0 {
 		if err := ctx.Store.SupersedeMemory(args.MemoryID, args.ReplacedBy, args.Reason); err != nil {
 			return fmt.Sprintf("error superseding memory: %v", err)


### PR DESCRIPTION
## Summary

- **`CanForget()` guard** enforces hard rules in code that the dreamer LLM cannot override
- **Protected cards**: identity, health, relationships, etc. — memories inside them can never be autonomously removed
- **Importance floor**: only memories scored ≤3 are eligible
- **Age/usage floor**: must be 60+ days old AND unused for 60+ days
- **Supersession chains**: can't remove the head of a chain (would orphan history)
- **Dreamer prompt** updated with matching REMOVE/NEVER REMOVE policy
- **`MemoryCardForMemory()`** new store method for efficient protected-card lookup
- Only applies to dream agent — user-requested deletions via the memory agent bypass the guard

Defense in depth: the prompt tells the dreamer what not to remove, and the code catches it if the LLM ignores the prompt. Continuity over completeness — a slow drift, not a sweep.

Implements Feature 3 from the cognitive loop improvements plan (PR #85).

## Test plan

- [x] Build passes
- [x] All memory, remove_memory, persona, gateway tests pass
- [ ] Run a dream cycle with dry_run=true and verify the audit log shows refused removals
- [ ] Attempt to remove a memory in a protected card via dream agent — verify refusal
- [ ] After 30 days: verify `forgetting.refused > forgetting.removed` (policy biased toward keeping)