### PR TITLE
fix: address audit findings across PRs #90-#94

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -350,15 +350,14 @@ func Run(params RunParams) (*RunResult, error) {
 	// Load the agent prompt from disk (hot-reloadable, like prompt.md).
 	agentPrompt := loadAgentPrompt(params.Cfg.Persona.AgentPromptFile, params.Cfg)
 
-	// When direct reply mode is active, append instructions telling the
-	// driver to use reply_direct instead of reply.
+	// When direct reply mode is active, append the direct reply prompt
+	// section from disk. Follows data primacy: prompt text in .md, not Go.
 	if params.Cfg.Driver.DirectReply {
-		agentPrompt += "\n\n## Direct Reply Mode (ACTIVE)\n\n" +
-			"You are writing the actual words the user will see. There is no separate " +
-			"conversational model — your text IS the reply. Carry " + params.Cfg.Identity.Her + "'s " +
-			"voice yourself: short, warm, specific, curious. Refer to your persona notes above.\n\n" +
-			"Use reply_direct(text=\"your actual words\") instead of reply(instruction=\"...\").\n" +
-			"The text parameter is delivered verbatim to the user.\n"
+		if drp, err := os.ReadFile("direct_reply_prompt.md"); err == nil {
+			agentPrompt += "\n\n" + params.Cfg.ExpandPrompt(string(drp))
+		} else {
+			log.Warn("direct reply enabled but prompt file missing", "err", err)
+		}
 	}
 
 	// Set up the conversation with the agent model.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -163,6 +163,7 @@ type RunParams struct {
 	AgentEventCB              tools.AgentEventCallback    // nil-safe — fires when memory agent calls notify_agent
 	Tracker                   *turn.Tracker               // nil-safe — manages turn lifecycle, typing, sub-agent coordination
 	IntrospectionWG           *sync.WaitGroup             // nil-safe — signaled when memory goroutine finishes, introspection waits on this
+	IsSimRun                  bool                        // true when running via the sim adapter
 }
 
 // RunResult holds the outcome of an agent run — the reply text plus
@@ -405,6 +406,7 @@ func Run(params RunParams) (*RunResult, error) {
 		ActiveTools:               &toolDefs,
 		EventBus:                  params.EventBus,
 		ConfigPath:                params.ConfigPath,
+		IsSimRun:                  params.IsSimRun,
 		PreApprovedRewrites:       make(map[string]bool),
 	}
 

