### PR TITLE
feat: conversational scheduled briefings + timezone + /schedule

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -30,11 +30,14 @@ import (
 	_ "her/tools/calendar_delete"
 	_ "her/tools/calendar_list"
 	_ "her/tools/calendar_update"
+	_ "her/tools/create_schedule"
+	_ "her/tools/delete_schedule"
 	_ "her/tools/done"
 	_ "her/tools/get_time"
 	_ "her/tools/get_weather"
 	_ "her/tools/list_calendars"
 	_ "her/tools/list_files"
+	_ "her/tools/list_schedules"
 	_ "her/tools/narrate_report"
 	_ "her/tools/nearby_search"
 	_ "her/tools/publish_report"
@@ -48,6 +51,7 @@ import (
 	_ "her/tools/shift_hours"
 	_ "her/tools/think"
 	_ "her/tools/update_persona"
+	_ "her/tools/update_schedule"
 	_ "her/tools/use_tools"
 	_ "her/tools/view_image"
 	_ "her/tools/web_read"
@@ -793,7 +797,7 @@ outer:
 				params.LiteToolHook("reply")
 			}
 			toolSeq = append(toolSeq, "reply")
-			fallbackResult := tools.Execute("reply", `{"instruction":"The user sent a message. Respond naturally. Do not reference any interruption or claim you were cut off."}`, tctx)
+			fallbackResult := tools.Execute("reply", `{"instruction":"The driver agent loop failed — NO tools were called and NO actions were taken. Do NOT claim you did something. Acknowledge the user's request and offer to try again. Be honest that nothing happened."}`, tctx)
 			if tctx.ReplyCount == 0 {
 				log.Error("fallback reply also failed", "result", fallbackResult)
 				return nil, fmt.Errorf("agent failed to generate a reply")

--- a/bot/commands_gateway.go
+++ b/bot/commands_gateway.go
@@ -704,3 +704,67 @@ func (b *Bot) ExecRollup() (string, error) {
 	}
 	return "Rollup ran — no new daily entry (already exists or insufficient data).", nil
 }
+
+// ExecSchedule shows all upcoming scheduled tasks — both system (yaml)
+// and user-created. Groups by status and shows next fire times in the
+// user's configured timezone.
+func (b *Bot) ExecSchedule() (string, error) {
+	loc := time.UTC
+	if tz := b.cfg.Timezone(); tz != "" {
+		if parsed, err := time.LoadLocation(tz); err == nil {
+			loc = parsed
+		}
+	}
+
+	tasks, err := b.store.ListAllSchedulerTasks()
+	if err != nil {
+		return "", fmt.Errorf("listing schedules: %w", err)
+	}
+
+	if len(tasks) == 0 {
+		return "No scheduled tasks.", nil
+	}
+
+	// Split into user and system tasks.
+	var userTasks, systemTasks []memory.SchedulerTask
+	for _, t := range tasks {
+		if t.Source == "user" {
+			userTasks = append(userTasks, t)
+		} else {
+			systemTasks = append(systemTasks, t)
+		}
+	}
+
+	var msg strings.Builder
+	msg.WriteString("== Scheduled Tasks ==\n\n")
+
+	if len(userTasks) > 0 {
+		msg.WriteString("User Schedules\n")
+		for _, t := range userTasks {
+			status := "on"
+			if !t.Enabled {
+				status = "off"
+			}
+			name := t.Name
+			if name == "" {
+				name = t.Kind
+			}
+			humanCron := scheduler.DescribeCron(t.CronExpr)
+			nextStr := t.NextFire.In(loc).Format("Mon Jan 2, 3:04 PM")
+			fmt.Fprintf(&msg, " [%s] #%d %s\n   %s (%s) | next: %s\n",
+				status, t.ID, name, humanCron, t.Kind, nextStr)
+		}
+		msg.WriteString("\n")
+	}
+
+	if len(systemTasks) > 0 {
+		msg.WriteString("System Tasks\n")
+		for _, t := range systemTasks {
+			humanCron := scheduler.DescribeCron(t.CronExpr)
+			nextStr := t.NextFire.In(loc).Format("Mon Jan 2, 3:04 PM")
+			fmt.Fprintf(&msg, " %s — %s | next: %s\n", t.Kind, humanCron, nextStr)
+		}
+	}
+
+	return msg.String(), nil
+}

--- a/bot/helpers_test.go
+++ b/bot/helpers_test.go
@@ -169,6 +169,7 @@ func (s stubStore) LatestSummary(conversationID, stream string) (string, int64, 
 	return "", 0, nil
 }
 func (s stubStore) UpsertSchedulerTask(t *memory.SchedulerTask) error { return nil }
+func (s stubStore) ListAllSchedulerTasks() ([]memory.SchedulerTask, error) { return nil, nil }
 func (s stubStore) DueSchedulerTasks(now time.Time) ([]memory.SchedulerTask, error) {
 	return nil, nil
 }

--- a/bot/helpers_test.go
+++ b/bot/helpers_test.go
@@ -173,11 +173,20 @@ func (s stubStore) DueSchedulerTasks(now time.Time) ([]memory.SchedulerTask, err
 	return nil, nil
 }
 func (s stubStore) SchedulerTaskByKind(kind string) (*memory.SchedulerTask, error) { return nil, nil }
-func (s stubStore) MarkSchedulerSuccess(id int64, nextFire time.Time) error         { return nil }
+func (s stubStore) SchedulerTaskByKindAndSource(kind, source string) (*memory.SchedulerTask, error) {
+	return nil, nil
+}
+func (s stubStore) MarkSchedulerSuccess(id int64, nextFire time.Time) error { return nil }
 func (s stubStore) MarkSchedulerFailure(id int64, nextFire time.Time, errMsg string, attempts int) error {
 	return nil
 }
 func (s stubStore) DeleteSchedulerTask(id int64) error { return nil }
+func (s stubStore) CreateUserSchedulerTask(t *memory.SchedulerTask) (int64, error) { return 0, nil }
+func (s stubStore) GetUserSchedulerTask(id int64) (*memory.SchedulerTask, error)   { return nil, nil }
+func (s stubStore) ListUserSchedulerTasks(includeDisabled bool) ([]memory.SchedulerTask, error) {
+	return nil, nil
+}
+func (s stubStore) UpdateUserSchedulerTask(id int64, updates map[string]any) error { return nil }
 func (s stubStore) InsertCalendarEvent(title, start, end, location, notes, calendar, eventID, job string) (int64, error) {
 	return 0, nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -799,6 +799,22 @@ func runBotBackground(cfg *config.Config, store memory.Store, bus *tui.Bus, prog
 		Cfg:          cfg,
 		RootDir:      rootDir,
 		AgentEventCh: agentEventCh,
+		ScheduledPromptFn: func(prompt string) error {
+			if agentEventCh == nil {
+				return fmt.Errorf("send_prompt: no agent event channel")
+			}
+			evt := agent.AgentEvent{
+				Type:     agent.EventSchedulerFired,
+				Prompt:   prompt,
+				TaskName: "send_prompt",
+			}
+			select {
+			case agentEventCh <- evt:
+				return nil
+			default:
+				return fmt.Errorf("send_prompt: agent event channel full")
+			}
+		},
 	}
 	sched, err := scheduler.New(store, schedDeps, rootDir)
 	if err != nil {

--- a/cmd/sim.go
+++ b/cmd/sim.go
@@ -217,6 +217,7 @@ type suite struct {
 	DreamAfter         []int               `yaml:"dream_after"`          // run dream cycle after these turns (supports multiple dreams per suite)
 	RunDream           bool                `yaml:"run_dream"`            // run a full dream cycle after all messages complete
 	RunRollup          bool                `yaml:"run_rollup"`           // force the daily mood rollup after all messages complete
+	FireSchedules      bool                `yaml:"fire_schedules"`       // force-fire all user-created schedules after all messages
 }
 
 // seedMemory supports both plain strings and structured objects in YAML.

--- a/cmd/sim_gw.go
+++ b/cmd/sim_gw.go
@@ -14,6 +14,7 @@ import (
 	"her/gateway"
 	"her/llm"
 	"her/memory"
+	"her/scheduler"
 	"her/search"
 	"her/tui"
 	"her/voice"
@@ -406,10 +407,11 @@ func runSimGW(cmd *cobra.Command, args []string) error {
 	gw.RegisterStore(tmpDBPath, store)
 	gw.SimMessages = gwMessages
 	gw.SimTriggers = gateway.SimTriggers{
-		CompactAfter: s.CompactAfter,
-		DreamAfter:   s.DreamAfter,
-		RunDream:     s.RunDream,
-		RunRollup:    s.RunRollup,
+		CompactAfter:  s.CompactAfter,
+		DreamAfter:    s.DreamAfter,
+		RunDream:      s.RunDream,
+		RunRollup:     s.RunRollup,
+		FireSchedules: s.FireSchedules,
 	}
 	gw.SimOptions = gateway.SimOptions{
 		DelaySeconds: delayFlag,
@@ -435,6 +437,36 @@ func runSimGW(cmd *cobra.Command, args []string) error {
 	if sa == nil {
 		cancel()
 		return fmt.Errorf("sim adapter not found after gateway start")
+	}
+
+	// Wire fire-schedules callback — needs scheduler deps built from
+	// sim-local clients. Safe to set here: fire_schedules only runs
+	// after all messages complete.
+	if s.FireSchedules {
+		sa.SetFireSchedulesFn(func(ctx context.Context) []string {
+			schedDeps := &scheduler.Deps{
+				Store:        store,
+				Send:         func(chatID int64, text string) (int, error) {
+					log.Infof("sim: [send_message] %s", text)
+					return 0, nil
+				},
+				ChatID:       0,
+				WorkerLLMs:   simWorkerLLMs,
+				TavilyClient: tavilyClient,
+				Cfg:          cfg,
+				RootDir:      simRootDir,
+			}
+			results := scheduler.FireAllUserTasks(ctx, store, schedDeps)
+			var lines []string
+			for _, r := range results {
+				if r.Err != nil {
+					lines = append(lines, fmt.Sprintf("#%d %s (%s): FAILED — %v", r.TaskID, r.Name, r.Kind, r.Err))
+				} else {
+					lines = append(lines, fmt.Sprintf("#%d %s (%s): OK", r.TaskID, r.Name, r.Kind))
+				}
+			}
+			return lines
+		})
 	}
 
 	// Block until all messages are processed or the gateway exits early.

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	Dream              DreamConfig              `yaml:"dream"`
 	Voice              VoiceConfig              `yaml:"voice"`
 	Location           LocationConfig           `yaml:"location,omitempty"`
+	DefaultTimezone    string                   `yaml:"default_timezone,omitempty"` // e.g. "America/New_York", applies to schedules, weather, mood rollups, and get_time
 	Calendar           CalendarConfig           `yaml:"calendar"`
 	Tunnel             TunnelConfig             `yaml:"tunnel"`
 	Cloudflare         CloudflareConfig         `yaml:"cloudflare"`
@@ -234,6 +235,63 @@ func (c *Config) ExpandPrompt(content string) string {
 	content = strings.ReplaceAll(content, "{{her}}", c.Identity.Her)
 	content = strings.ReplaceAll(content, "{{user}}", c.Identity.User)
 	return content
+}
+
+// Timezone returns the effective timezone string. Checks the top-level
+// DefaultTimezone first, falls back to Calendar.DefaultTimezone for
+// backward compatibility.
+func (c *Config) Timezone() string {
+	if c.DefaultTimezone != "" {
+		return c.DefaultTimezone
+	}
+	return c.Calendar.DefaultTimezone
+}
+
+// SetTimezone writes the timezone string into both the in-memory config and
+// config.yaml on disk. It does a surgical line-level edit — finds or creates
+// the top-level default_timezone: key and updates it, preserving all comments
+// and formatting.
+func (c *Config) SetTimezone(configPath, tz string) error {
+	c.DefaultTimezone = tz
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	// Find existing top-level default_timezone line (no leading whitespace).
+	tzIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "default_timezone:") && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			tzIdx = i
+			break
+		}
+	}
+
+	newLine := fmt.Sprintf("default_timezone: %q", tz)
+
+	if tzIdx >= 0 {
+		lines[tzIdx] = newLine
+	} else {
+		// Insert before the location: or calendar: section so it sits with
+		// the other top-level settings. Fall back to prepending.
+		inserted := false
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "location:") || strings.HasPrefix(trimmed, "calendar:") {
+				lines = insertAfter(lines, i-1, newLine)
+				inserted = true
+				break
+			}
+		}
+		if !inserted {
+			lines = append([]string{newLine}, lines...)
+		}
+	}
+
+	return os.WriteFile(configPath, []byte(strings.Join(lines, "\n")), 0644)
 }
 
 // TelegramConfig holds Telegram bot settings.

--- a/docs/plans/HANDOFF-scheduled-briefings.md
+++ b/docs/plans/HANDOFF-scheduled-briefings.md
@@ -1,0 +1,62 @@
+# Handoff: Conversational Scheduled Briefings
+
+## Context
+
+The worker agent system is fully shipped and working in production. Mira can:
+- Accept research/briefing requests via `send_task(target="worker")`
+- Run background web research with configurable model tiers (low/medium/high)
+- Write markdown reports to `reports/`
+- Publish to Telegraph for rich rendering
+- Auto-inject Telegraph links after replies
+- Narrate reports aloud via TTS
+
+**What's missing:** Mira can't CREATE scheduled briefings from conversation. Right now all research/briefings are one-off — the user asks, Mira delegates, the worker runs once. There's no way to say "brief me every morning about Go news" and have it recur automatically.
+
+## What to Build
+
+A `create_briefing_schedule` tool (or extend the existing junkdrawered `create_schedule` tool) that lets the driver agent create recurring worker tasks from conversation.
+
+### User Stories
+
+1. "Mira, every morning at 8am, send me a briefing on Go programming and AI agents"
+   → Creates a recurring scheduler row: `kind=worker_briefing`, `cron="0 8 * * *"`, `payload={topics: "Go programming, AI agents", depth: "brief"}`
+
+2. "Give me a weekly deep dive on Rust ecosystem news every Friday"
+   → Creates: `kind=worker_briefing`, `cron="0 9 * * 5"`, `payload={topics: "Rust ecosystem", depth: "deep"}`, `model_tier: "medium"`
+
+3. "What briefings do I have scheduled?" → Lists active briefing schedules
+4. "Cancel the morning tech briefing" → Disables/deletes the schedule
+5. "Change my morning briefing to 7am instead of 8" → Updates the cron
+
+### Architecture
+
+The pieces that exist:
+- **Scheduler system** (`scheduler/`) — fully functional cron-based task runner with retry, damping, quiet hours
+- **`scheduler_tasks` table** — already stores kind, cron_expr, payload, enabled flag
+- **Worker briefing handler** (`workeragent/briefing_handler.go`) — already reads `instruction` and `topics` from the payload
+- **Junkdrawered schedule tools** — `_junkdrawer/tools/create_schedule/`, `_junkdrawer/tools/list_schedules/`, `_junkdrawer/tools/update_schedule/` — these were built for the old v0.2 scheduler but have the right shape
+
+The pieces that need building:
+1. **Revive `create_schedule` tool** — pull from junkdrawer, update to support `task_type: "worker_briefing"` with custom payloads
+2. **Extend payload schema** — briefing payloads need `topics`, `depth` ("brief"/"deep"), and optionally `model_tier` override
+3. **Briefing handler reads payload** — already partially done (`briefing_handler.go` reads `instruction` and `topics` from payload), but needs to support the `depth` → model tier mapping
+4. **List/update/delete schedule tools** — revive from junkdrawer for managing existing schedules
+5. **Driver prompt update** — teach the driver about scheduling briefings
+
+### Key Decisions
+
+- **One handler, variable payloads:** Don't create separate scheduler handlers for each briefing topic. Use one `worker_briefing` handler that reads its behavior from the payload. Multiple rows in `scheduler_tasks` with `kind=worker_briefing` but different payloads = different briefings.
+- **The scheduler already supports this:** `scheduler_tasks` can have multiple rows with the same `kind` — each fires independently with its own cron and payload. The loader only upserts from `task.yaml`; user-created rows are untouched.
+- **Model tier in payload:** Default to the `meta.yaml` tier (low for briefings), but allow the payload to override it for "deep dive" recurring schedules that want medium tier.
+
+### Files to Reference
+
+- `scheduler/` — the full scheduler system
+- `scheduler/types.go` — Handler interface, Deps, TaskConfig
+- `workeragent/briefing_handler.go` — existing handler that reads payload
+- `_junkdrawer/tools/create_schedule/handler.go` — old create_schedule tool
+- `_junkdrawer/tools/list_schedules/handler.go` — old list_schedules tool  
+- `_junkdrawer/tools/update_schedule/handler.go` — old update_schedule tool
+- `_junkdrawer/store_tasks.go` — old ScheduledTask CRUD methods
+- `docs/spec/scheduler.md` — full scheduler spec with all task types documented
+- `driver_agent_prompt.md` — needs scheduling flows added

--- a/docs/plans/PLAN-agent-engine.md
+++ b/docs/plans/PLAN-agent-engine.md
@@ -1,0 +1,523 @@
+# Agent Engine Extraction Plan
+
+## 1. Context
+
+The her-go codebase has 5 agentic agents (driver, memory, introspection, worker, dream) that each independently implement the same tool-calling loop pattern: build messages, call LLM with tools, execute tool calls, append results, check for done, handle continuations. This produces ~950 lines of duplicated loop logic spread across 4 packages (`agent/`, `workeragent/`, `persona/`).
+
+Extracting a shared `agent_engine` package eliminates this duplication while preserving each agent's unique behavior through a config-with-callbacks pattern. The engine owns the loop skeleton; agents own their identity, hooks, and pre/post logic.
+
+Simultaneously, the memory write pipeline (style gate, length gate, dedup, classifier, safety classifier) is duplicated across `save_memory`, `update_memory`, and `merge_memories`. Extracting it to `tools/memgate/` makes it a single shared middleware.
+
+**Estimated net reduction: ~470 lines** (350 new, 820 removed duplication).
+
+## 2. Architecture
+
+```
+agent_engine/           NEW - shared loop engine
+  engine.go             EngineConfig, LoopResult, RunLoop()
+  engine_test.go        Unit tests with mock LLM
+  trace.go              Trace formatting helpers (moved from agent/)
+
+tools/memgate/          NEW - memory write pipeline middleware
+  pipeline.go           Gate type, RunPipeline(), gate implementations
+  pipeline_test.go      Unit tests with mock classifier
+```
+
+### Dependency graph (post-extraction)
+
+```
+bot/run_agent.go
+  -> agent/agent.go (driver)           -> agent_engine.RunLoop()
+  -> agent/memory_agent.go             -> agent_engine.RunLoop()
+  -> agent/introspection_agent.go      -> agent_engine.RunLoop()
+
+scheduler/
+  -> workeragent/worker.go             -> agent_engine.RunLoop()
+
+persona/dream_cycle.go
+  -> persona/memory_dreamer.go         -> agent_engine.RunLoop()
+
+tools/save_memory/     -> tools/memgate.RunPipeline()
+tools/save_self_memory -> tools/memgate.RunPipeline() (via ExecSaveMemory)
+tools/update_memory/   -> tools/memgate.RunPipeline()
+tools/merge_memories/  -> tools/memgate.RunPipeline()
+```
+
+The `agent_engine` package imports: `her/llm`, `her/memory`, `her/tools`, `her/tui`, `her/turn`, `her/logger`. It does NOT import `her/agent`, `her/workeragent`, or `her/persona` -- the dependency arrow always points inward.
+
+## 3. Design Pattern: Config Struct with Callbacks
+
+Each agent creates an `EngineConfig` with its dependencies and hook functions, then calls `RunLoop()`. Hooks are nil-safe -- nil means "use default" or "skip." This avoids inheritance (Go doesn't have it) and avoids interfaces (which force stub methods for hooks the agent doesn't care about).
+
+The Python analogy: it's like passing `key=` and `default=` kwargs to a library function, not like subclassing a base class.
+
+## 4. EngineConfig Struct
+
+```go
+package agent_engine
+
+// EngineConfig defines a single agent run. The engine owns the loop;
+// the caller owns identity, prompt construction, and behavioral hooks.
+type EngineConfig struct {
+    // -- Identity --
+    Name       string // "driver", "memory", "introspection", "worker", "dream"
+    MetricRole string // memory.RoleDriver, memory.RoleMemory, etc.
+
+    // -- Core dependencies --
+    LLM          *llm.Client
+    Store        memory.Store
+    ToolDefs     []llm.ToolDef
+    ToolCtx      *tools.Context   // pre-built by caller
+    Messages     []llm.ChatMessage // initial [system, user] messages
+    TriggerMsgID int64
+
+    // -- Loop tuning --
+    IterationsPerWindow int // default 15, hard cap 50
+    MaxContinuations    int // default 2, hard cap 10
+
+    // -- Observability (built-in, not hooks) --
+    // The engine owns ALL trace emission. Agents never format or send
+    // trace lines — the engine does it automatically using tools.FormatTrace().
+    // This guarantees consistent formatting, HTML escaping, truncation,
+    // and slot rendering across all agents.
+    TraceCallback tools.TraceCallback // nil = no tracing
+    LiteToolHook  func(toolName string) // nil = no lite tracing
+    EventBus      *tui.Bus              // nil-safe
+    Phase         *turn.PhaseHandle     // nil-safe
+
+    // -- Level 1 Hooks (all nil-safe) --
+
+    // ToolChoiceFirst: if non-nil, used as tool_choice on iteration 0
+    // of window 0. Typically "required" for the driver agent.
+    ToolChoiceFirst interface{}
+
+    // ContinuationMsg builds the system message injected when a
+    // continuation window opens. nil = engine uses a sensible default.
+    ContinuationMsg func(window, maxWindows int, summary string) string
+
+    // PreTool fires before each tool execution. Return skip=true to
+    // prevent execution (engine appends skipResult as the tool result).
+    // Use case: dream agent's maxOps safety cap, dry-run interception.
+    PreTool func(tc llm.ToolCall, tctx *tools.Context) (skipResult string, skip bool)
+
+    // PostTool fires after each tool execution. Called AFTER the engine
+    // has already handled tracing and TUI events. This hook is only for
+    // agent-specific concerns (SaveAgentTurn, think capture, op counting).
+    PostTool func(tc llm.ToolCall, result string, isError bool)
+
+    // PreIteration fires before each LLM call.
+    PreIteration func(iteration, window int)
+
+    // PostIteration fires after each LLM response, before tool
+    // execution. Return true to break the loop.
+    // Use case: driver loop detection (repeated think calls).
+    PostIteration func(iteration, window int, resp *llm.ChatResponse) (breakLoop bool)
+
+    // OnNoToolCalls fires when the LLM returns no tool calls.
+    // Return true to suppress the default "break outer" behavior.
+    // Use case: driver "done" text detection, agentFinalText capture.
+    OnNoToolCalls func(resp *llm.ChatResponse) (handled bool)
+
+    // OnLoopExit fires when the loop ends for any reason.
+    // Use case: driver fallback reply path, placeholder cleanup.
+    OnLoopExit func(reason string, messages []llm.ChatMessage)
+
+    // ActiveToolGuard validates tool calls before execution. Return
+    // errResult to reject. Used by driver for ActiveTools whitelist.
+    ActiveToolGuard func(tc llm.ToolCall) (errResult string, reject bool)
+}
+```
+
+## 5. LoopResult Struct
+
+```go
+type LoopResult struct {
+    Messages   []llm.ChatMessage // final message history
+    TotalCost  float64
+    ToolCalls  int
+    Iterations int
+    ExitReason string // "done", "no_tool_calls", "max_iterations",
+                      // "max_continuations", "error", "hook_break",
+                      // "finish_reason_stop"
+    TraceLines []string
+}
+```
+
+## 6. RunLoop Algorithm (with hook injection points)
+
+```go
+func RunLoop(cfg EngineConfig) (*LoopResult, error) {
+    iterationsPerWindow := coerce(cfg.IterationsPerWindow, 15, 50)
+    maxContinuations    := coerce(cfg.MaxContinuations, 2, 10)
+
+    messages   := cfg.Messages
+    var totalCost, totalTools, totalIters int/float
+    var traceLines []string
+    tracing := cfg.TraceCallback != nil
+
+    exitReason := "max_continuations"
+
+outer:
+    for window := 0; window <= maxContinuations; window++ {
+
+        // >> HOOK: ContinuationMsg (window > 0)
+        if window > 0 {
+            summary := buildContinuationSummary(traceLines)
+            if cfg.ContinuationMsg != nil {
+                contMsg = cfg.ContinuationMsg(window, maxContinuations, summary)
+            } else {
+                contMsg = defaultContinuationMsg(...)
+            }
+            messages = append(messages, system message)
+        }
+
+        for i := 0; i < iterationsPerWindow; i++ {
+            totalIters++
+
+            // >> HOOK: PreIteration
+            if cfg.PreIteration != nil { cfg.PreIteration(i, window) }
+
+            // Tool choice (ToolChoiceFirst on iter 0, window 0)
+            toolChoice := nil
+            if i == 0 && window == 0 && cfg.ToolChoiceFirst != nil {
+                toolChoice = cfg.ToolChoiceFirst
+            }
+
+            // LLM call
+            resp, err := cfg.LLM.ChatCompletionWithTools(messages, cfg.ToolDefs, toolChoice)
+            if err != nil { exitReason = "error"; break outer }
+
+            // Metrics + cost accumulation + TUI event emission
+            cfg.Store.SaveMetric(...)
+            totalCost += resp.CostUSD
+
+            // >> HOOK: PostIteration (before tool execution)
+            if cfg.PostIteration != nil {
+                if cfg.PostIteration(i, window, resp) {
+                    exitReason = "hook_break"; break outer
+                }
+            }
+
+            // No tool calls -> exit
+            if len(resp.ToolCalls) == 0 {
+                // >> HOOK: OnNoToolCalls
+                if cfg.OnNoToolCalls != nil && cfg.OnNoToolCalls(resp) {
+                    continue  // hook handled it
+                }
+                exitReason = "no_tool_calls"; break outer
+            }
+
+            // Append assistant message
+            messages = append(messages, assistant msg with ToolCalls)
+
+            // Execute each tool call
+            for _, tc := range resp.ToolCalls {
+                if tc.Function.Name == "" { continue }
+
+                // >> HOOK: ActiveToolGuard
+                if cfg.ActiveToolGuard != nil {
+                    if errResult, reject := cfg.ActiveToolGuard(tc); reject {
+                        append error result; continue
+                    }
+                }
+
+                // >> HOOK: PreTool (dry-run, safety caps)
+                var result string
+                if cfg.PreTool != nil {
+                    if skipResult, skip := cfg.PreTool(tc, cfg.ToolCtx); skip {
+                        result = skipResult
+                    } else {
+                        result = tools.Execute(tc, cfg.ToolCtx)
+                    }
+                } else {
+                    result = tools.Execute(tc, cfg.ToolCtx)
+                }
+
+                totalTools++
+                isError := strings.HasPrefix(result, "error:") || ...
+
+                // == BUILT-IN: Trace emission (not a hook) ==
+                // Every agent gets this for free. Consistent formatting,
+                // HTML escaping, and truncation via tools.FormatTrace().
+                if tracing {
+                    line := tools.FormatTrace(tc.Function.Name, tc.Function.Arguments, result)
+                    traceLines = append(traceLines, line)
+                    sendTrace()
+                }
+
+                // == BUILT-IN: Lite trace (not a hook) ==
+                if cfg.LiteToolHook != nil {
+                    cfg.LiteToolHook(tc.Function.Name)
+                }
+
+                // == BUILT-IN: TUI event emission ==
+                emitToolCallEvent(cfg, tc, result, isError)
+
+                // >> HOOK: PostTool (agent-specific only: SaveAgentTurn, think capture, etc.)
+                if cfg.PostTool != nil { cfg.PostTool(tc, result, isError) }
+
+                // Append tool result to messages
+            }
+
+            // Done check
+            if cfg.ToolCtx.DoneCalled { exitReason = "done"; break outer }
+
+            // finish_reason=stop exit
+            if resp.FinishReason == "stop" {
+                exitReason = "finish_reason_stop"; break outer
+            }
+        }
+
+        if window == maxContinuations { break outer }
+    }
+
+    // >> HOOK: OnLoopExit
+    if cfg.OnLoopExit != nil { cfg.OnLoopExit(exitReason, messages) }
+
+    return &LoopResult{...}, nil
+}
+```
+
+### Hook injection point summary
+
+| Hook | When | Use Case |
+|------|------|----------|
+| `ToolChoiceFirst` | iter 0, window 0 | Driver: `"required"` to force tool use |
+| `ContinuationMsg` | window > 0 | Custom continuation prompts per agent |
+| `PreIteration` | before each LLM call | Introspection: latency tracking |
+| `PostIteration` | after LLM response, before tools | Driver: loop detection (repeated think) |
+| `OnNoToolCalls` | LLM returns no tool calls | Driver: "done" text detection, agentFinalText |
+| `ActiveToolGuard` | before each tool execution | Driver: ActiveTools whitelist |
+| `PreTool` | before tools.Execute | Dream: dry-run interception, maxOps cap |
+| `PostTool` | after tools.Execute (after built-in tracing) | Driver: SaveAgentTurn, think capture, op counting |
+| `OnLoopExit` | after loop ends | Driver: fallback reply, placeholder cleanup |
+
+### What's built-in vs what's a hook
+
+The engine handles these **automatically** for every agent (not hooks):
+- **Full trace emission**: `tools.FormatTrace()` → `traceLines` → `sendTrace()` — consistent HTML, emoji, truncation
+- **Lite trace emission**: `LiteToolHook(toolName)` — tool sequence tracking for compact view
+- **TUI event emission**: `Phase.EmitToolCall()` / `EventBus.Emit(ToolCallEvent{})` — nil-safe
+- **Iteration events**: `AgentIterEvent` with tokens, cost, finish reason
+- **Continuation headers**: `"🔄 continuation window N/M"` trace line
+- **Error/fallback traces**: `"❌ error: ..."`, `"⚡ fallback: model"`
+- **Metric saving**: `Store.SaveMetric()` with role tag
+
+Agent hooks are only for **agent-specific concerns** that differ between agents.
+
+## 7. Trace Unification
+
+### Problem
+
+The current trace system has 7 inconsistencies across agents:
+
+| Issue | Impact |
+|-------|--------|
+| Introspection doesn't use `tools.FormatTrace()` — manual plain-text formatting | Traces look different in Telegram (no emoji, no HTML) |
+| Introspection truncates to 60 chars, others use 80+ | Results cut short |
+| Memory dreamer registers a trace slot but never writes to it | Dream cycle is invisible |
+| Worker has no lite-mode integration in `liteTraceState` | Worker traces always verbose |
+| Each agent reimplements `traceLines []string` + `sendTrace()` closure | 5 copies of identical boilerplate |
+| Continuation summary HTML stripping is hardcoded per-agent | New tags break stripping |
+| TUI event emission pattern varies (Phase vs EventBus vs neither) | Inconsistent observability |
+
+### Solution
+
+The engine owns all trace emission as built-in behavior. After every tool call, the engine:
+
+```
+1. tools.FormatTrace(name, args, result)    // consistent formatting
+2. traceLines = append(traceLines, line)    // accumulate
+3. sendTrace()                              // push to Board slot
+4. LiteToolHook(name)                       // lite mode tracking
+5. EmitToolCallEvent(...)                   // TUI event
+```
+
+No agent reimplements any of this. The driver's one special case (reply fallback annotation) is handled in its PostTool hook, which can *append* an extra trace line — but the engine already emitted the standard one.
+
+### What this fixes
+
+- **Introspection**: automatically gets `tools.FormatTrace()` formatting, correct truncation, HTML
+- **Dream agent**: automatically gets traces just by being migrated to the engine — the registered `persona` slot starts receiving data
+- **Worker**: gets lite-mode support automatically via the engine's `LiteToolHook` field
+- **All agents**: one implementation of `traceLines`, `sendTrace()`, continuation headers, error traces
+- **Future agents**: get full trace support by default — zero trace code needed
+
+### What stays agent-specific
+
+- **Driver**: PostTool hook adds reply fallback annotation (`"⚡ reply(fallback → model)"`)
+- **Mood agent**: not a tool-loop agent, keeps its own `traceBuf` (this is correct — it traces decisions, not tool calls)
+
+## 8. memgate Pipeline Design (Level 2)
+
+```go
+package memgate
+
+type Verdict struct {
+    Allowed  bool
+    Reason   string   // human-readable rejection reason
+    Rewrite  string   // classifier-suggested rewrite (empty if none)
+    Splits   []string // SPLIT verdict sub-memories
+}
+
+type PipelineInput struct {
+    Text      string // the memory text to validate
+    Subject   string // "user" or "self"
+    Tags      string
+    Category  string
+    Context   string // optional "why this matters" context
+    CardID    int64
+    OldText   string // non-empty for updates (shows classifier the delta)
+}
+
+type PipelineDeps struct {
+    Store           memory.Store
+    EmbedClient     *embed.Client
+    ClassifierLLM   *llm.Client
+    Threshold       float64
+    MaxLength       int
+    ConversationID  string
+    TriggerMsgID    int64
+    Snippet         []memory.Message // pre-captured context for classifier
+    PreApproved     map[string]bool  // bypass on classifier-suggested rewrites
+    SkipDedup       bool             // merge_memories skips dedup
+}
+
+// RunPipeline validates a memory write through all gates in order.
+// Returns early on the first rejection.
+//
+// Gate order (cheapest first):
+//   1. Style blocklist  (string matching, ~0ms)
+//   2. Length gate       (len() check, ~0ms)
+//   3. Embedding dedup   (two-vector tag+text, ~50ms, skipped if SkipDedup)
+//   4. Classifier LLM    (~200-500ms)
+//   5. Safety classifier (self-subject only, ~200-500ms)
+func RunPipeline(input PipelineInput, deps PipelineDeps) Verdict { ... }
+```
+
+### Callers after extraction
+
+| Tool | Before | After |
+|------|--------|-------|
+| `save_memory` / `save_self_memory` | `ExecSaveMemory()` in `tools/memory_helpers.go` -- inline pipeline ~170 lines | `memgate.RunPipeline()` then `Store.SaveMemory()` |
+| `update_memory` | Inline style+length+classifier ~60 lines | `memgate.RunPipeline(SkipDedup: true, OldText: old.Content)` then `Store.SaveMemory()` + `Store.SupersedeMemory()` |
+| `merge_memories` | Inline style+length+classifier+safety ~90 lines | `memgate.RunPipeline(SkipDedup: true)` then `Store.SaveMemory()` + supersede chains |
+
+## 9. Migration Steps
+
+All in one branch, one commit per logical step.
+
+### Step 1: Create `agent_engine/engine.go`
+Create the package with `EngineConfig`, `LoopResult`, `RunLoop()`, and helper functions (`buildContinuationSummary`, `truncateLog`). No callers yet.
+
+**Files created:** `agent_engine/engine.go`, `agent_engine/engine_test.go`
+
+### Step 2: Create `tools/memgate/pipeline.go`
+Extract the 5-gate pipeline from `tools/memory_helpers.go`. Pure function, no callers yet.
+
+**Files created:** `tools/memgate/pipeline.go`, `tools/memgate/pipeline_test.go`
+
+### Step 3: Migrate memory write callers to memgate
+Replace inline pipelines in `tools/memory_helpers.go`, `tools/update_memory/handler.go`, and `tools/merge_memories/handler.go` with `memgate.RunPipeline()` calls. External APIs stay identical.
+
+### Step 4: Migrate Dream agent (`persona/memory_dreamer.go`)
+Simplest agentic loop. ~120 lines of loop -> ~40 lines of config + hooks.
+
+**Hooks used:** `PreTool` (dry-run + maxOps cap), `PostTool` (operation counting), `ContinuationMsg` (includes opCount).
+
+### Step 5: Migrate Worker agent (`workeragent/worker.go`)
+~110 lines of loop -> ~35 lines of config + hooks.
+
+**Hooks used:** `PostTool` (LiteToolHook, TUI events), `ContinuationMsg` ("Finish up and call done").
+
+### Step 6: Migrate Memory agent (`agent/memory_agent.go`)
+~110 lines of loop -> ~30 lines of config + hooks.
+
+**Hooks used:** `PostTool` (TUI events via Phase/EventBus fallback), `ContinuationMsg` ("Continue... call done or notify_agent").
+
+### Step 7: Migrate Introspection agent (`agent/introspection_agent.go`)
+~90 lines of loop -> ~35 lines of config + hooks.
+
+**Hooks used:** `PreIteration` (latency timer), `PostTool` (TUI events), `ContinuationMsg` ("Call skip or done now").
+
+**Watch for:** Introspection appends messages differently (one assistant+tool pair per tool call instead of batch). If behavior diverges in testing, add a `SingleToolCallMessages bool` field to EngineConfig.
+
+### Step 8: Migrate Driver agent (`agent/agent.go`)
+Most complex. ~340 lines of loop -> ~80 lines of config + hooks.
+
+**Hooks used:** All of them.
+- `ToolChoiceFirst`: `"required"` (conditionally from config)
+- `PostIteration`: loop detection (repeated think calls)
+- `OnNoToolCalls`: "done" text detection, agentFinalText capture
+- `ActiveToolGuard`: ActiveTools whitelist
+- `PostTool`: SaveAgentTurn, think trace capture, LiteToolHook, tool sequence tracking, reply fallback trace annotation
+- `OnLoopExit`: fallback reply paths, orphan placeholder cleanup, auto-done for diffusion models
+
+### Step 9: Cleanup
+- Remove `buildContinuationSummary()` from `agent/agent.go` (now in engine)
+- Remove duplicate `truncateLog()` from `workeragent/worker.go` and `persona/memory_dreamer.go`
+- Remove `executeTool()` from `agent/agent.go` (engine calls `tools.Execute` directly)
+- Verify no dead code remains
+
+## 10. Files Summary
+
+### New files
+| File | Purpose |
+|------|---------|
+| `agent_engine/engine.go` | EngineConfig, LoopResult, RunLoop, helpers |
+| `agent_engine/engine_test.go` | Unit tests with mock LLM |
+| `tools/memgate/pipeline.go` | RunPipeline, Verdict, gate implementations |
+| `tools/memgate/pipeline_test.go` | Unit tests with mock classifier |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `agent/agent.go` | Replace ~340-line loop with RunLoop + hooks (~80 lines) |
+| `agent/memory_agent.go` | Replace ~110-line loop with RunLoop + hooks (~30 lines) |
+| `agent/introspection_agent.go` | Replace ~90-line loop with RunLoop + hooks (~35 lines) |
+| `workeragent/worker.go` | Replace ~110-line loop with RunLoop + hooks (~35 lines) |
+| `persona/memory_dreamer.go` | Replace ~120-line loop with RunLoop + hooks (~40 lines) |
+| `tools/memory_helpers.go` | Replace ~100-line inline pipeline with memgate call (~15 lines) |
+| `tools/update_memory/handler.go` | Replace ~40-line inline gates with memgate call |
+| `tools/merge_memories/handler.go` | Replace ~50-line inline gates with memgate call |
+
+## 11. Verification
+
+### Unit tests (Steps 1-2)
+- **`agent_engine/engine_test.go`** -- mock LLM with scripted responses:
+  - Basic loop: 3 tool calls then done -> verify LoopResult
+  - Continuation windows: exhaust iterations -> verify injection
+  - Max continuations: exhaust all windows -> verify exit reason
+  - ToolChoiceFirst: verify first call passes "required", second passes nil
+  - PreTool skip: return skip=true -> verify tool not executed
+  - PostIteration break: return true -> verify exit reason "hook_break"
+  - OnNoToolCalls: LLM returns text -> verify hook called
+  - Error handling: LLM returns error -> verify exit reason "error"
+
+- **`tools/memgate/pipeline_test.go`** -- mock classifier and embed client:
+  - Style gate: blocked pattern -> rejected
+  - Length gate: oversized text -> rejected
+  - Dedup: similar embedding -> rejected with existing ID
+  - Classifier REJECT -> rejected
+  - Classifier SPLIT -> splits returned
+  - Self-memory safety -> rejected for sycophancy
+  - Happy path: all gates pass -> allowed
+
+### Integration tests (Steps 3-8)
+After each agent migration, run sim tests:
+```bash
+go test ./sims/... -run TestSim
+```
+
+### Manual verification checklist
+- [ ] Driver: tool calls work, reply delivered, traces appear, fallback reply fires
+- [ ] Memory: facts saved after turn, classifier rejects bad writes, traces appear
+- [ ] Introspection: self-memories saved when warranted, skip on casual turns
+- [ ] Worker: briefing report generated, file written to reports/
+- [ ] Dream: dry-run shows planned operations, real run executes merges/rewrites
+
+### Regression signals
+- Cost per turn stays the same (no extra LLM calls)
+- Tool call counts per turn stay the same
+- Trace output is identical (diff Telegram trace messages before/after)
+- Continuation windows fire at the same iteration thresholds

--- a/driver_agent_prompt.md
+++ b/driver_agent_prompt.md
@@ -16,6 +16,8 @@ Need more tools? Call **use_tools** to load them by category:
 
 Example: `use_tools(["search"])` loads web_search and web_read.
 
+**Important:** Deferred tools reset every turn. If you used `use_tools(["schedule"])` last turn, you must call it again this turn before using schedule tools. The same applies to all deferred categories.
+
 ## Order of Operations
 
 1. **think** — understand the message, plan your approach
@@ -48,6 +50,19 @@ Use the worker for requests like "research X for me", "write up a report on Y", 
 - `publish_report({path: "report.md"})` — publishes a report to Telegraph and returns a shareable link. Use when {{user}} wants to share or read a report in a formatted view.
 - `narrate_report({path: "report.md"})` — reads a report aloud as a voice memo. Use when {{user}} wants to listen to a report. The audio is sent after your reply.
 
+**Scheduling recurring tasks:** Load schedule tools with `use_tools(["schedule"])` to manage recurring tasks:
+- `create_schedule({name: "Morning tech briefing", cron_expr: "0 8 * * *", task_type: "worker_briefing", payload: {topics: "Go, AI agents", depth: "brief"}})` — creates a daily briefing at 8am
+- `list_schedules()` — shows all active schedules (add `show_disabled: true` to include cancelled ones)
+- `update_schedule({task_id: 5, cron_expr: "0 7 * * *"})` — changes the schedule time
+- `delete_schedule({task_id: 5})` — cancels a schedule (soft-delete, can be audited)
+
+Three task types:
+- **worker_briefing** — runs background research. Payload: `{topics: "...", depth: "brief"|"deep"}`
+- **send_message** — sends a static Telegram message. Payload: `{message: "..."}`
+- **send_prompt** — runs a prompt through the full agent pipeline for contextual messages. Payload: `{prompt: "..."}`
+
+Cron cheat sheet: `0 8 * * *` (daily 8am), `0 9 * * 1-5` (weekdays 9am), `0 9 * * 5` (Fridays 9am), `0 */6 * * *` (every 6h), `@daily` (midnight), `@hourly`. Call **get_time** first to confirm the user's timezone before choosing a cron expression.
+
 ## Typical Flows
 
 1. Simple greeting:
@@ -73,6 +88,12 @@ Use the worker for requests like "research X for me", "write up a report on Y", 
 
 8. Narrating a report aloud:
    think("user wants to listen to the report") → list_files() → use_tools(["content"]) → narrate_report({path: "2026-06-10-tech-digest.md"}) → reply("voice memo incoming") → done
+
+9. Setting up a recurring briefing:
+   think("user wants daily briefings — check timezone first") → get_time() → use_tools(["schedule"]) → create_schedule({name: "Morning tech briefing", cron_expr: "0 7 * * *", task_type: "worker_briefing", payload: {topics: "AI, Go programming", depth: "brief"}}) → reply("confirm the schedule, tell them when the first briefing will arrive") → done
+
+10. Managing schedules:
+    think("user wants to see or change schedules") → use_tools(["schedule"]) → list_schedules() → think("found the schedule to update") → update_schedule({task_id: 5, cron_expr: "0 8 * * *"}) → reply("confirm the change") → done
 
 Other tool-specific flows (calendar, nearby places, memory cleanup, etc.) are described in each tool's description — load them with use_tools to see the details.
 

--- a/gateway/commands.go
+++ b/gateway/commands.go
@@ -122,5 +122,12 @@ func buildCommandsFromBot(bot *bot.Bot) []CommandDef {
 				return bot.ExecUsage()
 			},
 		},
+		{
+			Name:        "schedule",
+			Description: "Show all scheduled tasks and next fire times",
+			Handler: func(_ context.Context, _ string) (string, error) {
+				return bot.ExecSchedule()
+			},
+		},
 	}
 }

