### PR TITLE
refactor: unify dream cycle into single RunDreamCycle() entry point

### DIFF
--- a/bot/commands_gateway.go
+++ b/bot/commands_gateway.go
@@ -480,78 +480,43 @@ func (b *Bot) execPersonaRewrite() (string, error) {
 	return fmt.Sprintf("Persona rewritten.\n\n%s", string(data)), nil
 }
 
-// ExecDream runs a full dream cycle and returns a summary.
+// ExecDream runs a full dream cycle via the unified RunDreamCycle and
+// returns a human-readable summary. ForceRewrite=true since the user
+// (or sim) explicitly requested a dream.
 func (b *Bot) ExecDream() (string, error) {
-	var msg strings.Builder
-	msg.WriteString("== Dream Complete ==\n\n")
-
 	dreamLLM := b.dreamAgentLLM
 	if dreamLLM == nil {
 		dreamLLM = b.memoryAgentLLM
 	}
-	if dreamLLM != nil && b.cfg.Dream.DreamEnabled() {
-		result := persona.RunMemoryDreamer(persona.MemoryDreamerParams{
-			LLM:         dreamLLM,
-			Store:       b.store,
-			EmbedClient: b.embedClient,
-			Cfg:         b.cfg,
-		})
-		if result.Error != nil {
-			log.Error("dream consolidation", "err", result.Error)
-			fmt.Fprintf(&msg, "Consolidation error: %v\n\n", result.Error)
-		} else if result.Rewrites+result.Merges+result.Expires+result.Creates > 0 {
-			fmt.Fprintf(&msg, "Consolidated: %d rewrites, %d merges, %d expires, %d creates\n\n",
-				result.Rewrites, result.Merges, result.Expires, result.Creates)
-		} else {
-			msg.WriteString("Memories look tidy — nothing to consolidate.\n\n")
-		}
-	}
 
-	if err := persona.NightlyReflect(b.llm, b.store, b.cfg, b.cfg.Identity.Her, b.cfg.Identity.User); err != nil {
-		return "", fmt.Errorf("reflection failed: %w", err)
-	}
+	result := persona.RunDreamCycle(persona.DreamCycleParams{
+		LLM:           b.llm,
+		DreamLLM:      dreamLLM,
+		ClassifierLLM: b.classifierLLM,
+		Embed:         b.embedClient,
+		Store:         b.store,
+		Cfg:           b.cfg,
+		EventBus:      b.eventBus,
+		ForceRewrite:  true,
+		MinDays:       b.cfg.Persona.MinRewriteDays,
+		MinRefl:       b.cfg.Persona.MinReflections,
+	})
 
-	minDays := b.cfg.Persona.MinRewriteDays
-	if minDays == 0 {
-		minDays = 7
-	}
-	minRefl := b.cfg.Persona.MinReflections
-	if minRefl == 0 {
-		minRefl = 3
-	}
-	rewritten, err := persona.GatedRewrite(b.llm, b.classifierLLM, b.embedClient, b.store, b.cfg.Persona.PersonaFile, b.cfg.Identity.Her, true, minDays, minRefl)
-	if err != nil {
-		return "", fmt.Errorf("rewrite failed: %w", err)
-	}
-
+	// Append the latest reflection to the summary.
+	summary := result.Summary()
 	reflections, _ := b.store.ReflectionsSince(time.Now().Add(-30 * time.Second))
 	if len(reflections) > 0 {
-		fmt.Fprintf(&msg, "Reflection:\n%s\n\n", reflections[len(reflections)-1].Content)
-	} else {
-		msg.WriteString("Nothing notable to reflect on right now.\n\n")
+		summary = strings.Replace(summary, "== Dream Complete ==\n\n",
+			fmt.Sprintf("== Dream Complete ==\n\nReflection:\n%s\n\n", reflections[len(reflections)-1].Content), 1)
 	}
 
-	// Step 3: Tomorrow's preload.
-	if b.cfg.Dream.TomorrowPreload.Enabled {
-		if err := persona.RunTomorrowPreload(persona.TomorrowPreloadParams{
-			LLM:      b.llm,
-			Store:    b.store,
-			Cfg:      b.cfg,
-			EventBus: b.eventBus,
-		}); err != nil {
-			log.Error("dream preload", "err", err)
-			fmt.Fprintf(&msg, "Preload error: %v\n\n", err)
-		} else {
-			msg.WriteString("Tomorrow's preload generated.\n\n")
-		}
+	if result.ReflectionError != nil {
+		return "", fmt.Errorf("reflection failed: %w", result.ReflectionError)
 	}
-
-	if rewritten {
-		msg.WriteString("Persona rewritten. Use /persona to see the update.")
-	} else {
-		msg.WriteString("No persona changes — not enough has shifted yet.")
+	if result.RewriteError != nil {
+		return "", fmt.Errorf("rewrite failed: %w", result.RewriteError)
 	}
-	return msg.String(), nil
+	return summary, nil
 }
 
 // ExecDreamLog returns recent memory dreamer audit entries.

--- a/persona/dream_cycle.go
+++ b/persona/dream_cycle.go
@@ -1,0 +1,166 @@
+package persona
+
+import (
+	"fmt"
+	"strings"
+
+	"her/config"
+	"her/embed"
+	"her/llm"
+	"her/memory"
+	"her/tui"
+)
+
+// DreamCycleParams bundles everything a full dream cycle needs.
+// Both the nightly timer (dreamer.go) and the /dream command
+// (ExecDream) use this — one function, one set of steps.
+type DreamCycleParams struct {
+	LLM           *llm.Client   // persona/reflection model
+	DreamLLM      *llm.Client   // memory dreamer model — nil disables consolidation
+	ClassifierLLM *llm.Client   // persona quality gate — nil-safe
+	Embed         *embed.Client // reflection dedup — nil-safe
+	Store         memory.Store
+	Cfg           *config.Config
+	EventBus      *tui.Bus
+
+	// ForceRewrite bypasses the min-days/min-reflections gate on persona
+	// rewrite. true when the user explicitly runs /dream; false for the
+	// nightly timer.
+	ForceRewrite bool
+
+	MinDays int // minimum days between rewrites; 0 defaults to 7
+	MinRefl int // minimum unconsumed reflections; 0 defaults to 3
+}
+
+// DreamCycleResult summarizes what happened across all dream steps.
+type DreamCycleResult struct {
+	// Step 0: Consolidation
+	ConsolidationRewrites int
+	ConsolidationMerges   int
+	ConsolidationExpires  int
+	ConsolidationCreates  int
+	ConsolidationError    error
+
+	// Step 1: Reflection
+	ReflectionError error
+
+	// Step 2: Persona rewrite
+	PersonaRewritten bool
+	RewriteError     error
+
+	// Step 3: Tomorrow's preload
+	PreloadGenerated bool
+	PreloadError     error
+}
+
+// Summary returns a human-readable summary of the dream cycle, suitable
+// for the /dream command response or sim report.
+func (r DreamCycleResult) Summary() string {
+	var msg strings.Builder
+	msg.WriteString("== Dream Complete ==\n\n")
+
+	if r.ConsolidationError != nil {
+		fmt.Fprintf(&msg, "Consolidation error: %v\n\n", r.ConsolidationError)
+	} else if r.ConsolidationRewrites+r.ConsolidationMerges+r.ConsolidationExpires+r.ConsolidationCreates > 0 {
+		fmt.Fprintf(&msg, "Consolidated: %d rewrites, %d merges, %d expires, %d creates\n\n",
+			r.ConsolidationRewrites, r.ConsolidationMerges, r.ConsolidationExpires, r.ConsolidationCreates)
+	} else {
+		msg.WriteString("Memories look tidy — nothing to consolidate.\n\n")
+	}
+
+	if r.ReflectionError != nil {
+		fmt.Fprintf(&msg, "Reflection error: %v\n\n", r.ReflectionError)
+	}
+
+	if r.PreloadGenerated {
+		msg.WriteString("Tomorrow's preload generated.\n\n")
+	} else if r.PreloadError != nil {
+		fmt.Fprintf(&msg, "Preload error: %v\n\n", r.PreloadError)
+	}
+
+	if r.PersonaRewritten {
+		msg.WriteString("Persona rewritten. Use /persona to see the update.")
+	} else {
+		msg.WriteString("No persona changes — not enough has shifted yet.")
+	}
+
+	return msg.String()
+}
+
+// RunDreamCycle executes the full 4-step dream cycle. This is the single
+// entry point — both the nightly timer and the /dream command use it.
+// Adding a new dream step means changing only this function.
+func RunDreamCycle(p DreamCycleParams) DreamCycleResult {
+	var result DreamCycleResult
+
+	if p.MinDays == 0 {
+		p.MinDays = 7
+	}
+	if p.MinRefl == 0 {
+		p.MinRefl = 3
+	}
+
+	log.Info("dreamer: running dream cycle")
+
+	// Step 0: Memory consolidation.
+	if p.DreamLLM != nil && p.Cfg.Dream.DreamEnabled() {
+		dreamerResult := RunMemoryDreamer(MemoryDreamerParams{
+			LLM:         p.DreamLLM,
+			Store:       p.Store,
+			EmbedClient: p.Embed,
+			Cfg:         p.Cfg,
+			EventBus:    p.EventBus,
+		})
+		result.ConsolidationRewrites = dreamerResult.Rewrites
+		result.ConsolidationMerges = dreamerResult.Merges
+		result.ConsolidationExpires = dreamerResult.Expires
+		result.ConsolidationCreates = dreamerResult.Creates
+		result.ConsolidationError = dreamerResult.Error
+		if dreamerResult.Error != nil {
+			log.Error("dreamer: memory consolidation failed", "err", dreamerResult.Error)
+		} else {
+			log.Infof("dreamer: %d rewrites, %d merges, %d expires, %d creates",
+				dreamerResult.Rewrites, dreamerResult.Merges, dreamerResult.Expires, dreamerResult.Creates)
+			emitPersonaEvent(p.EventBus, "dream_consolidate",
+				fmt.Sprintf("%d rewrites, %d merges, %d expires, %d creates",
+					dreamerResult.Rewrites, dreamerResult.Merges, dreamerResult.Expires, dreamerResult.Creates))
+		}
+	}
+
+	// Step 1: Nightly reflection.
+	if err := NightlyReflect(p.LLM, p.Store, p.Cfg, p.Cfg.Identity.Her, p.Cfg.Identity.User); err != nil {
+		log.Error("dreamer: nightly reflection failed", "err", err)
+		result.ReflectionError = err
+	} else {
+		emitPersonaEvent(p.EventBus, "dream_reflect", "nightly reflection complete")
+	}
+
+	// Step 2: Gated rewrite.
+	rewritten, err := GatedRewrite(p.LLM, p.ClassifierLLM, p.Embed, p.Store,
+		p.Cfg.Persona.PersonaFile, p.Cfg.Identity.Her, p.ForceRewrite, p.MinDays, p.MinRefl)
+	if err != nil {
+		log.Error("dreamer: gated rewrite failed", "err", err)
+		result.RewriteError = err
+	} else if rewritten {
+		log.Info("dreamer: persona rewritten during dream cycle")
+		emitPersonaEvent(p.EventBus, "dream_rewrite", "persona updated via dream")
+	}
+	result.PersonaRewritten = rewritten
+
+	// Step 3: Tomorrow's preload.
+	if p.Cfg.Dream.TomorrowPreload.Enabled {
+		if err := RunTomorrowPreload(TomorrowPreloadParams{
+			LLM:      p.LLM,
+			Store:    p.Store,
+			Cfg:      p.Cfg,
+			EventBus: p.EventBus,
+		}); err != nil {
+			log.Error("dreamer: tomorrow preload failed", "err", err)
+			result.PreloadError = err
+		} else {
+			result.PreloadGenerated = true
+		}
+	}
+
+	return result
+}

--- a/persona/dreamer.go
+++ b/persona/dreamer.go
@@ -11,7 +11,6 @@ package persona
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"her/config"
@@ -99,69 +98,27 @@ func StartDreamer(ctx context.Context, p DreamerParams) {
 	}
 }
 
-// runDream executes one full dream cycle: reflection + optional gated rewrite.
-// It's extracted from the loop so the catch-up call and the scheduled call share
-// identical logic — no code duplication.
+// runDream delegates to RunDreamCycle — the single entry point for all
+// dream steps. The nightly timer uses ForceRewrite=false (respect cooldown).
 func runDream(ctx context.Context, p DreamerParams) {
-	// Check for cancellation before starting — avoid burning tokens during shutdown.
 	select {
 	case <-ctx.Done():
 		return
 	default:
 	}
 
-	log.Info("dreamer: running dream cycle")
-
-	// Step 0: Memory consolidation — clean house before reflecting.
-	// Only runs if the dream agent is configured and consolidation is enabled.
-	if p.DreamLLM != nil && p.Cfg.Dream.DreamEnabled() {
-		dreamerResult := RunMemoryDreamer(MemoryDreamerParams{
-			LLM:         p.DreamLLM,
-			Store:       p.Store,
-			EmbedClient: p.Embed,
-			Cfg:         p.Cfg,
-			EventBus:    p.EventBus,
-		})
-		if dreamerResult.Error != nil {
-			log.Error("dreamer: memory consolidation failed", "err", dreamerResult.Error)
-		} else {
-			log.Infof("dreamer: %d rewrites, %d merges, %d expires, %d creates",
-				dreamerResult.Rewrites, dreamerResult.Merges, dreamerResult.Expires, dreamerResult.Creates)
-			emitPersonaEvent(p.EventBus, "dream_consolidate",
-				fmt.Sprintf("%d rewrites, %d merges, %d expires, %d creates",
-					dreamerResult.Rewrites, dreamerResult.Merges, dreamerResult.Expires, dreamerResult.Creates))
-		}
-	}
-
-	// Step 1: Nightly reflection — always runs.
-	if err := NightlyReflect(p.LLM, p.Store, p.Cfg, p.Cfg.Identity.Her, p.Cfg.Identity.User); err != nil {
-		log.Error("dreamer: nightly reflection failed", "err", err)
-	} else {
-		emitPersonaEvent(p.EventBus, "dream_reflect", "nightly reflection complete")
-	}
-
-	// Step 2: Gated rewrite — only runs if gates pass.
-	rewritten, err := GatedRewrite(p.LLM, p.ClassifierLLM, p.Embed, p.Store, p.Cfg.Persona.PersonaFile, p.Cfg.Identity.Her, false, p.MinDays, p.MinRefl)
-	if err != nil {
-		log.Error("dreamer: gated rewrite failed", "err", err)
-	} else if rewritten {
-		log.Info("dreamer: persona rewritten during dream cycle")
-		emitPersonaEvent(p.EventBus, "dream_rewrite", "persona updated via dream")
-	}
-
-	// Step 3: Tomorrow's preload — write a note about what to bring up
-	// in the next conversation. Runs after reflection and rewrite so it
-	// has access to tonight's fresh outputs.
-	if p.Cfg.Dream.TomorrowPreload.Enabled {
-		if err := RunTomorrowPreload(TomorrowPreloadParams{
-			LLM:      p.LLM,
-			Store:    p.Store,
-			Cfg:      p.Cfg,
-			EventBus: p.EventBus,
-		}); err != nil {
-			log.Error("dreamer: tomorrow preload failed", "err", err)
-		}
-	}
+	RunDreamCycle(DreamCycleParams{
+		LLM:           p.LLM,
+		DreamLLM:      p.DreamLLM,
+		ClassifierLLM: p.ClassifierLLM,
+		Embed:         p.Embed,
+		Store:         p.Store,
+		Cfg:           p.Cfg,
+		EventBus:      p.EventBus,
+		ForceRewrite:  false,
+		MinDays:       p.MinDays,
+		MinRefl:       p.MinRefl,
+	})
 }
 
 // durationUntilNextDream returns how long to sleep until the next occurrence


### PR DESCRIPTION
## Summary

The dream cycle had two code paths that diverged when Step 3 (tomorrow's preload) was added — `dreamer.go:runDream()` had all 4 steps while `ExecDream()` was missing the preload. This refactor extracts the shared logic into `persona.RunDreamCycle()` so both callers are thin wrappers.

- **New**: `persona/dream_cycle.go` — `RunDreamCycle()`, `DreamCycleParams`, `DreamCycleResult`
- **`dreamer.go:runDream()`** → delegates to `RunDreamCycle(ForceRewrite: false)`
- **`ExecDream()`** → delegates to `RunDreamCycle(ForceRewrite: true)` + appends reflection text
- `DreamCycleResult.Summary()` produces the human-readable output both paths need
- Adding a new dream step (Step 5, 6, etc.) now requires changing only `RunDreamCycle()`

## Test plan

- [x] Build passes
- [x] All persona, bot, gateway tests pass
- [ ] Run `her sim` with dream_after — verify dream still fires all steps
- [ ] Run `/dream` command — verify same behavior as before