--- a/bot/helpers_test.go
+++ b/bot/helpers_test.go
@@ -237,6 +237,15 @@ func (s stubStore) CardLogEntries(cardID int64, limit int) ([]memory.MemoryLogEn
 func (s stubStore) SemanticSearchByCard(queryVec []float32, cardID int64, topK int) ([]memory.Memory, error) {
 	return nil, nil
 }
+func (s stubStore) MarkMemoriesRecalled(ids []int64) error { return nil }
+func (s stubStore) MemoryCardForMemory(memoryID int64) (*memory.MemoryCard, error) {
+	return nil, nil
+}
+func (s stubStore) SaveTomorrowPreload(content string, expiresAfter time.Duration) (int64, error) {
+	return 0, nil
+}
+func (s stubStore) ActiveTomorrowPreload() (*memory.TomorrowPreload, error) { return nil, nil }
+func (s stubStore) ConsumeTomorrowPreload(id int64) error                   { return nil }
 func (s stubStore) SemanticSearchBySubject(queryVec []float32, subject string, topK int) ([]memory.Memory, error) {
 	return nil, nil
 }

--- a/bot/run_agent.go
+++ b/bot/run_agent.go
@@ -204,6 +204,7 @@ func (b *Bot) runAgent(fe Frontend, input AgentInput) error {
 	params.ImageBase64 = input.ImageBase64
 	params.ImageMIME = input.ImageMIME
 	params.OCRText = input.OCRText
+	params.IsSimRun = b.isSimRun
 
 	b.agentBusy.Store(true)
 	result, err := agent.Run(params)

--- a/bot/telegram.go
+++ b/bot/telegram.go
@@ -54,6 +54,7 @@ type Bot struct {
 	configPath       string // path to config.yaml — needed for /traces toggle
 	systemPrompt     string
 	startTime        time.Time
+	isSimRun         bool   // true when running via the sim adapter
 
 	// moodRunner + moodSweeper are the post-turn mood pipeline. Nil
 	// when cfg.MoodAgent.Model is empty. runAgent launches a
@@ -338,6 +339,10 @@ func NewDev(cfg *config.Config, configPath string, llmClient *llm.Client, driver
 func (b *Bot) SetCalendarBridge(bridge calendar.Bridge) {
 	b.calendarBridge = bridge
 }
+
+// SetSimRun marks this bot as running in sim mode. Used by the gateway
+// sim adapter so reply_direct's sim-only guard can verify context.
+func (b *Bot) SetSimRun(v bool) { b.isSimRun = v }
 
 // ProcessMessage runs a user message through the full agent pipeline
 // using the given Frontend for I/O. This is the transport-agnostic

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -145,13 +145,7 @@ func runBot(cmd *cobra.Command, args []string) error {
 	store.AutoLinkCount = cfg.Memory.AutoLinkCount
 	store.AutoLinkThreshold = cfg.Memory.AutoLinkThreshold
 
-	// Blended retrieval weights — see config.RecallConfig for the formula.
-	rc := cfg.Memory.Recall.WithDefaults()
-	store.RecallSimilarityWeight = rc.SimilarityWeight
-	store.RecallImportanceWeight = rc.ImportanceWeight
-	store.RecallRecencyWeight = rc.RecencyWeight
-	store.RecallRecencyHalfLifeDays = rc.RecencyHalfLifeDays
-	store.RecallUsageBoostFactor = rc.UsageBoostFactor
+	store.ApplyRecallConfig(cfg.Memory.Recall)
 
 	// If D1 sync is configured, wrap SQLiteStore in SyncedStore for
 	// bidirectional sync with Cloudflare D1. Writes push to D1 in the

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -692,12 +692,7 @@ func runSim(cmd *cobra.Command, args []string) error {
 	defer store.Close()
 	store.AutoLinkCount = cfg.Memory.AutoLinkCount
 	store.AutoLinkThreshold = cfg.Memory.AutoLinkThreshold
-	rc := cfg.Memory.Recall.WithDefaults()
-	store.RecallSimilarityWeight = rc.SimilarityWeight
-	store.RecallImportanceWeight = rc.ImportanceWeight
-	store.RecallRecencyWeight = rc.RecencyWeight
-	store.RecallRecencyHalfLifeDays = rc.RecencyHalfLifeDays
-	store.RecallUsageBoostFactor = rc.UsageBoostFactor
+	store.ApplyRecallConfig(cfg.Memory.Recall)
 
 	// ------------------------------------------------------------------
 	// 5. Create LLM + embed + search clients (same pattern as run.go)

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -241,12 +241,12 @@ func (m *seedMemory) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Stored in both the DB (SQLite source of truth) and FakeBridge (for EventKit simulation).
 // Can represent any calendar event — meetings, shifts, appointments, etc.
 type SeedCalendarEvent struct {
-	ID       string `yaml:"id"`       // EventKit-style identifier (e.g., "SEED-001")
-	Title    string `yaml:"title"`    // Event title
-	Start    string `yaml:"start"`    // ISO8601 with timezone
-	End      string `yaml:"end"`      // ISO8601 with timezone
+	ID       string `yaml:"id"`    // EventKit-style identifier (e.g., "SEED-001")
+	Title    string `yaml:"title"` // Event title
+	Start    string `yaml:"start"` // ISO8601 with timezone
+	End      string `yaml:"end"`   // ISO8601 with timezone
 	Location string `yaml:"location,omitempty"`
-	Notes    string `yaml:"notes,omitempty"` // Can include shift metadata like "position: Bake\ntrainer: Mike\n..."
+	Notes    string `yaml:"notes,omitempty"`    // Can include shift metadata like "position: Bake\ntrainer: Mike\n..."
 	Calendar string `yaml:"calendar,omitempty"` // defaults to config.Calendar.DefaultCalendar
 	Job      string `yaml:"job,omitempty"`      // Job name (e.g., "Panera") — marks this as a shift event
 }
@@ -317,18 +317,18 @@ func (m simMessage) DisplayText() string {
 // inside a function are scoped to that function — they can't be used as
 // parameters elsewhere.
 type simTurnResult struct {
-	userMsg                string
-	botReply               string
-	followUpReply          string // from EventInboxReady — empty if no background task reported back
-	moodVerdict            string // per-turn mood agent outcome (logged/updated/dropped/dedup/error)
-	introspectionVerdict   string // per-turn introspection agent outcome (skip/save/update)
-	introspectionMemories  []string // actual self-memory texts saved this turn
-	memoryVerdict          string   // per-turn memory agent outcome (saved N facts, etc.)
-	memoriesSaved          []string // actual memory texts saved this turn
-	compactionSummary      string   // inline compaction summary (empty if no compaction this turn)
-	compactionMsgCount     int      // messages summarized by compaction
-	turnCost               float64  // total cost for this turn (all agents combined)
-	elapsed                time.Duration
+	userMsg               string
+	botReply              string
+	followUpReply         string   // from EventInboxReady — empty if no background task reported back
+	moodVerdict           string   // per-turn mood agent outcome (logged/updated/dropped/dedup/error)
+	introspectionVerdict  string   // per-turn introspection agent outcome (skip/save/update)
+	introspectionMemories []string // actual self-memory texts saved this turn
+	memoryVerdict         string   // per-turn memory agent outcome (saved N facts, etc.)
+	memoriesSaved         []string // actual memory texts saved this turn
+	compactionSummary     string   // inline compaction summary (empty if no compaction this turn)
+	compactionMsgCount    int      // messages summarized by compaction
+	turnCost              float64  // total cost for this turn (all agents combined)
+	elapsed               time.Duration
 }
 
 // simRollupResult captures the output of a forced daily mood rollup
@@ -337,16 +337,16 @@ type simTurnResult struct {
 // handler directly so we can verify the aggregation without waiting
 // for an actual day to pass.
 type simRollupResult struct {
-	Ran         bool
-	Skipped     bool   // true when the handler decided there was nothing to roll up
-	SkipReason  string // human-readable reason for Skipped
-	EntryID     int64
-	Valence     int
-	Labels      []string
+	Ran          bool
+	Skipped      bool   // true when the handler decided there was nothing to roll up
+	SkipReason   string // human-readable reason for Skipped
+	EntryID      int64
+	Valence      int
+	Labels       []string
 	Associations []string
-	Note        string
-	SummaryText string // what the bot would have sent to the owner chat
-	Error       string
+	Note         string
+	SummaryText  string // what the bot would have sent to the owner chat
+	Error        string
 }
 
 // simDreamResult captures the output of the dream cycle (run_dream: true)
@@ -396,8 +396,8 @@ func runDreamCycle(memoryAgentClient *llm.Client, classifierClient *llm.Client, 
 		log.Infof("[dream] %s — running memory consolidation", turnContext)
 		dreamerResult := persona.RunMemoryDreamer(persona.MemoryDreamerParams{
 			LLM:   memoryAgentClient,
-			Store:  store,
-			Cfg:    cfg,
+			Store: store,
+			Cfg:   cfg,
 		})
 		result.ConsolidationRewrites = dreamerResult.Rewrites
 		result.ConsolidationMerges = dreamerResult.Merges
@@ -1269,13 +1269,13 @@ func runSim(cmd *cobra.Command, args []string) error {
 
 		// Run the full agent pipeline — same call the Telegram bot makes.
 		result, err := agent.Run(agent.RunParams{
-			DriverLLM:            driverClient,
-			MemoryAgentLLM:       memoryAgentClient, // nil if not configured — memory agent skips
+			DriverLLM:           driverClient,
+			MemoryAgentLLM:      memoryAgentClient, // nil if not configured — memory agent skips
 			ChatLLM:             chatClient,
-			VisionLLM:           visionClient,      // nil if no vision model configured
-			ClassifierLLM:       classifierClient,   // nil if not configured, active if classifier section in config
-			ImageBase64:         imageBase64,         // empty if no image this turn
-			ImageMIME:           imageMIME,           // empty if no image this turn
+			VisionLLM:           visionClient,     // nil if no vision model configured
+			ClassifierLLM:       classifierClient, // nil if not configured, active if classifier section in config
+			ImageBase64:         imageBase64,      // empty if no image this turn
+			ImageMIME:           imageMIME,        // empty if no image this turn
 			Store:               store,
 			EmbedClient:         embedClient,
 			SimilarityThreshold: cfg.Embed.SimilarityThreshold,
@@ -1861,8 +1861,8 @@ func copyMoodEntries(tmpDB, simDB *sql.DB, runID int64) error {
 	for rows.Next() {
 		var (
 			ts, kind, labels, associations, note, source, convID string
-			valence                                               int
-			confidence                                            float64
+			valence                                              int
+			confidence                                           float64
 		)
 		if err := rows.Scan(&ts, &kind, &valence, &labels, &associations, &note,
 			&source, &confidence, &convID); err != nil {
@@ -2537,13 +2537,13 @@ func writeMemoriesSection(b *strings.Builder, simDB *sql.DB, runID int64) {
 	defer rows.Close()
 
 	type memoryRow struct {
-		id              int64
-		memory          string
-		category        sql.NullString
-		subject         string
-		importance      int
-		active          bool
-		superseded_by   sql.NullInt64
+		id               int64
+		memory           string
+		category         sql.NullString
+		subject          string
+		importance       int
+		active           bool
+		superseded_by    sql.NullInt64
 		supersede_reason sql.NullString
 	}
 	var memories []memoryRow
@@ -2758,8 +2758,8 @@ func writeMoodSection(b *strings.Builder, simDB *sql.DB, runID int64) {
 
 	type moodRow struct {
 		ts, kind, labels, associations, note, source string
-		valence                                       int
-		confidence                                    float64
+		valence                                      int
+		confidence                                   float64
 	}
 	var moods []moodRow
 	for rows.Next() {
@@ -2876,9 +2876,9 @@ func writeSummariesSection(b *strings.Builder, simDB *sql.DB, runID int64) {
 	defer rows.Close()
 
 	type summaryRow struct {
-		ts               string
-		summary          string
-		msgsSummarized   int
+		ts             string
+		summary        string
+		msgsSummarized int
 	}
 	var summaries []summaryRow
 	for rows.Next() {

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -184,7 +184,6 @@ dream:
   tomorrow_preload:
     enabled: true
     expires_after_hours: 48           # how long the note stays active
-    max_bullets: 5                    # max bullet points in the note
     history_lookback_days: 7          # how many days of messages to scan
 
 location:

--- a/config/config.go
+++ b/config/config.go
@@ -424,20 +424,19 @@ type DreamConfig struct {
 // step of the dream cycle.
 type TomorrowPreloadConfig struct {
 	Enabled             bool `yaml:"enabled"`
-	ExpiresAfterHours   int  `yaml:"expires_after_hours"`    // how long the note stays active (default 48)
-	MaxBullets          int  `yaml:"max_bullets"`            // max bullet points (default 5)
-	HistoryLookbackDays int  `yaml:"history_lookback_days"`  // how many days of messages to scan (default 7)
+	ExpiresAfterHours   int  `yaml:"expires_after_hours"`   // how long the note stays active (default 48)
+	HistoryLookbackDays int  `yaml:"history_lookback_days"` // how many days of messages to scan (default 7)
 }
 
 // ForgettingConfig controls the conservative forgetting policy enforced
 // during the dream cycle. Hard rules are in code (canForget guard);
 // soft rules are in the dreamer prompt.
 type ForgettingConfig struct {
-	Enabled            bool `yaml:"enabled"`
-	MaxRemovesPerCycle int  `yaml:"max_removes_per_cycle"` // hard ceiling per dream (default 5)
-	RequireLowImportance int `yaml:"require_low_importance"` // only memories ≤ this are eligible (default 3)
-	MinAgeDays         int  `yaml:"min_age_days"`           // eligible only after this many days (default 60)
-	MinUnusedDays      int  `yaml:"min_unused_days"`        // eligible only if unused for this many days (default 60)
+	Enabled              bool `yaml:"enabled"`
+	MaxRemovesPerCycle   int  `yaml:"max_removes_per_cycle"`  // hard ceiling per dream (default 5)
+	RequireLowImportance int  `yaml:"require_low_importance"` // only memories ≤ this are eligible (default 3)
+	MinAgeDays           int  `yaml:"min_age_days"`           // eligible only after this many days (default 60)
+	MinUnusedDays        int  `yaml:"min_unused_days"`        // eligible only if unused for this many days (default 60)
 }
 
 // DreamEnabled returns whether the memory dreamer is enabled.
@@ -558,11 +557,11 @@ type MemoryConfig struct {
 // weighted blend of similarity, importance, recency, and usage frequency.
 // Weights should sum to ~1.0 for interpretability but this isn't enforced.
 type RecallConfig struct {
-	SimilarityWeight    float64 `yaml:"similarity_weight"`     // cosine similarity contribution (default 0.60)
-	ImportanceWeight    float64 `yaml:"importance_weight"`     // importance score normalized 0-1 (default 0.25)
-	RecencyWeight       float64 `yaml:"recency_weight"`        // exponential decay on age (default 0.15)
+	SimilarityWeight    float64 `yaml:"similarity_weight"`      // cosine similarity contribution (default 0.60)
+	ImportanceWeight    float64 `yaml:"importance_weight"`      // importance score normalized 0-1 (default 0.25)
+	RecencyWeight       float64 `yaml:"recency_weight"`         // exponential decay on age (default 0.15)
 	RecencyHalfLifeDays int     `yaml:"recency_half_life_days"` // how fast recency decays (default 30)
-	UsageBoostFactor    float64 `yaml:"usage_boost_factor"`    // boost from recall_count with diminishing returns (default 0.10)
+	UsageBoostFactor    float64 `yaml:"usage_boost_factor"`     // boost from recall_count with diminishing returns (default 0.10)
 }
 
 // RecallDefaults returns a RecallConfig with sensible defaults when the

--- a/direct_reply_prompt.md
+++ b/direct_reply_prompt.md
@@ -1,0 +1,6 @@
+## Direct Reply Mode (ACTIVE)
+
+You are writing the actual words the user will see. There is no separate conversational model — your text IS the reply. Carry {{her}}'s voice yourself: short, warm, specific, curious. Refer to your persona notes above.
+
+Use reply_direct(text="your actual words") instead of reply(instruction="...").
+The text parameter is delivered verbatim to the user.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -148,6 +148,9 @@ func (g *Gateway) Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("creating pipeline for adapter %q: %w", acfg.Name, err)
 			}
+			if acfg.Type == "sim" {
+				pipeline.Engine().SetSimRun(true)
+			}
 		}
 
 		// Register commands: gateway-level first, then pipeline-derived.

--- a/memory/store.go
+++ b/memory/store.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"her/config"
+
 	// The underscore import is a Go idiom: it imports the package purely for
 	// its side effects (registering the SQLite driver with database/sql).
 	// The package's init() function runs at startup and calls sql.Register().
@@ -208,6 +210,17 @@ type SQLiteStore struct {
 	RecallRecencyWeight       float64
 	RecallRecencyHalfLifeDays int
 	RecallUsageBoostFactor    float64
+}
+
+// ApplyRecallConfig sets the blended retrieval weights from a RecallConfig.
+// Called from cmd/run.go and cmd/sim.go after store creation.
+func (s *SQLiteStore) ApplyRecallConfig(rc config.RecallConfig) {
+	rc = rc.WithDefaults()
+	s.RecallSimilarityWeight = rc.SimilarityWeight
+	s.RecallImportanceWeight = rc.ImportanceWeight
+	s.RecallRecencyWeight = rc.RecencyWeight
+	s.RecallRecencyHalfLifeDays = rc.RecencyHalfLifeDays
+	s.RecallUsageBoostFactor = rc.UsageBoostFactor
 }
 
 // NewStore opens (or creates) the SQLite database at the given path

--- a/memory/store_cards.go
+++ b/memory/store_cards.go
@@ -11,6 +11,7 @@ package memory
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -399,8 +400,11 @@ func (s *SQLiteStore) MemoryCardForMemory(memoryID int64) (*MemoryCard, error) {
 		JOIN memories m ON m.card_id = c.id
 		WHERE m.id = ?`, memoryID,
 	).Scan(&c.ID, &c.TopicSlug, &c.Name, &c.Subject, &summary, &c.Version, &c.Protected, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
 	if err != nil {
-		return nil, nil // no card — not an error
+		return nil, fmt.Errorf("MemoryCardForMemory(%d): %w", memoryID, err)
 	}
 	if summary.Valid {
 		c.Summary = summary.String

--- a/memory/store_facts.go
+++ b/memory/store_facts.go
@@ -542,12 +542,15 @@ func (s *SQLiteStore) GetMemory(memoryID int64) (*Memory, error) {
 	var supersededBy sql.NullInt64
 	var supersedeReason sql.NullString
 	var context sql.NullString
+	var lastRecalled sql.NullString
 	err := s.db.QueryRow(
 		`SELECT id, timestamp, memory, category, subject, importance, tags, active,
-		        superseded_by, supersede_reason, COALESCE(context, '')
+		        superseded_by, supersede_reason, COALESCE(context, ''),
+		        COALESCE(recall_count, 0), last_recalled_at
 		 FROM memories WHERE id = ?`, memoryID,
 	).Scan(&m.ID, &ts, &m.Content, &m.Category, &m.Subject, &m.Importance,
-		&m.Tags, &active, &supersededBy, &supersedeReason, &context)
+		&m.Tags, &active, &supersededBy, &supersedeReason, &context,
+		&m.RecallCount, &lastRecalled)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -556,6 +559,9 @@ func (s *SQLiteStore) GetMemory(memoryID int64) (*Memory, error) {
 	}
 	m.Timestamp = parseTimestamp(ts)
 	m.Active = active
+	if lastRecalled.Valid {
+		m.LastRecalledAt = parseTimestamp(lastRecalled.String)
+	}
 	if supersededBy.Valid {
 		m.SupersededBy = supersededBy.Int64
 	}

--- a/memory/store_facts.go
+++ b/memory/store_facts.go
@@ -820,7 +820,6 @@ func (s *SQLiteStore) SemanticSearch(queryVec []float32, topK int) ([]Memory, er
 		memories = append(memories, r.mem)
 	}
 
-
 	// Zettelkasten 1-hop traversal: for each primary KNN result, pull in
 	// linked neighbors that didn't directly match the query. This is the
 	// graph payoff — "what does she like to cook?" finds cooking memories via

--- a/memory/store_recall_test.go
+++ b/memory/store_recall_test.go
@@ -1,0 +1,62 @@
+package memory
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newRecallTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "recall_test.db")
+	store, err := NewStore(dbPath, 0)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestMarkMemoriesRecalled(t *testing.T) {
+	store := newRecallTestStore(t)
+
+	// Save two memories.
+	id1, err := store.SaveMemory("user likes tea", "preference", "user", 0, 5, nil, nil, "tea", "", 0)
+	if err != nil {
+		t.Fatalf("SaveMemory 1: %v", err)
+	}
+	id2, err := store.SaveMemory("user works at Cava", "work", "user", 0, 7, nil, nil, "work", "", 0)
+	if err != nil {
+		t.Fatalf("SaveMemory 2: %v", err)
+	}
+
+	// Mark both as recalled.
+	if err := store.MarkMemoriesRecalled([]int64{id1, id2}); err != nil {
+		t.Fatalf("MarkMemoriesRecalled: %v", err)
+	}
+
+	// Verify recall_count incremented.
+	m1, err := store.GetMemory(id1)
+	if err != nil || m1 == nil {
+		t.Fatalf("GetMemory(%d): %v", id1, err)
+	}
+	if m1.RecallCount != 1 {
+		t.Errorf("memory %d recall_count = %d, want 1", id1, m1.RecallCount)
+	}
+	if m1.LastRecalledAt.IsZero() {
+		t.Error("expected non-zero LastRecalledAt")
+	}
+
+	// Mark again — count should increment to 2.
+	if err := store.MarkMemoriesRecalled([]int64{id1}); err != nil {
+		t.Fatalf("MarkMemoriesRecalled second: %v", err)
+	}
+	m1, _ = store.GetMemory(id1)
+	if m1.RecallCount != 2 {
+		t.Errorf("memory %d recall_count = %d, want 2", id1, m1.RecallCount)
+	}
+
+	// Empty slice should be a no-op.
+	if err := store.MarkMemoriesRecalled(nil); err != nil {
+		t.Fatalf("MarkMemoriesRecalled nil: %v", err)
+	}
+}

--- a/memory/store_tomorrow_preload.go
+++ b/memory/store_tomorrow_preload.go
@@ -23,10 +23,10 @@ type TomorrowPreload struct {
 // SaveTomorrowPreload inserts a new preload note. expiresAfter controls
 // how long the note stays active before it's considered stale.
 func (s *SQLiteStore) SaveTomorrowPreload(content string, expiresAfter time.Duration) (int64, error) {
-	expiresAt := time.Now().Add(expiresAfter)
+	expiresAt := time.Now().UTC().Add(expiresAfter)
 	result, err := s.db.Exec(
 		`INSERT INTO tomorrow_preload (content, expires_at) VALUES (?, ?)`,
-		content, expiresAt.Format(time.RFC3339),
+		content, expiresAt.Format("2006-01-02 15:04:05"),
 	)
 	if err != nil {
 		return 0, err
@@ -43,7 +43,7 @@ func (s *SQLiteStore) ActiveTomorrowPreload() (*TomorrowPreload, error) {
 		`SELECT id, generated_at, expires_at, content
 		 FROM tomorrow_preload
 		 WHERE consumed = 0 AND expires_at > datetime('now')
-		 ORDER BY generated_at DESC
+		 ORDER BY id DESC
 		 LIMIT 1`,
 	).Scan(&p.ID, &generatedAt, &expiresAt, &p.Content)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/memory/store_tomorrow_preload.go
+++ b/memory/store_tomorrow_preload.go
@@ -1,6 +1,11 @@
 package memory
 
-import "time"
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
 
 // TomorrowPreload is a short note the dream cycle writes about what Mira
 // should be ready to bring up in the next conversation. Single-row pattern:
@@ -41,8 +46,11 @@ func (s *SQLiteStore) ActiveTomorrowPreload() (*TomorrowPreload, error) {
 		 ORDER BY generated_at DESC
 		 LIMIT 1`,
 	).Scan(&p.ID, &generatedAt, &expiresAt, &p.Content)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
 	if err != nil {
-		return nil, nil // no active preload — not an error
+		return nil, fmt.Errorf("querying active preload: %w", err)
 	}
 	p.GeneratedAt = parseTimestamp(generatedAt)
 	p.ExpiresAt = parseTimestamp(expiresAt)

--- a/memory/store_tomorrow_preload_test.go
+++ b/memory/store_tomorrow_preload_test.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newPreloadTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "preload_test.db")
+	store, err := NewStore(dbPath, 0)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestTomorrowPreloadLifecycle(t *testing.T) {
+	store := newPreloadTestStore(t)
+
+	// No active preload initially.
+	p, err := store.ActiveTomorrowPreload()
+	if err != nil {
+		t.Fatalf("ActiveTomorrowPreload: %v", err)
+	}
+	if p != nil {
+		t.Fatal("expected nil preload before any saves")
+	}
+
+	// Save a preload with 48h expiry.
+	id, err := store.SaveTomorrowPreload("- Check in about the interview\n- Mood has been low", 48*time.Hour)
+	if err != nil {
+		t.Fatalf("SaveTomorrowPreload: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+
+	// Should now be active.
+	p, err = store.ActiveTomorrowPreload()
+	if err != nil {
+		t.Fatalf("ActiveTomorrowPreload after save: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected active preload after save")
+	}
+	if p.ID != id {
+		t.Errorf("got ID %d, want %d", p.ID, id)
+	}
+	if p.Content == "" {
+		t.Error("expected non-empty content")
+	}
+
+	// Consume it.
+	if err := store.ConsumeTomorrowPreload(id); err != nil {
+		t.Fatalf("ConsumeTomorrowPreload: %v", err)
+	}
+
+	// Should no longer be active.
+	p, err = store.ActiveTomorrowPreload()
+	if err != nil {
+		t.Fatalf("ActiveTomorrowPreload after consume: %v", err)
+	}
+	if p != nil {
+		t.Fatal("expected nil preload after consumption")
+	}
+}
+
+func TestTomorrowPreloadExpiry(t *testing.T) {
+	store := newPreloadTestStore(t)
+
+	// Save with negative expiry — already expired.
+	_, err := store.SaveTomorrowPreload("this should be expired", -1*time.Hour)
+	if err != nil {
+		t.Fatalf("SaveTomorrowPreload: %v", err)
+	}
+
+	// Should not be active (expired).
+	p, err := store.ActiveTomorrowPreload()
+	if err != nil {
+		t.Fatalf("ActiveTomorrowPreload: %v", err)
+	}
+	if p != nil {
+		t.Fatal("expected nil preload for expired entry")
+	}
+}
+
+func TestTomorrowPreloadLatestWins(t *testing.T) {
+	store := newPreloadTestStore(t)
+
+	// Save two preloads — the most recent should be returned.
+	_, err := store.SaveTomorrowPreload("first preload", 48*time.Hour)
+	if err != nil {
+		t.Fatalf("SaveTomorrowPreload first: %v", err)
+	}
+	id2, err := store.SaveTomorrowPreload("second preload", 48*time.Hour)
+	if err != nil {
+		t.Fatalf("SaveTomorrowPreload second: %v", err)
+	}
+
+	p, err := store.ActiveTomorrowPreload()
+	if err != nil {
+		t.Fatalf("ActiveTomorrowPreload: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected active preload")
+	}
+	if p.ID != id2 {
+		t.Errorf("got ID %d, want latest %d", p.ID, id2)
+	}
+}

--- a/memory/synced_store.go
+++ b/memory/synced_store.go
@@ -50,7 +50,7 @@ type SyncedStore struct {
 	// This is Go's version of inheritance — composition + delegation.
 	*SQLiteStore
 
-	d1Client *d1.Client   // Cloudflare D1 HTTP client
+	d1Client *d1.Client    // Cloudflare D1 HTTP client
 	notify   chan struct{} // signals the carrier that new outbox entries exist
 	done     chan struct{} // closed when the carrier goroutine exits
 
@@ -285,11 +285,11 @@ func (s *SyncedStore) carrier() {
 
 // outboxEntry represents one row from the _d1_outbox table.
 type outboxEntry struct {
-	id      int64
-	table   string
-	rowID   int64
-	rowID2  sql.NullInt64 // NULL for single-PK tables
-	op      string
+	id     int64
+	table  string
+	rowID  int64
+	rowID2 sql.NullInt64 // NULL for single-PK tables
+	op     string
 }
 
 // processOutbox reads a batch of outbox entries, builds D1 statements for

--- a/tools/context.go
+++ b/tools/context.go
@@ -189,6 +189,10 @@ type Context struct {
 	// reply_direct to enforce the sim-only guard.
 	IsSimRun bool
 
+	// DreamRemoveCount tracks how many memories the dream agent has removed
+	// this cycle. Used by the forgetting guard to enforce MaxRemovesPerCycle.
+	DreamRemoveCount int
+
 	// Ctx is the parent context for this turn. Tools that spawn retries
 	// or background work should derive from this so they respect shutdown
 	// and turn cancellation. Defaults to context.Background() if unset.

--- a/tools/forget_guard_test.go
+++ b/tools/forget_guard_test.go
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"her/config"
+	"her/memory"
+)
+
+func newGuardTestStore(t *testing.T) *memory.SQLiteStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "guard_test.db")
+	store, err := memory.NewStore(dbPath, 0)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestCanForget(t *testing.T) {
+	store := newGuardTestStore(t)
+	cfg := config.ForgettingConfig{
+		Enabled:              true,
+		RequireLowImportance: 3,
+		MinAgeDays:           60,
+		MinUnusedDays:        60,
+	}
+
+	// Use the seed "identity" card (already created by migrations, protected=true).
+	protectedCard, err := store.GetCard("identity")
+	if err != nil || protectedCard == nil {
+		t.Fatalf("GetCard identity: %v", err)
+	}
+	protectedID, err := store.SaveMemory("user name is Autumn", "identity", "user", 0, 10, nil, nil, "name", "", protectedCard.ID)
+	if err != nil {
+		t.Fatalf("SaveMemory protected: %v", err)
+	}
+
+	// Save a memory in an unprotected card, old and low importance.
+	organicCard, err := store.CreateCard("temp-notes", "Temp Notes", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateCard organic: %v", err)
+	}
+	eligibleID, err := store.SaveMemory("had coffee on march 1", "event", "user", 0, 2, nil, nil, "coffee", "", organicCard.ID)
+	if err != nil {
+		t.Fatalf("SaveMemory eligible: %v", err)
+	}
+	// Backdate to 90 days ago so it passes the age check.
+	store.DB().Exec("UPDATE memories SET timestamp = datetime('now', '-90 days') WHERE id = ?", eligibleID)
+
+	// Save a high-importance memory in an unprotected card.
+	highImpID, err := store.SaveMemory("user's primary job", "work", "user", 0, 8, nil, nil, "work", "", organicCard.ID)
+	if err != nil {
+		t.Fatalf("SaveMemory high-imp: %v", err)
+	}
+	store.DB().Exec("UPDATE memories SET timestamp = datetime('now', '-90 days') WHERE id = ?", highImpID)
+
+	// Save a recent memory (low importance, unprotected, but too new).
+	recentID, err := store.SaveMemory("mentioned weather today", "event", "user", 0, 1, nil, nil, "weather", "", organicCard.ID)
+	if err != nil {
+		t.Fatalf("SaveMemory recent: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		memID    int64
+		wantOK   bool
+		wantSub  string
+	}{
+		{
+			name:    "protected card — refused",
+			memID:   protectedID,
+			wantOK:  false,
+			wantSub: "protected",
+		},
+		{
+			name:   "eligible — old, low importance, unprotected",
+			memID:  eligibleID,
+			wantOK: true,
+		},
+		{
+			name:    "high importance — refused",
+			memID:   highImpID,
+			wantOK:  false,
+			wantSub: "importance",
+		},
+		{
+			name:    "too recent — refused",
+			memID:   recentID,
+			wantOK:  false,
+			wantSub: "days ago",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem, err := store.GetMemory(tt.memID)
+			if err != nil || mem == nil {
+				t.Fatalf("GetMemory(%d): %v", tt.memID, err)
+			}
+			ok, reason := CanForget(mem, store, cfg)
+			if ok != tt.wantOK {
+				t.Errorf("CanForget = %v (reason: %s), want %v", ok, reason, tt.wantOK)
+			}
+			if !tt.wantOK && tt.wantSub != "" {
+				if reason == "" || !contains(reason, tt.wantSub) {
+					t.Errorf("reason %q should contain %q", reason, tt.wantSub)
+				}
+			}
+		})
+	}
+}
+
+func TestCanForget_RecalledRecently(t *testing.T) {
+	store := newGuardTestStore(t)
+	cfg := config.ForgettingConfig{
+		Enabled:              true,
+		RequireLowImportance: 3,
+		MinAgeDays:           60,
+		MinUnusedDays:        60,
+	}
+
+	card, _ := store.CreateCard("temp", "Temp", "user", 0)
+	id, _ := store.SaveMemory("old stale note", "event", "user", 0, 2, nil, nil, "note", "", card.ID)
+	// Backdate the memory to 90 days ago.
+	store.DB().Exec("UPDATE memories SET timestamp = datetime('now', '-90 days') WHERE id = ?", id)
+	// But mark it as recalled recently.
+	store.MarkMemoriesRecalled([]int64{id})
+
+	mem, _ := store.GetMemory(id)
+	ok, reason := CanForget(mem, store, cfg)
+	if ok {
+		t.Error("expected refusal for recently-recalled memory")
+	}
+	if !contains(reason, "recalled") {
+		t.Errorf("reason %q should mention recall", reason)
+	}
+}
+
+func TestCanForget_SupersessionChain(t *testing.T) {
+	store := newGuardTestStore(t)
+	cfg := config.ForgettingConfig{
+		Enabled:              true,
+		RequireLowImportance: 3,
+		MinAgeDays:           60,
+		MinUnusedDays:        60,
+	}
+
+	card, _ := store.CreateCard("temp", "Temp", "user", 0)
+	oldID, _ := store.SaveMemory("works at Panera", "work", "user", 0, 2, nil, nil, "work", "", card.ID)
+	newID, _ := store.SaveMemory("works at Cava", "work", "user", 0, 2, nil, nil, "work", "", card.ID)
+	store.SupersedeMemory(oldID, newID, "job changed")
+
+	// Backdate both.
+	store.DB().Exec("UPDATE memories SET timestamp = datetime('now', '-90 days') WHERE id IN (?, ?)", oldID, newID)
+
+	// The new memory is the head of the chain — should be refused.
+	mem, _ := store.GetMemory(newID)
+	ok, reason := CanForget(mem, store, cfg)
+	if ok {
+		t.Error("expected refusal for head of supersession chain")
+	}
+	if !contains(reason, "supersession") {
+		t.Errorf("reason %q should mention supersession", reason)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSub(s, sub))
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// Silence the "unused" warning for time import.
+var _ = time.Now

--- a/tools/remove_memory/handler.go
+++ b/tools/remove_memory/handler.go
@@ -46,6 +46,14 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		if !ctx.Cfg.Dream.Forgetting.Enabled {
 			return ""
 		}
+		// Per-cycle quota: cap removals to prevent sweeps.
+		maxRemoves := ctx.Cfg.Dream.Forgetting.MaxRemovesPerCycle
+		if maxRemoves <= 0 {
+			maxRemoves = 5
+		}
+		if ctx.DreamRemoveCount >= maxRemoves {
+			return fmt.Sprintf("refused: already removed %d memories this cycle (max %d). Leave the rest alone.", ctx.DreamRemoveCount, maxRemoves)
+		}
 		mem, err := ctx.Store.GetMemory(id)
 		if err != nil || mem == nil {
 			return ""
@@ -71,6 +79,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 				continue
 			}
 			removed++
+			if isDream {
+				ctx.DreamRemoveCount++
+			}
 		}
 		log.Infof("  remove_memory: batch deactivated %d/%d (reason: %s)", removed, len(args.MemoryIDs), args.Reason)
 		if len(errors) > 0 {
@@ -103,6 +114,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 
 	if err := ctx.Store.DeactivateMemory(args.MemoryID); err != nil {
 		return fmt.Sprintf("error removing memory: %v", err)
+	}
+	if isDream {
+		ctx.DreamRemoveCount++
 	}
 
 	log.Infof("  remove_memory: deactivated ID=%d (reason: %s)", args.MemoryID, args.Reason)

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -2,12 +2,12 @@
 // user-facing response via the chat model.
 //
 // This is the most complex tool in the system. It:
-//   1. Builds the chat system prompt from the layer registry (persona,
-//      memory, time, etc.)
-//   2. Assembles the conversation history with day-boundary detection
-//   3. Calls the chat LLM with the agent's instruction and context
-//   4. Guards against degenerate and overly-long responses
-//   5. Saves the response to the DB and delivers it to Telegram + TTS
+//  1. Builds the chat system prompt from the layer registry (persona,
+//     memory, time, etc.)
+//  2. Assembles the conversation history with day-boundary detection
+//  3. Calls the chat LLM with the agent's instruction and context
+//  4. Guards against degenerate and overly-long responses
+//  5. Saves the response to the DB and delivers it to Telegram + TTS
 //
 // Previously execReply lived inside agent/agent.go as a special-cased
 // function. Moving it here makes reply a first-class tool: traceable,

--- a/tools/reply/handler.go
+++ b/tools/reply/handler.go
@@ -215,18 +215,7 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		}
 	}
 
-	// Length directive — injected per-call so the base prompt stays clean.
-	// The driver picks brief/normal/detailed; the chat model only sees the
-	// one-liner relevant to this specific reply.
-	var lengthDirective string
-	switch args.Length {
-	case "detailed":
-		lengthDirective = "Length: This warrants a longer, more thoughtful response. Take the space you need."
-	case "normal":
-		lengthDirective = "Length: Keep this to 1-3 sentences."
-	default:
-		lengthDirective = "Length: Keep this SHORT. One sentence, maybe a few words. Fragments are fine. Don't elaborate unless asked."
-	}
+	lengthDirective := lengthDirectiveFor(args.Length)
 
 	// Build the user message. Search context and the agent's instruction
 	// go into a lightweight system note so they don't masquerade as user
@@ -719,4 +708,18 @@ func reduceEmDashes(text string) string {
 	}
 
 	return b.String()
+}
+
+// lengthDirectiveFor returns the per-call length directive injected into
+// the chat model's system note. The driver picks brief/normal/detailed;
+// unknown values fall to the default (brief).
+func lengthDirectiveFor(length string) string {
+	switch length {
+	case "detailed":
+		return "Length: This warrants a longer, more thoughtful response. Take the space you need."
+	case "normal":
+		return "Length: Keep this to 1-3 sentences."
+	default:
+		return "Length: Keep this SHORT. One sentence, maybe a few words. Fragments are fine. Don't elaborate unless asked."
+	}
 }

--- a/tools/reply/length_test.go
+++ b/tools/reply/length_test.go
@@ -1,0 +1,31 @@
+package reply
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLengthDirectiveFor(t *testing.T) {
+	tests := []struct {
+		length  string
+		wantSub string
+	}{
+		{"brief", "SHORT"},
+		{"normal", "1-3 sentences"},
+		{"detailed", "longer, more thoughtful"},
+		{"", "SHORT"},
+		{"unknown_value", "SHORT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.length, func(t *testing.T) {
+			got := lengthDirectiveFor(tt.length)
+			if !strings.Contains(got, tt.wantSub) {
+				t.Errorf("lengthDirectiveFor(%q) = %q, want substring %q", tt.length, got, tt.wantSub)
+			}
+			if !strings.HasPrefix(got, "Length:") {
+				t.Errorf("lengthDirectiveFor(%q) should start with 'Length:', got %q", tt.length, got)
+			}
+		})
+	}
+}

--- a/tools/reply_direct/handler.go
+++ b/tools/reply_direct/handler.go
@@ -161,12 +161,14 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	}
 
 	// Save to DB.
-	respID, err := ctx.Store.SaveMessage("assistant", replyText, replyText, ctx.ConversationID)
-	if err != nil {
-		log.Error("reply_direct: saving response", "err", err)
-	}
-	if respID > 0 {
-		ctx.Store.SaveMetric("direct", 0, 0, 0, 0, 0, respID, false, memory.RoleChat)
+	if ctx.Store != nil {
+		respID, err := ctx.Store.SaveMessage("assistant", replyText, replyText, ctx.ConversationID)
+		if err != nil {
+			log.Error("reply_direct: saving response", "err", err)
+		}
+		if respID > 0 {
+			ctx.Store.SaveMetric("direct", 0, 0, 0, 0, 0, respID, false, memory.RoleChat)
+		}
 	}
 
 	// TTS.


### PR DESCRIPTION
## Summary

Fixes all required findings from the go-audit runs on today's PRs:

- **gofmt** on 5 files with formatting issues (#91)
- **sql.ErrNoRows** distinguished from real DB errors in `ActiveTomorrowPreload` and `MemoryCardForMemory` — prevents silently swallowing corruption/lock errors (#92, #93)
- **MaxBullets** unused config field removed — data primacy violation (#92)
- **MaxRemovesPerCycle** now enforced in code via `DreamRemoveCount` on tools.Context — prompt no longer lies about system enforcement (#93)
- **IsSimRun** wired through Bot → RunParams → tools.Context, set by sim pipeline — reply_direct sim-only guard now functional (#94)
- **Nil guard** on ctx.Store in reply_direct handler before SaveMessage (#94)
- **Bot stubStore** updated with new Store interface methods (test compilation fix)

## Test plan

- [x] Build passes, go vet clean
- [x] All tests pass with -race (memory, tools, agent, gateway, bot)