--- a/gateway/commands_test.go
+++ b/gateway/commands_test.go
@@ -35,6 +35,7 @@ var expectedGatewayCommands = []string{
 	"lasttrace",
 	"rollup",
 	"usage",
+	"schedule",
 }
 
 func TestBuildCommandsFromBot_ReturnsExpectedNames(t *testing.T) {

--- a/gateway/sim.go
+++ b/gateway/sim.go
@@ -26,6 +26,7 @@ type SimTriggers struct {
 	DreamAfter   []int // run dream cycle after these turns
 	RunDream     bool  // run dream after all messages complete
 	RunRollup    bool  // force the daily mood rollup after all messages complete
+	FireSchedules bool // force-fire all user-created schedules after all messages
 }
 
 // SimOptions holds runtime options for sim execution.
@@ -73,6 +74,10 @@ type simAdapter struct {
 	// compactHandler is set by the gateway after pipeline creation.
 	compactHandler func(ctx context.Context, convID string) (string, error)
 
+	// fireSchedulesFn force-fires all user-created schedules. Set by
+	// cmd/sim_gw.go where scheduler deps are available.
+	fireSchedulesFn func(ctx context.Context) []string
+
 	// workerResultCh receives worker completion data for follow-up turns.
 	workerResultCh chan WorkerResult
 
@@ -91,6 +96,12 @@ type simAdapter struct {
 
 	// Done is closed when all messages have been processed.
 	Done chan struct{}
+}
+
+// SetFireSchedulesFn sets the callback for force-firing user schedules.
+// Called from cmd/sim_gw.go where scheduler deps are available.
+func (a *simAdapter) SetFireSchedulesFn(fn func(ctx context.Context) []string) {
+	a.fireSchedulesFn = fn
 }
 
 // turnCapture accumulates bus events for a single turn.
@@ -276,6 +287,14 @@ func (a *simAdapter) Start(ctx context.Context) error {
 		// Delay between turns to avoid rate limits on free-tier models.
 		if a.options.DelaySeconds > 0 && i < len(a.messages)-1 {
 			time.Sleep(time.Duration(a.options.DelaySeconds) * time.Second)
+		}
+	}
+
+	// Post-run: force-fire all user-created schedules.
+	if a.triggers.FireSchedules && a.fireSchedulesFn != nil {
+		results := a.fireSchedulesFn(ctx)
+		for _, r := range results {
+			log.Info("sim: fire-schedule result: " + r)
 		}
 	}
 

--- a/integrate/timezone.go
+++ b/integrate/timezone.go
@@ -1,0 +1,50 @@
+// integrate/timezone.go — Timezone lookup from coordinates via TimeAPI.io.
+// Free, no API key needed. Used by set_location to auto-detect timezone
+// when the user sets their home location.
+package integrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// TimezoneFromCoords looks up the IANA timezone name (e.g., "America/New_York")
+// for a given latitude/longitude pair using TimeAPI.io.
+func TimezoneFromCoords(lat, lon float64) (string, error) {
+	endpoint := fmt.Sprintf(
+		"https://timeapi.io/api/timezone/coordinate?latitude=%.6f&longitude=%.6f",
+		lat, lon,
+	)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("timezone lookup: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading timezone response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("timezone API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		TimeZone string `json:"timeZone"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parsing timezone response: %w", err)
+	}
+
+	if result.TimeZone == "" {
+		return "", fmt.Errorf("timezone API returned empty timezone for (%.4f, %.4f)", lat, lon)
+	}
+
+	return result.TimeZone, nil
+}

--- a/layers/agent_time.go
+++ b/layers/agent_time.go
@@ -21,8 +21,8 @@ func init() {
 func buildAgentTime(ctx *LayerContext) LayerResult {
 	// Use configured timezone if available, otherwise fall back to system timezone
 	loc := time.Local
-	if ctx.Cfg.Calendar.DefaultTimezone != "" {
-		if loadedLoc, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+	if ctx.Cfg.Timezone() != "" {
+		if loadedLoc, err := time.LoadLocation(ctx.Cfg.Timezone()); err == nil {
 			loc = loadedLoc
 		}
 		// If LoadLocation fails, silently fall back to time.Local

--- a/memory/store.go
+++ b/memory/store.go
@@ -156,9 +156,16 @@ type Store interface {
 	UpsertSchedulerTask(t *SchedulerTask) error
 	DueSchedulerTasks(now time.Time) ([]SchedulerTask, error)
 	SchedulerTaskByKind(kind string) (*SchedulerTask, error)
+	SchedulerTaskByKindAndSource(kind, source string) (*SchedulerTask, error)
 	MarkSchedulerSuccess(id int64, nextFire time.Time) error
 	MarkSchedulerFailure(id int64, nextFire time.Time, errMsg string, attempts int) error
 	DeleteSchedulerTask(id int64) error
+
+	// User-created schedules
+	CreateUserSchedulerTask(t *SchedulerTask) (int64, error)
+	GetUserSchedulerTask(id int64) (*SchedulerTask, error)
+	ListUserSchedulerTasks(includeDisabled bool) ([]SchedulerTask, error)
+	UpdateUserSchedulerTask(id int64, updates map[string]any) error
 
 	// Calendar
 	InsertCalendarEvent(title, start, end, location, notes, calendar, eventID, job string) (int64, error)

--- a/memory/store.go
+++ b/memory/store.go
@@ -155,6 +155,7 @@ type Store interface {
 	// Scheduler
 	UpsertSchedulerTask(t *SchedulerTask) error
 	DueSchedulerTasks(now time.Time) ([]SchedulerTask, error)
+	ListAllSchedulerTasks() ([]SchedulerTask, error)
 	SchedulerTaskByKind(kind string) (*SchedulerTask, error)
 	SchedulerTaskByKindAndSource(kind, source string) (*SchedulerTask, error)
 	MarkSchedulerSuccess(id int64, nextFire time.Time) error

--- a/memory/store_scheduler.go
+++ b/memory/store_scheduler.go
@@ -125,6 +125,26 @@ func (s *SQLiteStore) DueSchedulerTasks(now time.Time) ([]SchedulerTask, error) 
 	return scanSchedulerTasks(rows)
 }
 
+// ListAllSchedulerTasks returns every scheduler task (both yaml and user,
+// enabled and disabled). Used by the /schedule command to show a
+// complete overview.
+func (s *SQLiteStore) ListAllSchedulerTasks() ([]SchedulerTask, error) {
+	rows, err := s.db.Query(
+		`SELECT id, kind, cron_expr, next_fire, payload_json,
+		        retry_max_attempts, retry_backoff, retry_initial_wait,
+		        last_run_at, last_error, attempt_count, created_at,
+		        source, name, enabled
+		 FROM scheduler_tasks
+		 ORDER BY enabled DESC, next_fire ASC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing all scheduler tasks: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSchedulerTasks(rows)
+}
+
 // SchedulerTaskByKind looks up a row for a given kind. With multiple
 // rows per kind now possible, this returns the first match — prefer
 // SchedulerTaskByKindAndSource when you need a specific source.

--- a/memory/store_scheduler.go
+++ b/memory/store_scheduler.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -29,7 +30,7 @@ import (
 // as the rest of the codebase).
 type SchedulerTask struct {
 	ID               int64
-	Kind             string          // unique; matches the Handler.Kind() string
+	Kind             string          // matches the Handler.Kind() string
 	CronExpr         string          // empty when task is one-shot (next_fire only)
 	NextFire         time.Time       // absolute UTC time the task should execute next
 	Payload          json.RawMessage // free-form JSON blob; shape known only by the handler
@@ -40,31 +41,55 @@ type SchedulerTask struct {
 	LastError        string          // empty after a successful run
 	AttemptCount     int             // current failing-run count; reset after success
 	CreatedAt        time.Time
+	Source           string // "yaml" (loader-managed) or "user" (created via tools)
+	Name             string // human-readable label; empty for system tasks
+	Enabled          bool   // false = paused / soft-deleted
 }
 
-// UpsertSchedulerTask inserts a new scheduler task or updates the existing
-// one keyed by kind. Kind has a UNIQUE index, so each kind maps to exactly
-// one row — this matches how scheduler extensions register themselves at
-// startup (one handler → one kind → one scheduled entry).
+// UpsertSchedulerTask inserts or updates a YAML-managed scheduler task.
+// This method is used exclusively by the loader at startup — it hard-codes
+// source='yaml' so user-created rows are never touched.
 //
-// When updating, we only change the scheduling config (cron, next_fire,
-// payload, retry) — we leave last_run_at, last_error, and attempt_count
-// alone so historical state isn't lost when task.yaml is edited.
+// Uses explicit check-then-update instead of ON CONFLICT because the
+// kind column is no longer UNIQUE (multiple user rows can share a kind).
+// When updating, scheduling config changes but historical state
+// (last_run_at, last_error, attempt_count) is preserved.
 func (s *SQLiteStore) UpsertSchedulerTask(t *SchedulerTask) error {
 	cron := nullableString(t.CronExpr)
 
-	_, err := s.db.Exec(
+	// Try updating the existing yaml-source row first.
+	res, err := s.db.Exec(
+		`UPDATE scheduler_tasks
+		   SET cron_expr          = ?,
+		       next_fire          = ?,
+		       payload_json       = ?,
+		       retry_max_attempts = ?,
+		       retry_backoff      = ?,
+		       retry_initial_wait = ?
+		 WHERE kind = ? AND source = 'yaml'`,
+		cron,
+		t.NextFire.UTC(),
+		string(t.Payload),
+		t.RetryMaxAttempts,
+		t.RetryBackoff,
+		int64(t.RetryInitialWait),
+		t.Kind,
+	)
+	if err != nil {
+		return fmt.Errorf("upserting scheduler task %q: %w", t.Kind, err)
+	}
+
+	rows, _ := res.RowsAffected()
+	if rows > 0 {
+		return nil
+	}
+
+	// No existing yaml row — insert one.
+	_, err = s.db.Exec(
 		`INSERT INTO scheduler_tasks
 		   (kind, cron_expr, next_fire, payload_json,
-		    retry_max_attempts, retry_backoff, retry_initial_wait)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(kind) DO UPDATE SET
-		   cron_expr          = excluded.cron_expr,
-		   next_fire          = excluded.next_fire,
-		   payload_json       = excluded.payload_json,
-		   retry_max_attempts = excluded.retry_max_attempts,
-		   retry_backoff      = excluded.retry_backoff,
-		   retry_initial_wait = excluded.retry_initial_wait`,
+		    retry_max_attempts, retry_backoff, retry_initial_wait, source)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'yaml')`,
 		t.Kind,
 		cron,
 		t.NextFire.UTC(),
@@ -74,20 +99,21 @@ func (s *SQLiteStore) UpsertSchedulerTask(t *SchedulerTask) error {
 		int64(t.RetryInitialWait),
 	)
 	if err != nil {
-		return fmt.Errorf("upserting scheduler task %q: %w", t.Kind, err)
+		return fmt.Errorf("inserting scheduler task %q: %w", t.Kind, err)
 	}
 	return nil
 }
 
-// DueSchedulerTasks returns every task whose next_fire is at or before
-// `now`. The runner calls this on every tick.
+// DueSchedulerTasks returns every enabled task whose next_fire is at or
+// before `now`. The runner calls this on every tick.
 func (s *SQLiteStore) DueSchedulerTasks(now time.Time) ([]SchedulerTask, error) {
 	rows, err := s.db.Query(
 		`SELECT id, kind, cron_expr, next_fire, payload_json,
 		        retry_max_attempts, retry_backoff, retry_initial_wait,
-		        last_run_at, last_error, attempt_count, created_at
+		        last_run_at, last_error, attempt_count, created_at,
+		        source, name, enabled
 		 FROM scheduler_tasks
-		 WHERE next_fire <= ?
+		 WHERE next_fire <= ? AND enabled = 1
 		 ORDER BY next_fire ASC`,
 		now.UTC(),
 	)
@@ -99,13 +125,15 @@ func (s *SQLiteStore) DueSchedulerTasks(now time.Time) ([]SchedulerTask, error) 
 	return scanSchedulerTasks(rows)
 }
 
-// SchedulerTaskByKind looks up the row for a given kind. Returns
-// (nil, nil) when no row exists.
+// SchedulerTaskByKind looks up a row for a given kind. With multiple
+// rows per kind now possible, this returns the first match — prefer
+// SchedulerTaskByKindAndSource when you need a specific source.
 func (s *SQLiteStore) SchedulerTaskByKind(kind string) (*SchedulerTask, error) {
 	rows, err := s.db.Query(
 		`SELECT id, kind, cron_expr, next_fire, payload_json,
 		        retry_max_attempts, retry_backoff, retry_initial_wait,
-		        last_run_at, last_error, attempt_count, created_at
+		        last_run_at, last_error, attempt_count, created_at,
+		        source, name, enabled
 		 FROM scheduler_tasks
 		 WHERE kind = ?
 		 LIMIT 1`,
@@ -113,6 +141,35 @@ func (s *SQLiteStore) SchedulerTaskByKind(kind string) (*SchedulerTask, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying scheduler task %q: %w", kind, err)
+	}
+	defer rows.Close()
+
+	tasks, err := scanSchedulerTasks(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+	return &tasks[0], nil
+}
+
+// SchedulerTaskByKindAndSource looks up the row for a given kind and
+// source. Used by the loader to find only yaml-managed rows without
+// accidentally matching user-created ones.
+func (s *SQLiteStore) SchedulerTaskByKindAndSource(kind, source string) (*SchedulerTask, error) {
+	rows, err := s.db.Query(
+		`SELECT id, kind, cron_expr, next_fire, payload_json,
+		        retry_max_attempts, retry_backoff, retry_initial_wait,
+		        last_run_at, last_error, attempt_count, created_at,
+		        source, name, enabled
+		 FROM scheduler_tasks
+		 WHERE kind = ? AND source = ?
+		 LIMIT 1`,
+		kind, source,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying scheduler task %q (source=%s): %w", kind, source, err)
 	}
 	defer rows.Close()
 
@@ -181,7 +238,9 @@ func (s *SQLiteStore) DeleteSchedulerTask(id int64) error {
 }
 
 // scanSchedulerTasks reads rows from a SELECT into SchedulerTask structs.
-// Kept private — callers use the typed helpers above.
+// Kept private — callers use the typed helpers above. Column order must
+// match every SELECT in this file: the 12 original columns followed by
+// source, name, enabled (added by migration 000019).
 func scanSchedulerTasks(rows *sql.Rows) ([]SchedulerTask, error) {
 	var tasks []SchedulerTask
 	for rows.Next() {
@@ -191,11 +250,14 @@ func scanSchedulerTasks(rows *sql.Rows) ([]SchedulerTask, error) {
 			payload  string
 			initWait int64
 			lastErr  sql.NullString
+			name     sql.NullString
+			enabled  int
 		)
 		err := rows.Scan(
 			&t.ID, &t.Kind, &cron, &t.NextFire, &payload,
 			&t.RetryMaxAttempts, &t.RetryBackoff, &initWait,
 			&t.LastRunAt, &lastErr, &t.AttemptCount, &t.CreatedAt,
+			&t.Source, &name, &enabled,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning scheduler task: %w", err)
@@ -206,11 +268,155 @@ func scanSchedulerTasks(rows *sql.Rows) ([]SchedulerTask, error) {
 		if lastErr.Valid {
 			t.LastError = lastErr.String
 		}
+		if name.Valid {
+			t.Name = name.String
+		}
 		t.Payload = json.RawMessage(payload)
 		t.RetryInitialWait = time.Duration(initWait)
+		t.Enabled = enabled == 1
 		tasks = append(tasks, t)
 	}
 	return tasks, rows.Err()
+}
+
+// ─── User-Created Schedule CRUD ────────────────────────────────────
+//
+// These methods manage schedules created by the driver agent via tools
+// (create_schedule, list_schedules, etc.). All rows have source='user'.
+// Deletion is soft — set enabled=0 via UpdateUserSchedulerTask.
+
+// CreateUserSchedulerTask inserts a new user-created scheduler task.
+// The Source field is forced to "user" regardless of what the caller sets.
+func (s *SQLiteStore) CreateUserSchedulerTask(t *SchedulerTask) (int64, error) {
+	cron := nullableString(t.CronExpr)
+	name := nullableString(t.Name)
+
+	res, err := s.db.Exec(
+		`INSERT INTO scheduler_tasks
+		   (kind, cron_expr, next_fire, payload_json,
+		    retry_max_attempts, retry_backoff, retry_initial_wait,
+		    source, name, enabled)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'user', ?, 1)`,
+		t.Kind,
+		cron,
+		t.NextFire.UTC(),
+		string(t.Payload),
+		t.RetryMaxAttempts,
+		t.RetryBackoff,
+		int64(t.RetryInitialWait),
+		name,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("creating user scheduler task %q: %w", t.Kind, err)
+	}
+	return res.LastInsertId()
+}
+
+// GetUserSchedulerTask fetches a single user-created task by ID.
+// Returns (nil, nil) when not found.
+func (s *SQLiteStore) GetUserSchedulerTask(id int64) (*SchedulerTask, error) {
+	rows, err := s.db.Query(
+		`SELECT id, kind, cron_expr, next_fire, payload_json,
+		        retry_max_attempts, retry_backoff, retry_initial_wait,
+		        last_run_at, last_error, attempt_count, created_at,
+		        source, name, enabled
+		 FROM scheduler_tasks
+		 WHERE id = ? AND source = 'user'`,
+		id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying user scheduler task %d: %w", id, err)
+	}
+	defer rows.Close()
+
+	tasks, err := scanSchedulerTasks(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(tasks) == 0 {
+		return nil, nil
+	}
+	return &tasks[0], nil
+}
+
+// ListUserSchedulerTasks returns all user-created scheduler tasks. When
+// includeDisabled is false, only enabled tasks are returned. Set it to
+// true for auditing soft-deleted/paused schedules.
+func (s *SQLiteStore) ListUserSchedulerTasks(includeDisabled bool) ([]SchedulerTask, error) {
+	query := `SELECT id, kind, cron_expr, next_fire, payload_json,
+	                 retry_max_attempts, retry_backoff, retry_initial_wait,
+	                 last_run_at, last_error, attempt_count, created_at,
+	                 source, name, enabled
+	          FROM scheduler_tasks
+	          WHERE source = 'user'`
+	if !includeDisabled {
+		query += ` AND enabled = 1`
+	}
+	query += ` ORDER BY next_fire ASC`
+
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("listing user scheduler tasks: %w", err)
+	}
+	defer rows.Close()
+
+	return scanSchedulerTasks(rows)
+}
+
+// UpdateUserSchedulerTask applies partial updates to a user-created task.
+// Only keys present in updates are changed. Supported keys: "name" (string),
+// "cron_expr" (string), "next_fire" (time.Time), "enabled" (bool),
+// "payload_json" (string). Returns an error if the task doesn't exist or
+// isn't user-created.
+func (s *SQLiteStore) UpdateUserSchedulerTask(id int64, updates map[string]any) error {
+	if len(updates) == 0 {
+		return fmt.Errorf("no updates provided for scheduler task %d", id)
+	}
+
+	setClauses := make([]string, 0, len(updates))
+	args := make([]any, 0, len(updates)+1)
+
+	for key, val := range updates {
+		switch key {
+		case "name", "cron_expr", "payload_json":
+			setClauses = append(setClauses, key+" = ?")
+			args = append(args, val)
+		case "next_fire":
+			setClauses = append(setClauses, "next_fire = ?")
+			if t, ok := val.(time.Time); ok {
+				args = append(args, t.UTC())
+			} else {
+				args = append(args, val)
+			}
+		case "enabled":
+			setClauses = append(setClauses, "enabled = ?")
+			if b, ok := val.(bool); ok {
+				if b {
+					args = append(args, 1)
+				} else {
+					args = append(args, 0)
+				}
+			} else {
+				args = append(args, val)
+			}
+		default:
+			return fmt.Errorf("unsupported update key %q for scheduler task", key)
+		}
+	}
+
+	query := "UPDATE scheduler_tasks SET " + strings.Join(setClauses, ", ") +
+		" WHERE id = ? AND source = 'user'"
+	args = append(args, id)
+
+	res, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("updating user scheduler task %d: %w", id, err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return fmt.Errorf("user scheduler task %d not found", id)
+	}
+	return nil
 }
 
 // nullableString returns a sql.NullString that's NULL when s == "".

--- a/memory/store_scheduler_test.go
+++ b/memory/store_scheduler_test.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"encoding/json"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -307,24 +306,44 @@ func TestDeleteSchedulerTask(t *testing.T) {
 // TestUpsertSchedulerTask_EnforcesKindUnique double-checks the UNIQUE
 // index on kind is what lets the ON CONFLICT clause work. A direct
 // INSERT (bypassing the upsert) should fail on the second write.
-func TestUpsertSchedulerTask_EnforcesKindUnique(t *testing.T) {
+func TestUpsertSchedulerTask_AllowsMultipleKinds(t *testing.T) {
 	store := newSchedulerTestStore(t)
 
-	task := newTestTask("unit_unique")
+	// Upsert a yaml-source task.
+	task := newTestTask("unit_multi")
 	if err := store.UpsertSchedulerTask(task); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
-	// Raw INSERT bypasses the ON CONFLICT path — should bounce off the
-	// UNIQUE index, proving the index is doing its job.
-	_, err := store.db.Exec(
-		`INSERT INTO scheduler_tasks (kind, next_fire, payload_json, retry_backoff) VALUES (?, ?, '{}', 'none')`,
-		"unit_unique", time.Now(),
-	)
-	if err == nil {
-		t.Fatal("raw INSERT with duplicate kind succeeded; UNIQUE index missing")
+	// A user-created task with the same kind should succeed — the UNIQUE
+	// constraint on kind was dropped in migration 000019.
+	userTask := newTestTask("unit_multi")
+	userTask.Name = "user schedule"
+	id, err := store.CreateUserSchedulerTask(userTask)
+	if err != nil {
+		t.Fatalf("creating user task with same kind: %v", err)
 	}
-	if !strings.Contains(err.Error(), "UNIQUE") {
-		t.Errorf("error = %v, want UNIQUE constraint violation", err)
+	if id == 0 {
+		t.Fatal("expected non-zero ID for user task")
+	}
+
+	// Verify both rows exist.
+	yamlRow, err := store.SchedulerTaskByKindAndSource("unit_multi", "yaml")
+	if err != nil {
+		t.Fatalf("looking up yaml row: %v", err)
+	}
+	if yamlRow == nil {
+		t.Fatal("yaml row not found")
+	}
+
+	userRow, err := store.GetUserSchedulerTask(id)
+	if err != nil {
+		t.Fatalf("looking up user row: %v", err)
+	}
+	if userRow == nil {
+		t.Fatal("user row not found")
+	}
+	if userRow.Source != "user" {
+		t.Errorf("user row source = %q, want 'user'", userRow.Source)
 	}
 }

--- a/migrations/000019_scheduler_user_tasks.up.sql
+++ b/migrations/000019_scheduler_user_tasks.up.sql
@@ -1,0 +1,11 @@
+-- Allow multiple scheduler_tasks rows per kind (user-created schedules).
+-- Previously kind had a UNIQUE index, limiting to one row per handler.
+
+DROP INDEX IF EXISTS idx_scheduler_tasks_kind;
+
+ALTER TABLE scheduler_tasks ADD COLUMN source TEXT NOT NULL DEFAULT 'yaml';
+ALTER TABLE scheduler_tasks ADD COLUMN name TEXT;
+ALTER TABLE scheduler_tasks ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
+
+-- Non-unique composite index for loader lookups (WHERE kind=? AND source='yaml').
+CREATE INDEX idx_scheduler_tasks_kind_source ON scheduler_tasks(kind, source);

--- a/scheduler/cron.go
+++ b/scheduler/cron.go
@@ -1,0 +1,145 @@
+// cron.go — Exported cron helpers for tool handlers and display.
+//
+// These are pure functions wrapping robfig/cron/v3. Tools call
+// ValidateCron + NextRun when creating schedules; list_schedules
+// calls DescribeCron for human-readable display.
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// userParser includes the Descriptor flag so users can write @daily,
+// @hourly, etc. in addition to standard 5-field expressions.
+var userParser = cron.NewParser(
+	cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+)
+
+// ValidateCron checks whether a cron expression is syntactically valid.
+func ValidateCron(cronExpr string) error {
+	_, err := userParser.Parse(cronExpr)
+	if err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", cronExpr, err)
+	}
+	return nil
+}
+
+// NextRun computes the next fire time after `after`, evaluated in the
+// given timezone. Returns the result in UTC for database storage.
+func NextRun(cronExpr string, after time.Time, loc *time.Location) (time.Time, error) {
+	sched, err := userParser.Parse(cronExpr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid cron expression %q: %w", cronExpr, err)
+	}
+	next := sched.Next(after.In(loc))
+	return next.UTC(), nil
+}
+
+// DescribeCron converts a cron expression to a human-readable string.
+func DescribeCron(cronExpr string) string {
+	switch cronExpr {
+	case "@daily", "@midnight":
+		return "daily at midnight"
+	case "@hourly":
+		return "every hour"
+	case "@weekly":
+		return "weekly (Sunday midnight)"
+	case "@monthly":
+		return "monthly (1st at midnight)"
+	case "@yearly", "@annually":
+		return "yearly (Jan 1 at midnight)"
+	}
+
+	if len(cronExpr) > 6 && cronExpr[:6] == "@every" {
+		return "every " + cronExpr[7:]
+	}
+
+	fields := splitCronFields(cronExpr)
+	if len(fields) != 5 {
+		return cronExpr
+	}
+
+	minute, hour, dom, month, dow := fields[0], fields[1], fields[2], fields[3], fields[4]
+
+	timeStr := ""
+	if hour != "*" && minute != "*" {
+		h, m := 0, 0
+		fmt.Sscanf(hour, "%d", &h)
+		fmt.Sscanf(minute, "%d", &m)
+		ampm := "AM"
+		displayH := h
+		if h >= 12 {
+			ampm = "PM"
+			if h > 12 {
+				displayH = h - 12
+			}
+		}
+		if h == 0 {
+			displayH = 12
+		}
+		timeStr = fmt.Sprintf("%d:%02d %s", displayH, m, ampm)
+	} else if hour != "*" {
+		h := 0
+		fmt.Sscanf(hour, "%d", &h)
+		ampm := "AM"
+		displayH := h
+		if h >= 12 {
+			ampm = "PM"
+			if h > 12 {
+				displayH = h - 12
+			}
+		}
+		if h == 0 {
+			displayH = 12
+		}
+		timeStr = fmt.Sprintf("%d:00 %s", displayH, ampm)
+	}
+
+	dayStr := ""
+	if dow != "*" {
+		dayNames := map[string]string{
+			"0": "Sun", "1": "Mon", "2": "Tue", "3": "Wed",
+			"4": "Thu", "5": "Fri", "6": "Sat", "7": "Sun",
+			"1-5": "weekdays", "0,6": "weekends",
+		}
+		if name, ok := dayNames[dow]; ok {
+			dayStr = name
+		} else {
+			dayStr = "days " + dow
+		}
+	}
+
+	if dom == "*" && month == "*" && dow == "*" && timeStr != "" {
+		return "daily at " + timeStr
+	}
+	if dow != "*" && dom == "*" && month == "*" && timeStr != "" {
+		return dayStr + " at " + timeStr
+	}
+	if timeStr != "" {
+		return "at " + timeStr
+	}
+
+	return cronExpr
+}
+
+func splitCronFields(expr string) []string {
+	var fields []string
+	field := ""
+	for _, c := range expr {
+		if c == ' ' || c == '\t' {
+			if field != "" {
+				fields = append(fields, field)
+				field = ""
+			}
+		} else {
+			field += string(c)
+		}
+	}
+	if field != "" {
+		fields = append(fields, field)
+	}
+	return fields
+}

--- a/scheduler/fire.go
+++ b/scheduler/fire.go
@@ -1,0 +1,84 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"her/memory"
+)
+
+// FireResult reports the outcome of a forced task execution.
+type FireResult struct {
+	TaskID int64
+	Kind   string
+	Name   string
+	Err    error
+}
+
+// FireTask dispatches a user-created scheduler task by ID regardless of
+// its next_fire time. Used for testing and manual triggering (sim, CLI).
+// Does NOT update next_fire or attempt counts — this is a one-off
+// forced execution, not a cron tick.
+func FireTask(ctx context.Context, taskID int64, store memory.Store, deps *Deps) error {
+	task, err := store.GetUserSchedulerTask(taskID)
+	if err != nil {
+		return fmt.Errorf("fire task %d: %w", taskID, err)
+	}
+	if task == nil {
+		return fmt.Errorf("fire task %d: not found", taskID)
+	}
+
+	h := lookup(task.Kind)
+	if h == nil {
+		return fmt.Errorf("fire task %d: no handler registered for kind %q", taskID, task.Kind)
+	}
+
+	return runHandler(ctx, h, task.Payload, deps)
+}
+
+// FireTaskByKind dispatches a task by handler kind with an explicit
+// payload. Used for firing system tasks or testing handlers directly.
+func FireTaskByKind(ctx context.Context, kind string, payload json.RawMessage, deps *Deps) error {
+	h := lookup(kind)
+	if h == nil {
+		return fmt.Errorf("fire task: no handler registered for kind %q", kind)
+	}
+	if payload == nil {
+		payload = json.RawMessage("{}")
+	}
+	return runHandler(ctx, h, payload, deps)
+}
+
+// FireAllUserTasks dispatches every enabled user-created task. Used by
+// the sim to exercise the full handler pipeline after schedule tools
+// have created rows. Returns one result per task.
+func FireAllUserTasks(ctx context.Context, store memory.Store, deps *Deps) []FireResult {
+	tasks, err := store.ListUserSchedulerTasks(false)
+	if err != nil {
+		return []FireResult{{Err: fmt.Errorf("listing user tasks: %w", err)}}
+	}
+
+	var results []FireResult
+	for _, t := range tasks {
+		h := lookup(t.Kind)
+		if h == nil {
+			results = append(results, FireResult{
+				TaskID: t.ID,
+				Kind:   t.Kind,
+				Name:   t.Name,
+				Err:    fmt.Errorf("no handler for kind %q", t.Kind),
+			})
+			continue
+		}
+
+		err := runHandler(ctx, h, t.Payload, deps)
+		results = append(results, FireResult{
+			TaskID: t.ID,
+			Kind:   t.Kind,
+			Name:   t.Name,
+			Err:    err,
+		})
+	}
+	return results
+}

--- a/scheduler/loader.go
+++ b/scheduler/loader.go
@@ -28,7 +28,7 @@ func (s *Scheduler) loadAndUpsertAll(rootDir string) error {
 		cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow,
 	)
 
-	for _, kind := range registeredKinds() {
+	for _, kind := range RegisteredKinds() {
 		h := lookup(kind)
 		path := h.ConfigPath()
 		if path == "" {

--- a/scheduler/loader.go
+++ b/scheduler/loader.go
@@ -68,10 +68,12 @@ func (s *Scheduler) loadAndUpsertAll(rootDir string) error {
 			return fmt.Errorf("scheduler: computing next_fire for %s: %w", kind, err)
 		}
 
-		// If a row already exists, preserve its next_fire — otherwise
-		// every restart would skip to "one cron tick from now" and the
-		// task could miss fires that were due during downtime.
-		existing, err := s.store.SchedulerTaskByKind(kind)
+		// If a yaml-source row already exists, preserve its next_fire —
+		// otherwise every restart would skip to "one cron tick from now"
+		// and the task could miss fires that were due during downtime.
+		// We scope to source='yaml' so user-created rows with the same
+		// kind don't interfere.
+		existing, err := s.store.SchedulerTaskByKindAndSource(kind, "yaml")
 		if err != nil {
 			return fmt.Errorf("scheduler: looking up existing %s: %w", kind, err)
 		}

--- a/scheduler/registry.go
+++ b/scheduler/registry.go
@@ -64,9 +64,9 @@ func lookup(kind string) Handler {
 	return registry[kind]
 }
 
-// registeredKinds returns the sorted list of every registered kind.
+// RegisteredKinds returns the sorted list of every registered kind.
 // Used by the loader to walk each handler once at startup.
-func registeredKinds() []string {
+func RegisteredKinds() []string {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 

--- a/scheduler/registry_test.go
+++ b/scheduler/registry_test.go
@@ -106,15 +106,15 @@ func TestRegisteredKinds_SortedAndComplete(t *testing.T) {
 	Register(&fakeHandler{kind: "alpha"})
 	Register(&fakeHandler{kind: "mango"})
 
-	got := registeredKinds()
+	got := RegisteredKinds()
 	want := []string{"alpha", "mango", "zebra"}
 
 	if len(got) != len(want) {
-		t.Fatalf("registeredKinds() len = %d, want %d", len(got), len(want))
+		t.Fatalf("RegisteredKinds() len = %d, want %d", len(got), len(want))
 	}
 	for i := range got {
 		if got[i] != want[i] {
-			t.Errorf("registeredKinds()[%d] = %q, want %q", i, got[i], want[i])
+			t.Errorf("RegisteredKinds()[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -91,7 +91,7 @@ func New(store memory.Store, deps *Deps, rootDir string) (*Scheduler, error) {
 	}
 
 	s.log.Info("scheduler initialized",
-		"registered_kinds", len(registeredKinds()),
+		"registered_kinds", len(RegisteredKinds()),
 		"tick_interval", TickInterval,
 	)
 	return s, nil

--- a/scheduler/send_message_handler.go
+++ b/scheduler/send_message_handler.go
@@ -1,0 +1,33 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// sendMessageHandler sends a static Telegram message on a cron schedule.
+// This is the simplest scheduled action — no LLM, no agent loop, just
+// a direct message. Think of it as a basic reminder.
+type sendMessageHandler struct{}
+
+func (sendMessageHandler) Kind() string       { return "send_message" }
+func (sendMessageHandler) ConfigPath() string { return "" }
+
+func (h sendMessageHandler) Execute(_ context.Context, payload json.RawMessage, deps *Deps) error {
+	var p struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("send_message: bad payload: %w", err)
+	}
+	if p.Message == "" {
+		return fmt.Errorf("send_message: empty message")
+	}
+	_, err := deps.Send(deps.ChatID, p.Message)
+	return err
+}
+
+func init() {
+	Register(sendMessageHandler{})
+}

--- a/scheduler/send_prompt_handler.go
+++ b/scheduler/send_prompt_handler.go
@@ -1,0 +1,43 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// sendPromptHandler runs a prompt through the full driver agent loop.
+// This is the "smart" counterpart to sendMessageHandler — instead of
+// static text, the driver agent gets the prompt as a system instruction
+// and generates a contextual response (aware of memories, mood, etc.).
+//
+// Emits events through deps.ScheduledPromptFn — a callback set by
+// cmd/run.go that constructs the AgentEvent and sends it on the event
+// channel. We use a callback instead of importing agent/ directly to
+// avoid an import cycle (agent → tools → scheduler → agent).
+type sendPromptHandler struct{}
+
+func (sendPromptHandler) Kind() string       { return "send_prompt" }
+func (sendPromptHandler) ConfigPath() string { return "" }
+
+func (h sendPromptHandler) Execute(_ context.Context, payload json.RawMessage, deps *Deps) error {
+	var p struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("send_prompt: bad payload: %w", err)
+	}
+	if p.Prompt == "" {
+		return fmt.Errorf("send_prompt: empty prompt")
+	}
+
+	if deps.ScheduledPromptFn == nil {
+		return fmt.Errorf("send_prompt: no prompt callback configured")
+	}
+
+	return deps.ScheduledPromptFn(p.Prompt)
+}
+
+func init() {
+	Register(sendPromptHandler{})
+}

--- a/scheduler/types.go
+++ b/scheduler/types.go
@@ -89,6 +89,12 @@ type Deps struct {
 	// AgentEventCh receives completion events from workers. The bot's
 	// event consumer handles them to trigger driver agent follow-ups.
 	AgentEventCh any
+
+	// ScheduledPromptFn fires a prompt through the full driver agent
+	// loop. Set by cmd/run.go — the callback constructs an AgentEvent
+	// and emits it on the event channel. This avoids a scheduler → agent
+	// import cycle while still triggering contextual agent runs.
+	ScheduledPromptFn func(prompt string) error
 }
 
 // RetryConfig governs what happens when a handler returns an error.

--- a/scheduler/validate.go
+++ b/scheduler/validate.go
@@ -1,0 +1,48 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ValidatePayload checks that the payload JSON is well-formed and contains
+// the required fields for the given task type. Returns nil if valid.
+//
+// Rules by type:
+//   - send_message: payload must have a "message" field (non-empty payload required)
+//   - send_prompt:  payload must have a "prompt" field (non-empty payload required)
+//   - worker_briefing: if "depth" is present it must be "brief" or "deep"
+func ValidatePayload(kind string, payload json.RawMessage) error {
+	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "null" {
+		if kind == "send_message" {
+			return fmt.Errorf("send_message requires payload with 'message' field")
+		}
+		if kind == "send_prompt" {
+			return fmt.Errorf("send_prompt requires payload with 'prompt' field")
+		}
+		return nil
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("payload must be a JSON object")
+	}
+
+	switch kind {
+	case "send_message":
+		if _, ok := p["message"]; !ok {
+			return fmt.Errorf("send_message payload requires 'message' field")
+		}
+	case "send_prompt":
+		if _, ok := p["prompt"]; !ok {
+			return fmt.Errorf("send_prompt payload requires 'prompt' field")
+		}
+	case "worker_briefing":
+		if depth, ok := p["depth"]; ok {
+			if d, ok := depth.(string); ok && d != "brief" && d != "deep" {
+				return fmt.Errorf("worker_briefing depth must be 'brief' or 'deep'")
+			}
+		}
+	}
+	return nil
+}

--- a/sims/schedule-crud.yaml
+++ b/sims/schedule-crud.yaml
@@ -1,0 +1,38 @@
+name: "Schedule CRUD — create, list, update, delete recurring tasks"
+description: >
+  Tests the full scheduling tool lifecycle: creating recurring schedules,
+  listing them, updating cron/payload, and soft-deleting (disabling).
+
+  Exercises all three task types: worker_briefing (daily news),
+  send_message (static reminder), and schedule management (list/update/delete).
+
+  What to look for in the report:
+  - Agent loads schedule tools via use_tools(["schedule"])
+  - create_schedule validates cron, computes next fire time
+  - Names get 6-char hash prefix for collision avoidance
+  - list_schedules shows all active schedules with human-readable cron
+  - update_schedule changes cron and recomputes next fire
+  - delete_schedule soft-disables (enabled=0, not hard-deleted)
+  - list_schedules with show_disabled reveals cancelled schedules
+  - No errors or panics from store operations
+tags: ["schedule", "crud", "tools", "reference"]
+fire_schedules: true
+
+messages:
+  # 1. Create a recurring briefing
+  - "hey, can you set up a daily briefing about Go and AI news? every morning at 8am"
+
+  # 2. Create a static reminder
+  - "also remind me to water the plants every evening at 6pm"
+
+  # 3. List all schedules
+  - "what schedules do I have set up?"
+
+  # 4. Update the briefing time
+  - "actually, change the morning briefing to 7am instead"
+
+  # 5. Cancel the plant reminder
+  - "cancel the plant watering reminder"
+
+  # 6. Verify the deletion was soft
+  - "show me all my schedules, including the cancelled ones"

--- a/telegraph/nodes.go
+++ b/telegraph/nodes.go
@@ -116,12 +116,19 @@ func convertBlock(node ast.Node, source []byte) interface{} {
 			if li, ok := child.(*ast.ListItem); ok {
 				var liChildren []interface{}
 				for liChild := li.FirstChild(); liChild != nil; liChild = liChild.NextSibling() {
-					if p, ok := liChild.(*ast.Paragraph); ok {
-						// Unwrap paragraph inside list items — Telegraph
-						// expects inline content directly inside <li>.
+					switch p := liChild.(type) {
+					case *ast.Paragraph:
+						// Loose list items wrap content in Paragraph.
 						liChildren = append(liChildren, convertInlineChildren(p, source)...)
-					} else if c := convertBlock(liChild, source); c != nil {
-						liChildren = append(liChildren, c)
+					case *ast.TextBlock:
+						// Tight list items (no blank lines between) use
+						// TextBlock instead of Paragraph — same inline
+						// extraction logic applies.
+						liChildren = append(liChildren, convertInlineChildren(p, source)...)
+					default:
+						if c := convertBlock(liChild, source); c != nil {
+							liChildren = append(liChildren, c)
+						}
 					}
 				}
 				items = append(items, &Node{Tag: "li", Children: liChildren})

--- a/tools/categories.yaml
+++ b/tools/categories.yaml
@@ -14,3 +14,6 @@ calendar:
 
 content:
   hint: "User wants a report read aloud, narrated, or converted to audio"
+
+schedule:
+  hint: "User wants to create, view, update, or cancel a recurring schedule like daily briefings or reminders"

--- a/tools/create_schedule/handler.go
+++ b/tools/create_schedule/handler.go
@@ -56,14 +56,14 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	}
 
 	// Validate payload shape per task type.
-	if err := validatePayload(a.TaskType, a.Payload); err != nil {
+	if err := scheduler.ValidatePayload(a.TaskType, a.Payload); err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
 
 	// Resolve timezone for cron evaluation.
 	loc := time.UTC
-	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
-		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+	if ctx.Cfg != nil && ctx.Cfg.Timezone() != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Timezone()); err == nil {
 			loc = parsed
 		}
 	}
@@ -114,37 +114,3 @@ func hashName(name string) string {
 	return fmt.Sprintf("%x-%s", h[:3], name)
 }
 
-func validatePayload(taskType string, payload json.RawMessage) error {
-	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "null" {
-		if taskType == "send_message" {
-			return fmt.Errorf("send_message requires payload with 'message' field")
-		}
-		if taskType == "send_prompt" {
-			return fmt.Errorf("send_prompt requires payload with 'prompt' field")
-		}
-		return nil
-	}
-
-	var p map[string]any
-	if err := json.Unmarshal(payload, &p); err != nil {
-		return fmt.Errorf("payload must be a JSON object")
-	}
-
-	switch taskType {
-	case "send_message":
-		if _, ok := p["message"]; !ok {
-			return fmt.Errorf("send_message payload requires 'message' field")
-		}
-	case "send_prompt":
-		if _, ok := p["prompt"]; !ok {
-			return fmt.Errorf("send_prompt payload requires 'prompt' field")
-		}
-	case "worker_briefing":
-		if depth, ok := p["depth"]; ok {
-			if d, ok := depth.(string); ok && d != "brief" && d != "deep" {
-				return fmt.Errorf("worker_briefing depth must be 'brief' or 'deep'")
-			}
-		}
-	}
-	return nil
-}

--- a/tools/create_schedule/handler.go
+++ b/tools/create_schedule/handler.go
@@ -1,0 +1,150 @@
+package create_schedule
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"her/logger"
+	"her/memory"
+	"her/scheduler"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/create_schedule")
+
+func init() {
+	tools.Register("create_schedule", Handle)
+}
+
+type args struct {
+	Name        string          `json:"name"`
+	CronExpr    string          `json:"cron_expr"`
+	TaskType    string          `json:"task_type"`
+	Payload     json.RawMessage `json:"payload"`
+	Description string          `json:"description"`
+}
+
+var validTaskTypes = map[string]string{
+	"worker_briefing": "worker_briefing",
+	"send_message":    "send_message",
+	"send_prompt":     "send_prompt",
+}
+
+// Handle creates a new user-scheduled task. It validates the cron
+// expression, auto-injects a 6-char hash prefix on the name for
+// collision avoidance, and computes the first fire time.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var a args
+	if err := json.Unmarshal([]byte(argsJSON), &a); err != nil {
+		return "error: invalid arguments"
+	}
+
+	if a.Name == "" {
+		return "error: name is required"
+	}
+	if a.CronExpr == "" {
+		return "error: cron_expr is required"
+	}
+	if _, ok := validTaskTypes[a.TaskType]; !ok {
+		return "error: task_type must be one of: worker_briefing, send_message, send_prompt"
+	}
+
+	if err := scheduler.ValidateCron(a.CronExpr); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	// Validate payload shape per task type.
+	if err := validatePayload(a.TaskType, a.Payload); err != nil {
+		return fmt.Sprintf("error: %s", err)
+	}
+
+	// Resolve timezone for cron evaluation.
+	loc := time.UTC
+	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+			loc = parsed
+		}
+	}
+
+	nextFire, err := scheduler.NextRun(a.CronExpr, time.Now(), loc)
+	if err != nil {
+		return fmt.Sprintf("error computing next fire time: %v", err)
+	}
+
+	// Auto-inject 6-char hash prefix for collision avoidance.
+	hashedName := hashName(a.Name)
+
+	// Normalize empty payload to {}.
+	payload := a.Payload
+	if len(payload) == 0 {
+		payload = json.RawMessage("{}")
+	}
+
+	task := &memory.SchedulerTask{
+		Kind:     a.TaskType,
+		CronExpr: a.CronExpr,
+		NextFire: nextFire,
+		Payload:  payload,
+		Name:     hashedName,
+		Enabled:  true,
+	}
+
+	id, err := ctx.Store.CreateUserSchedulerTask(task)
+	if err != nil {
+		log.Error("create_schedule failed", "err", err)
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	humanCron := scheduler.DescribeCron(a.CronExpr)
+	log.Infof("created schedule #%d: %s (%s) — %s", id, hashedName, a.TaskType, humanCron)
+	return fmt.Sprintf(
+		"Schedule #%d created: %q (%s)\nSchedule: %s (%s)\nNext run: %s",
+		id, hashedName, a.TaskType,
+		humanCron, a.CronExpr,
+		nextFire.In(loc).Format("Mon Jan 2 3:04 PM"),
+	)
+}
+
+// hashName generates a 6-char hex prefix from the name + current time,
+// producing names like "a3f2c1-Morning tech briefing".
+func hashName(name string) string {
+	h := sha256.Sum256([]byte(name + time.Now().String()))
+	return fmt.Sprintf("%x-%s", h[:3], name)
+}
+
+func validatePayload(taskType string, payload json.RawMessage) error {
+	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "null" {
+		if taskType == "send_message" {
+			return fmt.Errorf("send_message requires payload with 'message' field")
+		}
+		if taskType == "send_prompt" {
+			return fmt.Errorf("send_prompt requires payload with 'prompt' field")
+		}
+		return nil
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("payload must be a JSON object")
+	}
+
+	switch taskType {
+	case "send_message":
+		if _, ok := p["message"]; !ok {
+			return fmt.Errorf("send_message payload requires 'message' field")
+		}
+	case "send_prompt":
+		if _, ok := p["prompt"]; !ok {
+			return fmt.Errorf("send_prompt payload requires 'prompt' field")
+		}
+	case "worker_briefing":
+		if depth, ok := p["depth"]; ok {
+			if d, ok := depth.(string); ok && d != "brief" && d != "deep" {
+				return fmt.Errorf("worker_briefing depth must be 'brief' or 'deep'")
+			}
+		}
+	}
+	return nil
+}

--- a/tools/create_schedule/tool.yaml
+++ b/tools/create_schedule/tool.yaml
@@ -1,0 +1,33 @@
+name: create_schedule
+agent: [main]
+description: >-
+  Create a recurring scheduled task. Supported task types:
+  - worker_briefing: runs a background research briefing (payload: topics, depth)
+  - send_message: sends a static Telegram message (payload: message)
+  - send_prompt: runs a prompt through the full agent pipeline (payload: prompt)
+  Use get_time first to confirm the user's timezone before choosing a cron expression.
+hot: false
+category: schedule
+parameters:
+  type: object
+  properties:
+    name:
+      type: string
+      description: "Human-readable label for this schedule (e.g., 'Morning tech briefing')"
+    cron_expr:
+      type: string
+      description: "5-field cron expression. Examples: '0 8 * * *' (daily 8am), '0 9 * * 1-5' (weekday 9am), '0 9 * * 5' (Fridays 9am)"
+    task_type:
+      type: string
+      description: "Which handler to run"
+      enum: [worker_briefing, send_message, send_prompt]
+    payload:
+      type: object
+      description: "Task-specific config. worker_briefing: {topics, depth (brief|deep)}. send_message: {message}. send_prompt: {prompt}"
+    description:
+      type: string
+      description: "Optional plain-English explanation of the schedule"
+  required: [name, cron_expr, task_type]
+trace:
+  emoji: "📅"
+  format: "{{.name}} ({{.task_type}}) → {{.cron_expr}}"

--- a/tools/delete_schedule/handler.go
+++ b/tools/delete_schedule/handler.go
@@ -1,0 +1,51 @@
+package delete_schedule
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"her/logger"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/delete_schedule")
+
+func init() {
+	tools.Register("delete_schedule", Handle)
+}
+
+// Handle soft-deletes a user-created schedule by disabling it.
+// The row remains in the database for auditing — use list_schedules
+// with show_disabled=true to see cancelled schedules.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var a struct {
+		TaskID int64 `json:"task_id"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &a); err != nil {
+		return "error: invalid arguments"
+	}
+	if a.TaskID == 0 {
+		return "error: task_id is required"
+	}
+
+	// Verify it exists before disabling.
+	existing, err := ctx.Store.GetUserSchedulerTask(a.TaskID)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	if existing == nil {
+		return fmt.Sprintf("error: schedule #%d not found (or not user-created)", a.TaskID)
+	}
+	if !existing.Enabled {
+		return fmt.Sprintf("Schedule #%d (%q) is already disabled.", a.TaskID, existing.Name)
+	}
+
+	updates := map[string]any{"enabled": false}
+	if err := ctx.Store.UpdateUserSchedulerTask(a.TaskID, updates); err != nil {
+		log.Error("delete_schedule failed", "err", err)
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	log.Infof("disabled schedule #%d: %s", a.TaskID, existing.Name)
+	return fmt.Sprintf("Schedule #%d (%q) has been disabled. It will no longer fire.", a.TaskID, existing.Name)
+}

--- a/tools/delete_schedule/tool.yaml
+++ b/tools/delete_schedule/tool.yaml
@@ -1,0 +1,18 @@
+name: delete_schedule
+agent: [main]
+description: >-
+  Cancel a user-created schedule by disabling it. The schedule is
+  soft-deleted (disabled, not removed) so it can be audited later.
+  Use list_schedules with show_disabled to see cancelled schedules.
+hot: false
+category: schedule
+parameters:
+  type: object
+  properties:
+    task_id:
+      type: integer
+      description: "ID of the schedule to cancel (from list_schedules)"
+  required: [task_id]
+trace:
+  emoji: "🗑️"
+  format: "schedule #{{.task_id}}"

--- a/tools/get_time/handler.go
+++ b/tools/get_time/handler.go
@@ -16,14 +16,13 @@ func init() {
 // No parameters required — just returns the current time with multiple formats
 // for the agent to use in calculations and scheduling.
 func Handle(argsJSON string, ctx *tools.Context) string {
-	// Load timezone from config (Calendar.DefaultTimezone)
-	// Fall back to system timezone if not configured
+	// Load timezone from config, fall back to system timezone if not configured.
 	loc := time.Local
-	if ctx.Cfg.Calendar.DefaultTimezone != "" {
-		loadedLoc, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone)
+	if ctx.Cfg.Timezone() != "" {
+		loadedLoc, err := time.LoadLocation(ctx.Cfg.Timezone())
 		if err != nil {
 			// Invalid timezone in config — warn but continue with system timezone
-			return fmt.Sprintf("error: invalid timezone %q in config: %v", ctx.Cfg.Calendar.DefaultTimezone, err)
+			return fmt.Sprintf("error: invalid timezone %q in config: %v", ctx.Cfg.Timezone(), err)
 		}
 		loc = loadedLoc
 	}

--- a/tools/get_time/handler_test.go
+++ b/tools/get_time/handler_test.go
@@ -22,6 +22,7 @@ func newCtx(t *testing.T, tz string) *tools.Context {
 	t.Helper()
 	return &tools.Context{
 		Cfg: &config.Config{
+			DefaultTimezone: tz,
 			Calendar: config.CalendarConfig{
 				DefaultTimezone: tz,
 			},

--- a/tools/list_schedules/handler.go
+++ b/tools/list_schedules/handler.go
@@ -23,7 +23,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		ShowDisabled bool `json:"show_disabled"`
 	}
 	if argsJSON != "" {
-		json.Unmarshal([]byte(argsJSON), &a)
+		if err := json.Unmarshal([]byte(argsJSON), &a); err != nil {
+			return "error: invalid arguments"
+		}
 	}
 
 	tasks, err := ctx.Store.ListUserSchedulerTasks(a.ShowDisabled)

--- a/tools/list_schedules/handler.go
+++ b/tools/list_schedules/handler.go
@@ -1,0 +1,121 @@
+package list_schedules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"her/logger"
+	"her/scheduler"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/list_schedules")
+
+func init() {
+	tools.Register("list_schedules", Handle)
+}
+
+// Handle lists all user-created scheduled tasks.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var a struct {
+		ShowDisabled bool `json:"show_disabled"`
+	}
+	if argsJSON != "" {
+		json.Unmarshal([]byte(argsJSON), &a)
+	}
+
+	tasks, err := ctx.Store.ListUserSchedulerTasks(a.ShowDisabled)
+	if err != nil {
+		log.Error("list_schedules failed", "err", err)
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	if len(tasks) == 0 {
+		if a.ShowDisabled {
+			return "No scheduled tasks found (including disabled)."
+		}
+		return "No active scheduled tasks."
+	}
+
+	// Resolve timezone for display.
+	loc := time.UTC
+	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+			loc = parsed
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Scheduled tasks (%d):\n\n", len(tasks)))
+
+	for _, t := range tasks {
+		status := "active"
+		if !t.Enabled {
+			status = "DISABLED"
+		}
+
+		humanCron := scheduler.DescribeCron(t.CronExpr)
+		name := t.Name
+		if name == "" {
+			name = "<unnamed>"
+		}
+
+		sb.WriteString(fmt.Sprintf(
+			"#%d %s [%s]\n  Type: %s | Schedule: %s (%s)\n  Next: %s | Status: %s\n",
+			t.ID, name, t.Kind,
+			t.Kind, humanCron, t.CronExpr,
+			t.NextFire.In(loc).Format("Mon Jan 2 3:04 PM"),
+			status,
+		))
+
+		// Payload summary.
+		summary := payloadSummary(t.Kind, t.Payload)
+		if summary != "" {
+			sb.WriteString(fmt.Sprintf("  Payload: %s\n", summary))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// payloadSummary returns a short description of the payload for display.
+func payloadSummary(kind string, payload json.RawMessage) string {
+	if len(payload) == 0 || string(payload) == "{}" {
+		return ""
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return ""
+	}
+
+	switch kind {
+	case "worker_briefing":
+		parts := []string{}
+		if topics, ok := p["topics"].(string); ok && topics != "" {
+			parts = append(parts, "topics: "+topics)
+		}
+		if depth, ok := p["depth"].(string); ok && depth != "" {
+			parts = append(parts, "depth: "+depth)
+		}
+		return strings.Join(parts, ", ")
+	case "send_message":
+		if msg, ok := p["message"].(string); ok {
+			if len(msg) > 60 {
+				msg = msg[:57] + "..."
+			}
+			return fmt.Sprintf("message: %q", msg)
+		}
+	case "send_prompt":
+		if prompt, ok := p["prompt"].(string); ok {
+			if len(prompt) > 60 {
+				prompt = prompt[:57] + "..."
+			}
+			return fmt.Sprintf("prompt: %q", prompt)
+		}
+	}
+	return ""
+}

--- a/tools/list_schedules/handler.go
+++ b/tools/list_schedules/handler.go
@@ -43,8 +43,8 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 
 	// Resolve timezone for display.
 	loc := time.UTC
-	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
-		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+	if ctx.Cfg != nil && ctx.Cfg.Timezone() != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Timezone()); err == nil {
 			loc = parsed
 		}
 	}

--- a/tools/list_schedules/tool.yaml
+++ b/tools/list_schedules/tool.yaml
@@ -1,0 +1,18 @@
+name: list_schedules
+agent: [main]
+description: >-
+  List all user-created scheduled tasks with their next run times,
+  task types, and payload summaries. By default shows only active
+  schedules; set show_disabled to include paused/cancelled ones.
+hot: false
+category: schedule
+parameters:
+  type: object
+  properties:
+    show_disabled:
+      type: boolean
+      description: "Include disabled/cancelled schedules for auditing (default: false)"
+  required: []
+trace:
+  emoji: "📋"
+  format: "{{if .show_disabled}}(including disabled) {{end}}→ {{.Result | truncate 80 | escape}}"

--- a/tools/loader_test.go
+++ b/tools/loader_test.go
@@ -13,7 +13,7 @@ func TestYAMLLoader(t *testing.T) {
 
 	// Check that all expected tools loaded from YAML.
 	// Update this count when tools are added or removed.
-	const expectedToolCount = 39
+	const expectedToolCount = 43
 	if len(toolDefs) != expectedToolCount {
 		t.Errorf("expected %d tools, got %d", expectedToolCount, len(toolDefs))
 	}

--- a/tools/set_location/handler.go
+++ b/tools/set_location/handler.go
@@ -68,8 +68,6 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 
 	// Step 3: persist to config.yaml. This also mutates ctx.Cfg in
 	// memory, so subsequent tool calls in this turn see the new coords.
-	// Failure here means the lat/lon won't survive restart — surface
-	// that to the agent so it can tell the user.
 	configSaved := true
 	if ctx.ConfigPath != "" && ctx.Cfg != nil {
 		if err := ctx.Cfg.SetLocation(ctx.ConfigPath, loc.Latitude, loc.Longitude, loc.DisplayName); err != nil {
@@ -78,11 +76,30 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		}
 	}
 
+	// Step 4: auto-detect timezone from coordinates. This makes cron
+	// schedules, mood rollups, and get_time all use the right local
+	// time without manual config editing.
+	tzName := ""
+	tz, err := integrate.TimezoneFromCoords(loc.Latitude, loc.Longitude)
+	if err != nil {
+		log.Warn("timezone auto-detect failed", "err", err)
+	} else {
+		tzName = tz
+		if ctx.ConfigPath != "" && ctx.Cfg != nil {
+			if err := ctx.Cfg.SetTimezone(ctx.ConfigPath, tz); err != nil {
+				log.Warn("failed to persist timezone to config", "err", err)
+			} else {
+				log.Info("timezone auto-detected", "tz", tz)
+			}
+		}
+	}
+
 	log.Info("set_location",
 		"query", args.Query,
 		"name", loc.DisplayName,
 		"lat", loc.Latitude,
-		"lon", loc.Longitude)
+		"lon", loc.Longitude,
+		"tz", tzName)
 
 	if !configSaved {
 		return fmt.Sprintf(
@@ -91,8 +108,12 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		)
 	}
 
-	return fmt.Sprintf(
-		"Home location set to %s (%.4f, %.4f). Saved to config and location_history. get_weather will now use this.",
+	result := fmt.Sprintf(
+		"Home location set to %s (%.4f, %.4f). Saved to config and location_history.",
 		loc.DisplayName, loc.Latitude, loc.Longitude,
 	)
+	if tzName != "" {
+		result += fmt.Sprintf(" Timezone auto-detected: %s.", tzName)
+	}
+	return result
 }

--- a/tools/shift_hours/handler.go
+++ b/tools/shift_hours/handler.go
@@ -38,7 +38,7 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 
 	// Resolve period to start/end timestamps. Uses the configured timezone
 	// so "this week" means the user's local week, not UTC.
-	start, end, periodLabel, err := resolvePeriod(args.Period, args.Start, args.End, ctx.Cfg.Calendar.DefaultTimezone)
+	start, end, periodLabel, err := resolvePeriod(args.Period, args.Start, args.End, ctx.Cfg.Timezone())
 	if err != nil {
 		return fmt.Sprintf("error: %v", err)
 	}

--- a/tools/update_schedule/handler.go
+++ b/tools/update_schedule/handler.go
@@ -53,7 +53,7 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		updates["enabled"] = *a.Enabled
 	}
 	if len(a.Payload) > 0 && string(a.Payload) != "null" {
-		if err := validatePayload(existing.Kind, a.Payload); err != nil {
+		if err := scheduler.ValidatePayload(existing.Kind, a.Payload); err != nil {
 			return fmt.Sprintf("error: %s", err)
 		}
 		updates["payload_json"] = string(a.Payload)
@@ -65,8 +65,8 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 
 		// Recompute next fire time from the new cron.
 		loc := time.UTC
-		if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
-			if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+		if ctx.Cfg != nil && ctx.Cfg.Timezone() != "" {
+			if parsed, err := time.LoadLocation(ctx.Cfg.Timezone()); err == nil {
 				loc = parsed
 			}
 		}
@@ -96,8 +96,8 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	}
 
 	loc := time.UTC
-	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
-		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+	if ctx.Cfg != nil && ctx.Cfg.Timezone() != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Timezone()); err == nil {
 			loc = parsed
 		}
 	}
@@ -118,29 +118,3 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 	)
 }
 
-func validatePayload(kind string, payload json.RawMessage) error {
-	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "null" {
-		return nil
-	}
-	var p map[string]any
-	if err := json.Unmarshal(payload, &p); err != nil {
-		return fmt.Errorf("payload must be a JSON object")
-	}
-	switch kind {
-	case "send_message":
-		if _, ok := p["message"]; !ok {
-			return fmt.Errorf("send_message payload requires 'message' field")
-		}
-	case "send_prompt":
-		if _, ok := p["prompt"]; !ok {
-			return fmt.Errorf("send_prompt payload requires 'prompt' field")
-		}
-	case "worker_briefing":
-		if depth, ok := p["depth"]; ok {
-			if d, ok := depth.(string); ok && d != "brief" && d != "deep" {
-				return fmt.Errorf("worker_briefing depth must be 'brief' or 'deep'")
-			}
-		}
-	}
-	return nil
-}

--- a/tools/update_schedule/handler.go
+++ b/tools/update_schedule/handler.go
@@ -1,0 +1,116 @@
+package update_schedule
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"her/logger"
+	"her/scheduler"
+	"her/tools"
+)
+
+var log = logger.WithPrefix("tools/update_schedule")
+
+func init() {
+	tools.Register("update_schedule", Handle)
+}
+
+type args struct {
+	TaskID  int64           `json:"task_id"`
+	Name    *string         `json:"name"`
+	CronExpr *string       `json:"cron_expr"`
+	Enabled *bool           `json:"enabled"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// Handle updates an existing user-created schedule. At least one
+// optional field (name, cron_expr, enabled, payload) must be provided.
+func Handle(argsJSON string, ctx *tools.Context) string {
+	var a args
+	if err := json.Unmarshal([]byte(argsJSON), &a); err != nil {
+		return "error: invalid arguments"
+	}
+	if a.TaskID == 0 {
+		return "error: task_id is required"
+	}
+
+	// Verify the task exists before updating.
+	existing, err := ctx.Store.GetUserSchedulerTask(a.TaskID)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	if existing == nil {
+		return fmt.Sprintf("error: schedule #%d not found (or not user-created)", a.TaskID)
+	}
+
+	updates := make(map[string]any)
+
+	if a.Name != nil {
+		updates["name"] = *a.Name
+	}
+	if a.Enabled != nil {
+		updates["enabled"] = *a.Enabled
+	}
+	if len(a.Payload) > 0 && string(a.Payload) != "null" {
+		updates["payload_json"] = string(a.Payload)
+	}
+	if a.CronExpr != nil {
+		if err := scheduler.ValidateCron(*a.CronExpr); err != nil {
+			return fmt.Sprintf("error: %v", err)
+		}
+
+		// Recompute next fire time from the new cron.
+		loc := time.UTC
+		if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
+			if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+				loc = parsed
+			}
+		}
+
+		nextFire, err := scheduler.NextRun(*a.CronExpr, time.Now(), loc)
+		if err != nil {
+			return fmt.Sprintf("error computing next fire time: %v", err)
+		}
+
+		updates["cron_expr"] = *a.CronExpr
+		updates["next_fire"] = nextFire
+	}
+
+	if len(updates) == 0 {
+		return "error: at least one field (name, cron_expr, enabled, payload) must be provided"
+	}
+
+	if err := ctx.Store.UpdateUserSchedulerTask(a.TaskID, updates); err != nil {
+		log.Error("update_schedule failed", "err", err)
+		return fmt.Sprintf("error: %v", err)
+	}
+
+	// Re-fetch to show the updated state.
+	updated, err := ctx.Store.GetUserSchedulerTask(a.TaskID)
+	if err != nil || updated == nil {
+		return fmt.Sprintf("Schedule #%d updated.", a.TaskID)
+	}
+
+	loc := time.UTC
+	if ctx.Cfg != nil && ctx.Cfg.Calendar.DefaultTimezone != "" {
+		if parsed, err := time.LoadLocation(ctx.Cfg.Calendar.DefaultTimezone); err == nil {
+			loc = parsed
+		}
+	}
+
+	status := "active"
+	if !updated.Enabled {
+		status = "DISABLED"
+	}
+
+	humanCron := scheduler.DescribeCron(updated.CronExpr)
+	log.Infof("updated schedule #%d: %s", a.TaskID, updated.Name)
+	return fmt.Sprintf(
+		"Schedule #%d updated: %q\nSchedule: %s (%s)\nNext run: %s\nStatus: %s",
+		updated.ID, updated.Name,
+		humanCron, updated.CronExpr,
+		updated.NextFire.In(loc).Format("Mon Jan 2 3:04 PM"),
+		status,
+	)
+}

--- a/tools/update_schedule/handler.go
+++ b/tools/update_schedule/handler.go
@@ -53,6 +53,9 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		updates["enabled"] = *a.Enabled
 	}
 	if len(a.Payload) > 0 && string(a.Payload) != "null" {
+		if err := validatePayload(existing.Kind, a.Payload); err != nil {
+			return fmt.Sprintf("error: %s", err)
+		}
 		updates["payload_json"] = string(a.Payload)
 	}
 	if a.CronExpr != nil {
@@ -113,4 +116,31 @@ func Handle(argsJSON string, ctx *tools.Context) string {
 		updated.NextFire.In(loc).Format("Mon Jan 2 3:04 PM"),
 		status,
 	)
+}
+
+func validatePayload(kind string, payload json.RawMessage) error {
+	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "null" {
+		return nil
+	}
+	var p map[string]any
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("payload must be a JSON object")
+	}
+	switch kind {
+	case "send_message":
+		if _, ok := p["message"]; !ok {
+			return fmt.Errorf("send_message payload requires 'message' field")
+		}
+	case "send_prompt":
+		if _, ok := p["prompt"]; !ok {
+			return fmt.Errorf("send_prompt payload requires 'prompt' field")
+		}
+	case "worker_briefing":
+		if depth, ok := p["depth"]; ok {
+			if d, ok := depth.(string); ok && d != "brief" && d != "deep" {
+				return fmt.Errorf("worker_briefing depth must be 'brief' or 'deep'")
+			}
+		}
+	}
+	return nil
 }

--- a/tools/update_schedule/tool.yaml
+++ b/tools/update_schedule/tool.yaml
@@ -1,0 +1,30 @@
+name: update_schedule
+agent: [main]
+description: >-
+  Update an existing user-created schedule. Can change the name, cron
+  expression, enabled status, or payload. Use list_schedules first to
+  find the task_id.
+hot: false
+category: schedule
+parameters:
+  type: object
+  properties:
+    task_id:
+      type: integer
+      description: "ID of the schedule to update (from list_schedules)"
+    name:
+      type: string
+      description: "New human-readable label"
+    cron_expr:
+      type: string
+      description: "New cron expression (recomputes next fire time)"
+    enabled:
+      type: boolean
+      description: "true to resume, false to pause"
+    payload:
+      type: object
+      description: "New task-specific config (replaces entire payload)"
+  required: [task_id]
+trace:
+  emoji: "✏️"
+  format: "schedule #{{.task_id}}"

--- a/workeragent/briefing_handler.go
+++ b/workeragent/briefing_handler.go
@@ -26,10 +26,12 @@ func (briefingHandler) Kind() string       { return "worker_briefing" }
 func (briefingHandler) ConfigPath() string { return "workeragent/tasks/briefing/task.yaml" }
 
 func (h briefingHandler) Execute(ctx context.Context, payload json.RawMessage, deps *scheduler.Deps) error {
-	// Parse optional payload (briefing topics, etc.).
+	// Parse optional payload (briefing topics, depth, tier override).
 	var p struct {
 		Topics      string `json:"topics"`
 		Instruction string `json:"instruction"`
+		Depth       string `json:"depth"`      // "brief" or "deep" — maps to model tier
+		ModelTier   string `json:"model_tier"` // explicit tier override (wins over depth)
 	}
 	if len(payload) > 0 {
 		if err := json.Unmarshal(payload, &p); err != nil {
@@ -57,14 +59,22 @@ func (h briefingHandler) Execute(ctx context.Context, payload json.RawMessage, d
 		return fmt.Errorf("worker briefing: task type 'briefing' not registered")
 	}
 
-	// Select the LLM client for this task type's tier.
+	// Select the LLM client — tier override chain:
+	// meta.yaml default → depth mapping → explicit model_tier.
 	workerLLMs, _ := deps.WorkerLLMs.(map[string]*llm.Client)
 	if workerLLMs == nil {
 		return fmt.Errorf("worker briefing: no worker LLMs configured")
 	}
-	llmClient := workerLLMs[taskType.ModelTier]
+	tier := taskType.ModelTier
+	if p.Depth == "deep" {
+		tier = "medium"
+	}
+	if p.ModelTier != "" {
+		tier = p.ModelTier
+	}
+	llmClient := workerLLMs[tier]
 	if llmClient == nil {
-		return fmt.Errorf("worker briefing: no LLM for tier %q", taskType.ModelTier)
+		return fmt.Errorf("worker briefing: no LLM for tier %q", tier)
 	}
 
 	tavilyClient, _ := deps.TavilyClient.(*search.TavilyClient)


### PR DESCRIPTION
## Summary

- **4 schedule tools** — `create_schedule`, `list_schedules`, `update_schedule`, `delete_schedule` (soft-delete) let the driver agent manage recurring tasks from conversation
- **3 task handlers** — `worker_briefing` (background research with depth/tier override), `send_message` (static text), `send_prompt` (full driver agent loop via EventSchedulerFired)
- **Schema migration** — drop UNIQUE on `scheduler_tasks.kind`, add `source`/`name`/`enabled` columns for dual-source (yaml + user) task management
- **Timezone overhaul** — top-level `cfg.DefaultTimezone` + `Timezone()` accessor; `set_location` auto-detects timezone from coordinates via TimeAPI.io
- **`/schedule` command** — shows all upcoming tasks (user + system) with human-readable cron and next fire times
- **Force-fire API** — `FireTask`, `FireTaskByKind`, `FireAllUserTasks` for testing; sim YAML `fire_schedules: true` option
- **Telegraph fix** — list items with bold text no longer render as empty (TextBlock vs Paragraph in goldmark tight lists)
- **Fallback reply fix** — driver loop failures no longer hallucinate success

## Test plan

- [x] `go test ./... -count=1 -race` — all pass, zero races
- [x] Sim `schedule-crud.yaml` — full CRUD cycle (create → list → update → delete → audit)
- [x] Sim with `fire_schedules: true` — worker_briefing handler fires, runs web research, writes report, publishes to Telegraph
- [x] Telegraph content verified — list items now render with full content
- [x] Go PR audit (C0–C8 + STRIDE) — all findings addressed