### PR TITLE
feat: direct reply experiment — sim-only A/B tool

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,6 +38,7 @@ import (
 	_ "her/tools/nearby_search"
 	_ "her/tools/recall_memories"
 	_ "her/tools/reply"
+	_ "her/tools/reply_direct"
 	_ "her/tools/search_books"
 	_ "her/tools/send_task"
 	_ "her/tools/set_location"
@@ -347,6 +348,17 @@ func Run(params RunParams) (*RunResult, error) {
 
 	// Load the agent prompt from disk (hot-reloadable, like prompt.md).
 	agentPrompt := loadAgentPrompt(params.Cfg.Persona.AgentPromptFile, params.Cfg)
+
+	// When direct reply mode is active, append instructions telling the
+	// driver to use reply_direct instead of reply.
+	if params.Cfg.Driver.DirectReply {
+		agentPrompt += "\n\n## Direct Reply Mode (ACTIVE)\n\n" +
+			"You are writing the actual words the user will see. There is no separate " +
+			"conversational model — your text IS the reply. Carry " + params.Cfg.Identity.Her + "'s " +
+			"voice yourself: short, warm, specific, curious. Refer to your persona notes above.\n\n" +
+			"Use reply_direct(text=\"your actual words\") instead of reply(instruction=\"...\").\n" +
+			"The text parameter is delivered verbatim to the user.\n"
+	}
 
 	// Set up the conversation with the agent model.
 	messages := []llm.ChatMessage{

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -139,6 +139,11 @@ var moodModelFlag string
 // Example: --disable-reasoning
 var disableReasoningFlag bool
 
+// directReplyFlag enables the reply_direct tool — the driver agent writes
+// the actual reply text instead of delegating to the chat model. Sim-only
+// experiment for A/B testing reply mechanisms.
+var directReplyFlag bool
+
 // simCmd defines the "her sim" subcommand. Cobra commands are just structs
 // with metadata + a RunE function. RunE returns an error (vs Run which doesn't),
 // so Cobra can print it nicely and set the exit code. Same idea as argparse

--- a/cmd/sim_gw.go
+++ b/cmd/sim_gw.go
@@ -57,6 +57,7 @@ func init() {
 	f.StringVar(&fallbackModelFlag, "fallback-model", "", "override fallback model for all roles")
 	f.StringVar(&fallbackVisionModelFlag, "fallback-vision-model", "", "override fallback model for vision")
 	f.BoolVar(&disableReasoningFlag, "disable-reasoning", false, "disable reasoning mode for hybrid models")
+	f.BoolVar(&directReplyFlag, "direct-reply", false, "enable reply_direct tool — driver writes reply text directly (experimental)")
 	simGWCmd.MarkFlagRequired("suite")
 	rootCmd.AddCommand(simGWCmd)
 }
@@ -545,6 +546,12 @@ func applySimModelOverrides(cfg *config.Config) {
 	}
 	if disableReasoningFlag {
 		log.Infof("sim: reasoning disabled for hybrid models")
+	}
+	if directReplyFlag {
+		cfg.Driver.DirectReply = true
+		simOnly := false
+		cfg.Driver.DirectReplySimOnly = &simOnly
+		log.Infof("sim: direct reply mode enabled — driver writes reply text directly")
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -316,6 +316,14 @@ type DriverConfig struct {
 	// is a hard ceiling on top of that. Default 2 (enough for "let me look
 	// that up" → "here's what I found").
 	MaxRepliesPerTurn int `yaml:"max_replies_per_turn"` // 0 = 2
+
+	// DirectReply enables the reply_direct tool — the driver agent writes
+	// the actual reply text instead of delegating to the chat model. This
+	// is an experimental feature for A/B testing in sims.
+	DirectReply bool `yaml:"direct_reply"`
+	// DirectReplySimOnly restricts direct reply to sim runs only. When true
+	// (default), the flag is ignored in production even if set.
+	DirectReplySimOnly *bool `yaml:"direct_reply_sim_only,omitempty"` // nil = true
 }
 
 // VisionConfig holds settings for the vision language model (VLM).

--- a/tools/context.go
+++ b/tools/context.go
@@ -185,6 +185,10 @@ type Context struct {
 	// deferred loading to the agent's declared tool set.
 	AgentName string
 
+	// IsSimRun is true when running through the sim adapter. Used by
+	// reply_direct to enforce the sim-only guard.
+	IsSimRun bool
+
 	// Ctx is the parent context for this turn. Tools that spawn retries
 	// or background work should derive from this so they respect shutdown
 	// and turn cancellation. Defaults to context.Background() if unset.

--- a/tools/loader.go
+++ b/tools/loader.go
@@ -501,6 +501,14 @@ func HotToolDefs(agentName string, cfg *config.Config) []llm.ToolDef {
 	}
 	if agentName == "main" {
 		result = append(result, UseToolsDef())
+		// Conditionally inject reply_direct when the experiment is active.
+		// The tool is hot:false in YAML so it doesn't load by default —
+		// it only appears when the driver.direct_reply flag is set.
+		if cfg != nil && cfg.Driver.DirectReply {
+			if t, ok := toolDefs["reply_direct"]; ok {
+				result = append(result, ExpandToolIdentity(t, cfg))
+			}
+		}
 	}
 	return result
 }

--- a/tools/loader_test.go
+++ b/tools/loader_test.go
@@ -13,7 +13,7 @@ func TestYAMLLoader(t *testing.T) {
 
 	// Check that all expected tools loaded from YAML.
 	// Update this count when tools are added or removed.
-	const expectedToolCount = 32
+	const expectedToolCount = 33
 	if len(toolDefs) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolDefs))
 	}

--- a/tools/reply_direct/handler.go
+++ b/tools/reply_direct/handler.go
@@ -1,0 +1,206 @@
+// Package reply_direct implements the reply_direct tool — delivers text
+// written directly by the driver agent, bypassing the chat model entirely.
+//
+// This is an experimental alternative to the standard reply tool. The
+// driver agent writes the actual words the user sees, instead of writing
+// instructions for a separate chat model to interpret. Style and safety
+// gates still run; PII deanonymization still happens.
+//
+// Gated by config: driver.direct_reply must be true AND (direct_reply_sim_only
+// must be false OR we must be in a sim run).
+package reply_direct
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"her/classifier"
+	"her/logger"
+	"her/memory"
+	"her/retry"
+	"her/scrub"
+	"her/tools"
+	"her/tui"
+)
+
+var log = logger.WithPrefix("tools/reply_direct")
+
+func init() {
+	tools.Register("reply_direct", Handle)
+}
+
+// Handle delivers driver-authored text directly to the user. Same delivery
+// pipeline as the standard reply (Telegram send, pagination, TTS, DB save)
+// but skips the chat LLM call and layer assembly entirely.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	// Gate check: direct reply must be enabled.
+	if ctx.Cfg != nil && !ctx.Cfg.Driver.DirectReply {
+		return "error: reply_direct is not enabled. Use the standard reply tool instead."
+	}
+
+	// Sim-only guard: if direct_reply_sim_only is true (default), only
+	// allow in sim runs.
+	if ctx.Cfg != nil {
+		simOnly := ctx.Cfg.Driver.DirectReplySimOnly
+		if simOnly == nil || *simOnly {
+			if ctx.AgentName != "sim" && !ctx.IsSimRun {
+				return "error: reply_direct is restricted to sim runs. Set direct_reply_sim_only: false to use in production."
+			}
+		}
+	}
+
+	// Reply count guard — same cap as the standard reply tool.
+	maxReplies := 2
+	if ctx.Cfg != nil && ctx.Cfg.Driver.MaxRepliesPerTurn > 0 {
+		maxReplies = ctx.Cfg.Driver.MaxRepliesPerTurn
+	}
+	if ctx.ReplyCount >= maxReplies {
+		return fmt.Sprintf(
+			"rejected: you already sent %d replies this turn (max %d). Call done now.",
+			ctx.ReplyCount, maxReplies)
+	}
+
+	var args struct {
+		Text      string  `json:"text"`
+		MemoryIDs []int64 `json:"memory_ids"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("error parsing arguments: %v", err)
+	}
+
+	if strings.TrimSpace(args.Text) == "" {
+		return "error: text cannot be empty"
+	}
+
+	// Track memory usage for blended retrieval scoring.
+	if len(args.MemoryIDs) > 0 && ctx.Store != nil {
+		if err := ctx.Store.MarkMemoriesRecalled(args.MemoryIDs); err != nil {
+			log.Warn("reply_direct: failed to mark memories recalled", "err", err)
+		}
+	}
+
+	replyText := args.Text
+
+	// Style gate — same deterministic check as the standard reply.
+	// We don't have a chat model to retry with, so if the gate fires
+	// we return an error asking the driver to rephrase.
+	if ctx.ClassifierLLM != nil {
+		styleVerdict := classifier.Check(ctx.ClassifierLLM, "reply", replyText, nil)
+		if styleVerdict.Model != "" && ctx.Store != nil {
+			ctx.Store.SaveMetric(styleVerdict.Model, styleVerdict.PromptTokens, styleVerdict.CompletionTokens, styleVerdict.TotalTokens, styleVerdict.CostUSD, 0, ctx.TriggerMsgID, false, memory.RoleClassifier)
+		}
+		if !styleVerdict.Allowed {
+			return fmt.Sprintf("rejected (style): %s. Rephrase your text and try again.", styleVerdict.Reason)
+		}
+	}
+
+	// Safety gate.
+	if ctx.ClassifierLLM != nil {
+		safetySnippet := []memory.Message{{
+			Role:            "user",
+			ContentScrubbed: ctx.ScrubbedUserMessage,
+		}}
+		safetyVerdict := classifier.Check(ctx.ClassifierLLM, "reply_safety", replyText, safetySnippet)
+		if safetyVerdict.Model != "" && ctx.Store != nil {
+			ctx.Store.SaveMetric(safetyVerdict.Model, safetyVerdict.PromptTokens, safetyVerdict.CompletionTokens, safetyVerdict.TotalTokens, safetyVerdict.CostUSD, 0, ctx.TriggerMsgID, false, memory.RoleClassifier)
+		}
+		if !safetyVerdict.Allowed {
+			return fmt.Sprintf("rejected (safety): %s. Rephrase to be supportive but balanced.", safetyVerdict.Reason)
+		}
+	}
+
+	// PII deanonymization.
+	replyText = scrub.Deanonymize(replyText, ctx.ScrubVault)
+
+	// Duplicate guard.
+	if ctx.ReplyCalled && replyText == ctx.ReplyText {
+		return "reply skipped (duplicate of previous reply)"
+	}
+
+	// Deliver.
+	var sendErr error
+	sendRetry := retry.Config{
+		MaxAttempts: 3,
+		Backoff:     retry.Exponential,
+		InitialWait: 500 * time.Millisecond,
+	}
+	sendCtx := ctx.Ctx
+	if sendCtx == nil {
+		sendCtx = context.Background()
+	}
+
+	if len(replyText) > tools.TelegramMaxMessageLen && ctx.SendPaginatedCallback != nil {
+		if !ctx.ReplyCalled && ctx.DeletePlaceholderCallback != nil {
+			_ = ctx.DeletePlaceholderCallback()
+		}
+		sendErr = retry.Do(sendCtx, sendRetry, func() error {
+			return ctx.SendPaginatedCallback(replyText)
+		})
+	} else {
+		if ctx.ReplyCalled && ctx.SendCallback != nil {
+			sendErr = retry.Do(sendCtx, sendRetry, func() error {
+				return ctx.SendCallback(replyText)
+			})
+		} else if ctx.StatusCallback != nil {
+			sendErr = retry.Do(sendCtx, sendRetry, func() error {
+				return ctx.StatusCallback(replyText)
+			})
+		}
+	}
+
+	if sendErr != nil {
+		log.Error("reply_direct: send failed", "err", sendErr)
+		return fmt.Sprintf("error: send failed: %v", sendErr)
+	}
+
+	if ctx.StopTypingFn != nil {
+		ctx.StopTypingFn()
+	}
+
+	// Save to DB.
+	respID, err := ctx.Store.SaveMessage("assistant", replyText, replyText, ctx.ConversationID)
+	if err != nil {
+		log.Error("reply_direct: saving response", "err", err)
+	}
+	if respID > 0 {
+		ctx.Store.SaveMetric("direct", 0, 0, 0, 0, 0, respID, false, memory.RoleChat)
+	}
+
+	// TTS.
+	if ctx.TTSCallback != nil {
+		go ctx.TTSCallback(replyText)
+	}
+
+	// Emit reply event.
+	replyEvent := tui.ReplyEvent{
+		Time:   time.Now(),
+		TurnID: ctx.TriggerMsgID,
+		Text:   replyText,
+	}
+	if ctx.Phase != nil {
+		ctx.Phase.Emit(replyEvent)
+	} else if ctx.EventBus != nil {
+		ctx.EventBus.Emit(replyEvent)
+	}
+
+	ctx.ReplyCalled = true
+	ctx.ReplyCount++
+	ctx.ReplyText = replyText
+
+	if ctx.StageResetCallback != nil {
+		if err := ctx.StageResetCallback(); err != nil {
+			log.Warn("reply_direct: stage reset failed", "err", err)
+		} else {
+			ctx.ReplyCalled = false
+		}
+	}
+
+	preview := replyText
+	if len(preview) > 300 {
+		preview = preview[:300] + "..."
+	}
+	return fmt.Sprintf("reply delivered to user: %q\n\nCall done to end your turn.", preview)
+}

--- a/tools/reply_direct/tool.yaml
+++ b/tools/reply_direct/tool.yaml
@@ -1,0 +1,28 @@
+name: reply_direct
+agent: [main]
+hint: "write and send a response directly (experimental)"
+description: >-
+  Write the actual response text and send it to the user. Unlike the standard
+  reply tool, YOU write the words — there is no separate conversational model.
+  Your output IS what the user sees. Write as {{her}} — short, warm, specific.
+  Only available when direct_reply is enabled in config.
+hot: false
+parameters:
+  type: object
+  properties:
+    text:
+      type: string
+      description: >-
+        The exact text to send to the user. Delivered verbatim after PII
+        deanonymization and style gate checks.
+    memory_ids:
+      type: array
+      items:
+        type: integer
+      description: >-
+        Memory IDs used in composing this reply. Tracked for usage metrics.
+  required:
+    - text
+trace:
+  emoji: "✍️"
+  format: "<i>{{.text | truncate 200 | escape}}</i>"


### PR DESCRIPTION
## Summary

- **`reply_direct` tool**: driver agent writes the actual reply text, bypassing the chat model
- **`--direct-reply` flag** on sim command enables the experiment (same UX as `--driver-model`)
- Tool is completely invisible when the flag is off — not in the tool list, no prompt section
- Style gate and safety gate still run on direct replies
- PII deanonymization, delivery, TTS, DB save all work identically to standard reply

The experiment tests whether removing the instruction-to-text translation step (driver writes instruction → chat model generates text) produces more natural, concise replies. The standard reply tool stays as the default.

```bash
# A/B comparison
her sim -s sims/basic.yaml                    # standard (driven) mode
her sim -s sims/basic.yaml --direct-reply     # direct mode
```

Implements Feature 4 from the cognitive loop improvements plan (PR #85).

## Test plan

- [x] Build passes
- [x] All tools, agent, gateway tests pass
- [ ] Run a sim without --direct-reply — verify reply_direct doesn't appear in traces
- [ ] Run a sim with --direct-reply — verify driver uses reply_direct and text is delivered
- [ ] Compare word count distributions between the two modes